### PR TITLE
Separate and name violations

### DIFF
--- a/kmcd
+++ b/kmcd
@@ -121,20 +121,11 @@ debug=false
 [[ ! "$run_command" == 'prove' ]] || backend='haskell'
 [[ ! "$run_command" =~ klab*   ]] || backend='java'
 while [[ $# -gt 0 ]]; do
-  arg="$1"
-  case $arg in
-    --backend)
-    backend="$2"
-    shift 2
-    ;;
-    --debug)
-    debug=true
-    shift
-    ;;
-    *)
-    break
-    ;;
-  esac
+    arg="$1"
+    case $arg in
+        --backend) backend="$2" ; shift 2 ;;
+        *)         break                  ;;
+    esac
 done
 backend_dir="$defn_dir/$backend"
 

--- a/kmcd-driver.md
+++ b/kmcd-driver.md
@@ -188,6 +188,17 @@ We model everything with arbitrary precision rationals, but use sort information
  // --------------------------------
 ```
 
+### Lookup Defaulting to 0
+
+Sometimes you need a lookup to default to zero, and want to cast the result as a `Rat`.
+
+```k
+    syntax Rat ::= #lookup ( Map , Address ) [function]
+ // ---------------------------------------------------
+    rule #lookup(M, A) => { M[A] }:>Rat requires A in_keys(M)
+    rule #lookup(M, A) => 0             [owise]
+```
+
 ### Time Increments
 
 Some methods rely on a timestamp.

--- a/kmcd-prelude.md
+++ b/kmcd-prelude.md
@@ -303,7 +303,6 @@ module KMCD-GEN
          <generator-next> N </generator-next>
          <generator-current> _ => head(BS) modInt N </generator-current>
          <generator-remainder> GSS => .GenStep </generator-remainder>
-         <violation> false </violation>
       requires lengthBytes(BS) >Int 0
        andBool N >Int 0
 

--- a/kmcd-props.md
+++ b/kmcd-props.md
@@ -140,10 +140,12 @@ A violation occurs if any of the properties above holds.
 ```k
     syntax Map ::= "#violationFSMs" [function]
  // ------------------------------------------
-    rule #violationFSMs => "Zero-Time Pot Interest Accumulation" |-> zeroTimePotInterest
-                           "Pot Interest Accumulation After End" |-> potEndInterest
-                           "Unauthorized Flip Kick"              |-> unAuthFlipKick
-                           "Unauthorized Flap Kick"              |-> unAuthFlapKick
+    rule #violationFSMs => ( "Zero-Time Pot Interest Accumulation" |-> zeroTimePotInterest )
+                           ( "Pot Interest Accumulation After End" |-> potEndInterest      )
+                           ( "Unauthorized Flip Kick"              |-> unAuthFlipKick      )
+                           ( "Unauthorized Flap Kick"              |-> unAuthFlapKick      )
+                           ( "PotChi * PotPie = Vat(Pot)"          |-> potChiPieDai        )
+                           ( "Total Debt Bounded by DSR"           |-> totalDebtBounded    )
 ```
 
 A violation can be checked using the Admin step `assert`. If a violation is detected,

--- a/kmcd-props.md
+++ b/kmcd-props.md
@@ -144,8 +144,8 @@ A violation occurs if any of the properties above holds.
                            ( "Pot Interest Accumulation After End" |-> potEndInterest      )
                            ( "Unauthorized Flip Kick"              |-> unAuthFlipKick      )
                            ( "Unauthorized Flap Kick"              |-> unAuthFlapKick      )
-                           ( "PotChi * PotPie = Vat(Pot)"          |-> potChiPieDai        )
-                           ( "Total Debt Bounded by DSR"           |-> totalDebtBounded    )
+                           ( "Total Bound on Debt"                 |-> totalDebtBounded    )
+                           ( "PotChi PotPie VatPot"                |-> potChiPieDai        )
 ```
 
 A violation can be checked using the Admin step `assert`. If a violation is detected,

--- a/kmcd-props.md
+++ b/kmcd-props.md
@@ -212,17 +212,17 @@ A default `owise` rule is added which leaves the FSM state unchanged.
 The Debt growth should be bounded in principle by the interest rates available in the system.
 
 ```k
-    syntax ViolationFSM ::= totalDebtBounded    ( Rat )
-                          | totalDebtBounded    ( Rat , Rat )
-                          | totalDebtBoundedEnd ( Rat       )
- // ---------------------------------------------------------
-    rule derive(totalDebtBounded(DSR), Measure(... debt: DEBT)) => totalDebtBounded(DEBT, DSR)
+    syntax ViolationFSM ::= totalDebtBounded    (             dsr: Rat )
+                          | totalDebtBoundedRun ( debt: Rat , dsr: Rat )
+                          | totalDebtBoundedEnd ( debt: Rat            )
+ // --------------------------------------------------------------------
+    rule derive(totalDebtBounded(DSR), Measure(... debt: DEBT)) => totalDebtBoundedRun(DEBT, DSR)
 
-    rule derive( totalDebtBounded(DEBT, _  ) , Measure(... debt: DEBT')            ) => Violated requires DEBT' >Rat DEBT
-    rule derive( totalDebtBounded(DEBT, DSR) , TimeStep(TIME, _)                   ) => totalDebtBounded(DEBT +Rat (vatDaiForUser(Pot) *Rat ((DSR ^Rat TIME) -Rat 1)) , DSR )
-    rule derive( totalDebtBounded(DEBT, DSR) , LogNote(_ , Vat . frob _ _ _ _ _ _) ) => totalDebtBounded(DSR)
-    rule derive( totalDebtBounded(DEBT, DSR) , LogNote(_ , Pot . file dsr DSR')    ) => totalDebtBounded(DEBT , DSR')
-    rule derive( totalDebtBounded(DEBT, _  ) , LogNote(_ , End . cage         )    ) => totalDebtBoundedEnd(DEBT)
+    rule derive( totalDebtBoundedRun(DEBT, _  ) , Measure(... debt: DEBT')            ) => Violated requires DEBT' >Rat DEBT
+    rule derive( totalDebtBoundedRun(DEBT, DSR) , TimeStep(TIME, _)                   ) => totalDebtBoundedRun(DEBT +Rat (vatDaiForUser(Pot) *Rat ((DSR ^Rat TIME) -Rat 1)) , DSR )
+    rule derive( totalDebtBoundedRun(DEBT, DSR) , LogNote(_ , Vat . frob _ _ _ _ _ _) ) => totalDebtBounded(DSR)
+    rule derive( totalDebtBoundedRun(DEBT, DSR) , LogNote(_ , Pot . file dsr DSR')    ) => totalDebtBoundedRun(DEBT , DSR')
+    rule derive( totalDebtBoundedRun(DEBT, _  ) , LogNote(_ , End . cage         )    ) => totalDebtBoundedEnd(DEBT)
 
     rule derive(totalDebtBoundedEnd(DEBT), Measure(... debt: DEBT')) => Violated requires DEBT' =/=Rat DEBT
 ```

--- a/kmcd-props.md
+++ b/kmcd-props.md
@@ -229,7 +229,7 @@ The Pot Chi multiplied by Pot Pie should equal the Vat Dai for the Pot
 ```k
     syntax ViolationFSM ::= "potChiPieDai"
  // --------------------------------------
-    rule derive(potChiPieDai, Measure(... controlDai: CONTROL_DAI, potChi: POT_CHI, potPie: POT_PIE)) => Violated requires POT_CHI *Rat POT_PIE =/=Rat { CONTROL_DAI[Pot] }:>Rat
+    rule derive(potChiPieDai, Measure(... controlDai: CONTROL_DAI, potChi: POT_CHI, potPie: POT_PIE)) => Violated requires POT_CHI *Rat POT_PIE =/=Rat #lookup(CONTROL_DAI, Pot)
 ```
 
 ### Kicking off a fake `flip` auction (inspired by lucash-flip)

--- a/tests/attacks/lucash-flap-end.mcd.expected
+++ b/tests/attacks/lucash-flap-end.mcd.expected
@@ -765,6 +765,12 @@
         </vow>
       </kmcd-state>
     </kmcd>
+    <processed-events>
+      .List
+    </processed-events>
+    <properties>
+      .Map
+    </properties>
     <violation>
       false
     </violation>

--- a/tests/attacks/lucash-flap-end.mcd.expected
+++ b/tests/attacks/lucash-flap-end.mcd.expected
@@ -3,97 +3,7 @@
     <kmcd>
       <kmcd-driver>
         <k>
-          checkViolated ( "Total Bound on Debt" ) ~> deriveVFSM ( ListItem ( "Unauthorized Flip Kick" ) , Measure ( 10 , "Alice" |-> 10
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) ) ~> deriveAll ( ListItem ( "Unauthorized Flap Kick" )
-          ListItem ( "Zero-Time Pot Interest Accumulation" )
-          ListItem ( "PotChi PotPie VatPot" )
-          ListItem ( "Pot Interest Accumulation After End" )
-          ListItem ( "Total Bound on Debt" )
-          ListItem ( "Unauthorized Flip Kick" ) , ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Alice" , Vat . move "Alice" Vow 1 ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 9
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 1 , 1 , 0 ) )
-          ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 1 ) )
-          ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 1 ) )
-          ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 1 ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 9
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 1 , 1 , 0 ) )
-          ListItem ( LogNote ( "Alice" , Vat . hope Flap ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 9
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 1 , 1 , 0 ) )
-          ListItem ( Exception ( Flap . kick 1 20 ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 9
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 1 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . cage ) )
-          ListItem ( LogNote ( ADMIN , Cat . cage ) )
-          ListItem ( LogNote ( Vow , Vat . move Flap Vow 0 ) )
-          ListItem ( LogNote ( End , Flap . cage 0 ) )
-          ListItem ( LogNote ( End , Flop . cage ) )
-          ListItem ( LogNote ( End , Vat . heal 0 ) )
-          ListItem ( LogNote ( ADMIN , Vow . cage ) )
-          ListItem ( LogNote ( ADMIN , Pot . cage ) )
-          ListItem ( LogNote ( ADMIN , End . cage ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 9
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 1 , 1 , 0 ) )
-          ListItem ( Exception ( Flap . yank 1 ) ) ) ~> .MCDSteps
+          .
         </k>
         <return-value>
           .
@@ -776,11 +686,92 @@
       Flap |-> 0
       Pot |-> 0
       Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Alice" , Vat . move "Alice" Vow 1 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 9
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 1 , 1 , 0 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 1 ) )
+      ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 1 ) )
+      ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 1 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 9
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 1 , 1 , 0 ) )
+      ListItem ( LogNote ( "Alice" , Vat . hope Flap ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 9
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 1 , 1 , 0 ) )
+      ListItem ( Exception ( Flap . kick 1 20 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 9
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 1 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . cage ) )
+      ListItem ( LogNote ( ADMIN , Cat . cage ) )
+      ListItem ( LogNote ( Vow , Vat . move Flap Vow 0 ) )
+      ListItem ( LogNote ( End , Flap . cage 0 ) )
+      ListItem ( LogNote ( End , Flop . cage ) )
+      ListItem ( LogNote ( End , Vat . heal 0 ) )
+      ListItem ( LogNote ( ADMIN , Vow . cage ) )
+      ListItem ( LogNote ( ADMIN , Pot . cage ) )
+      ListItem ( LogNote ( ADMIN , End . cage ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 9
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 1 , 1 , 0 ) )
+      ListItem ( Exception ( Flap . yank 1 ) )
     </processed-events>
     <properties>
-      "Pot Interest Accumulation After End" |-> potEndInterest
+      "Pot Interest Accumulation After End" |-> potEndInterestEnd
       "PotChi PotPie VatPot" |-> potChiPieDai
-      "Total Bound on Debt" |-> Violated
+      "Total Bound on Debt" |-> totalDebtBoundedEnd ( 20 )
       "Unauthorized Flap Kick" |-> unAuthFlapKick
       "Unauthorized Flip Kick" |-> unAuthFlipKick
       "Zero-Time Pot Interest Accumulation" |-> zeroTimePotInterest

--- a/tests/attacks/lucash-flap-end.mcd.expected
+++ b/tests/attacks/lucash-flap-end.mcd.expected
@@ -3,7 +3,97 @@
     <kmcd>
       <kmcd-driver>
         <k>
-          .
+          checkViolated ( "Total Bound on Debt" ) ~> deriveVFSM ( ListItem ( "Unauthorized Flip Kick" ) , Measure ( 10 , "Alice" |-> 10
+          "Bobby" |-> 0
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) ) ~> deriveAll ( ListItem ( "Unauthorized Flap Kick" )
+          ListItem ( "Zero-Time Pot Interest Accumulation" )
+          ListItem ( "PotChi PotPie VatPot" )
+          ListItem ( "Pot Interest Accumulation After End" )
+          ListItem ( "Total Bound on Debt" )
+          ListItem ( "Unauthorized Flip Kick" ) , ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( "Alice" , Vat . move "Alice" Vow 1 ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 9
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 1 , 1 , 0 ) )
+          ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 1 ) )
+          ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 1 ) )
+          ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 1 ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 9
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 1 , 1 , 0 ) )
+          ListItem ( LogNote ( "Alice" , Vat . hope Flap ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 9
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 1 , 1 , 0 ) )
+          ListItem ( Exception ( Flap . kick 1 20 ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 9
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 1 , 1 , 0 ) )
+          ListItem ( LogNote ( ADMIN , Vat . cage ) )
+          ListItem ( LogNote ( ADMIN , Cat . cage ) )
+          ListItem ( LogNote ( Vow , Vat . move Flap Vow 0 ) )
+          ListItem ( LogNote ( End , Flap . cage 0 ) )
+          ListItem ( LogNote ( End , Flop . cage ) )
+          ListItem ( LogNote ( End , Vat . heal 0 ) )
+          ListItem ( LogNote ( ADMIN , Vow . cage ) )
+          ListItem ( LogNote ( ADMIN , Pot . cage ) )
+          ListItem ( LogNote ( ADMIN , End . cage ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 9
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 1 , 1 , 0 ) )
+          ListItem ( Exception ( Flap . yank 1 ) ) ) ~> .MCDSteps
         </k>
         <return-value>
           .
@@ -686,90 +776,11 @@
       Flap |-> 0
       Pot |-> 0
       Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( "Alice" , Vat . move "Alice" Vow 1 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 9
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 1 , 1 , 0 ) )
-      ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 1 ) )
-      ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 1 ) )
-      ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 1 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 9
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 1 , 1 , 0 ) )
-      ListItem ( LogNote ( "Alice" , Vat . hope Flap ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 9
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 1 , 1 , 0 ) )
-      ListItem ( Exception ( Flap . kick 1 20 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 9
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 1 , 1 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vat . cage ) )
-      ListItem ( LogNote ( ADMIN , Cat . cage ) )
-      ListItem ( LogNote ( Vow , Vat . move Flap Vow 0 ) )
-      ListItem ( LogNote ( End , Flap . cage 0 ) )
-      ListItem ( LogNote ( End , Flop . cage ) )
-      ListItem ( LogNote ( End , Vat . heal 0 ) )
-      ListItem ( LogNote ( ADMIN , Vow . cage ) )
-      ListItem ( LogNote ( ADMIN , Pot . cage ) )
-      ListItem ( LogNote ( ADMIN , End . cage ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 9
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 1 , 1 , 0 ) )
-      ListItem ( Exception ( Flap . yank 1 ) )
     </processed-events>
     <properties>
-      "Pot Interest Accumulation After End" |-> potEndInterestEnd
+      "Pot Interest Accumulation After End" |-> potEndInterest
+      "PotChi PotPie VatPot" |-> potChiPieDai
+      "Total Bound on Debt" |-> Violated
       "Unauthorized Flap Kick" |-> unAuthFlapKick
       "Unauthorized Flip Kick" |-> unAuthFlipKick
       "Zero-Time Pot Interest Accumulation" |-> zeroTimePotInterest

--- a/tests/attacks/lucash-flap-end.mcd.expected
+++ b/tests/attacks/lucash-flap-end.mcd.expected
@@ -24,374 +24,7 @@
           .
         </pre-state>
         <events>
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . rely Pot ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . rely End ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Pot . rely End ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vow . rely Pot ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vow . rely End ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Cat . rely End ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Flap . rely Vow ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Flop . rely Vow ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initUser Vow ) )
-          ListItem ( Measure ( 0 , Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initUser Pot ) )
-          ListItem ( Measure ( 0 , Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initUser Flap ) )
-          ListItem ( Measure ( 0 , Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initUser End ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Pot . file vow-file Vow ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "gold" . init ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , GemJoin "gold" . init ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . rely GemJoin "gold" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initGem "gold" End ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initGem "gold" Flip "gold" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" End ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Spot . init "gold" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 1 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Flip "gold" . init ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Flip "gold" . rely End ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initGap "gold" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "MKR" . init ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , GemJoin "MKR" . init ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Vow ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Flap ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "MKR" . mint Flap 20 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . file Line 1000000000000 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initIlk "gold" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . file spot "gold" 3000000000 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vow . file bump 1000000000 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Alice" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Bobby" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Alice" 20 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Bobby" 20 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Alice" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Bobby" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Pot . initUser "Alice" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Pot . initUser "Bobby" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initUser "Alice" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Alice" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Alice" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initUser "Bobby" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Bobby" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Bobby" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Alice" , Vat . hope Pot ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Alice" , Vat . hope Flip "gold" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Alice" , Vat . hope End ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Bobby" , Vat . hope Pot ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Bobby" , Vat . hope Flip "gold" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Bobby" , Vat . hope End ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Alice" , Vat . slip "gold" "Alice" 10 ) )
-          ListItem ( LogNote ( "Alice" , Gem "gold" . transferFrom "Alice" GemJoin "gold" 10 ) )
-          ListItem ( LogNote ( "Alice" , GemJoin "gold" . join "Alice" 10 ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 10 ) )
-          ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 10 ) )
-          ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 10 ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Alice" , Vat . frob "gold" "Alice" "Alice" "Alice" 10 10 ) )
-          ListItem ( Measure ( 10 , "Alice" |-> 10
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Alice" , Vat . move "Alice" Vow 1 ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 9
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 1 , 1 , 0 ) )
-          ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 1 ) )
-          ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 1 ) )
-          ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 1 ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 9
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 1 , 1 , 0 ) )
-          ListItem ( LogNote ( "Alice" , Vat . hope Flap ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 9
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 1 , 1 , 0 ) )
-          ListItem ( Exception ( Flap . kick 1 20 ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 9
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 1 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . cage ) )
-          ListItem ( LogNote ( ADMIN , Cat . cage ) )
-          ListItem ( LogNote ( Vow , Vat . move Flap Vow 0 ) )
-          ListItem ( LogNote ( End , Flap . cage 0 ) )
-          ListItem ( LogNote ( End , Flop . cage ) )
-          ListItem ( LogNote ( End , Vat . heal 0 ) )
-          ListItem ( LogNote ( ADMIN , Vow . cage ) )
-          ListItem ( LogNote ( ADMIN , Pot . cage ) )
-          ListItem ( LogNote ( ADMIN , End . cage ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 9
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 1 , 1 , 0 ) )
-          ListItem ( Exception ( Flap . yank 1 ) )
+          .List
         </events>
         <frame-events>
           .List
@@ -766,14 +399,381 @@
       </kmcd-state>
     </kmcd>
     <processed-events>
-      .List
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . rely Pot ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . rely End ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Pot . rely End ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vow . rely Pot ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vow . rely End ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Cat . rely End ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Flap . rely Vow ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Flop . rely Vow ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser Vow ) )
+      ListItem ( Measure ( 0 , Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser Pot ) )
+      ListItem ( Measure ( 0 , Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser Flap ) )
+      ListItem ( Measure ( 0 , Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Pot . file vow-file Vow ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , GemJoin "gold" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . rely GemJoin "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" Flip "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Spot . init "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 1 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Flip "gold" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Flip "gold" . rely End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initGap "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "MKR" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , GemJoin "MKR" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Vow ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Flap ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "MKR" . mint Flap 20 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . file Line 1000000000000 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initIlk "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . file spot "gold" 3000000000 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vow . file bump 1000000000 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Alice" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Bobby" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Alice" 20 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Bobby" 20 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Alice" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Bobby" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Pot . initUser "Alice" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Pot . initUser "Bobby" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser "Alice" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Alice" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Alice" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser "Bobby" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Bobby" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Bobby" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Alice" , Vat . hope Pot ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Alice" , Vat . hope Flip "gold" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Alice" , Vat . hope End ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . hope Pot ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . hope Flip "gold" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . hope End ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Alice" , Vat . slip "gold" "Alice" 10 ) )
+      ListItem ( LogNote ( "Alice" , Gem "gold" . transferFrom "Alice" GemJoin "gold" 10 ) )
+      ListItem ( LogNote ( "Alice" , GemJoin "gold" . join "Alice" 10 ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 10 ) )
+      ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 10 ) )
+      ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 10 ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Alice" , Vat . frob "gold" "Alice" "Alice" "Alice" 10 10 ) )
+      ListItem ( Measure ( 10 , "Alice" |-> 10
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Alice" , Vat . move "Alice" Vow 1 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 9
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 1 , 1 , 0 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 1 ) )
+      ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 1 ) )
+      ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 1 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 9
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 1 , 1 , 0 ) )
+      ListItem ( LogNote ( "Alice" , Vat . hope Flap ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 9
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 1 , 1 , 0 ) )
+      ListItem ( Exception ( Flap . kick 1 20 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 9
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 1 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . cage ) )
+      ListItem ( LogNote ( ADMIN , Cat . cage ) )
+      ListItem ( LogNote ( Vow , Vat . move Flap Vow 0 ) )
+      ListItem ( LogNote ( End , Flap . cage 0 ) )
+      ListItem ( LogNote ( End , Flop . cage ) )
+      ListItem ( LogNote ( End , Vat . heal 0 ) )
+      ListItem ( LogNote ( ADMIN , Vow . cage ) )
+      ListItem ( LogNote ( ADMIN , Pot . cage ) )
+      ListItem ( LogNote ( ADMIN , End . cage ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 9
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 1 , 1 , 0 ) )
+      ListItem ( Exception ( Flap . yank 1 ) )
     </processed-events>
     <properties>
-      .Map
+      "Pot Interest Accumulation After End" |-> potEndInterestEnd
+      "Unauthorized Flap Kick" |-> unAuthFlapKick
+      "Unauthorized Flip Kick" |-> unAuthFlipKick
+      "Zero-Time Pot Interest Accumulation" |-> zeroTimePotInterest
     </properties>
-    <violation>
-      false
-    </violation>
   </kmcd-properties>
   <kmcd-gen>
     <random>

--- a/tests/attacks/lucash-flap-end.random.mcd.expected
+++ b/tests/attacks/lucash-flap-end.random.mcd.expected
@@ -3,7 +3,96 @@
     <kmcd>
       <kmcd-driver>
         <k>
-          .
+          checkViolated ( "Total Bound on Debt" ) ~> deriveVFSM ( ListItem ( "Unauthorized Flip Kick" ) , Measure ( 10 , "Alice" |-> 10
+          "Bobby" |-> 0
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) ) ~> deriveAll ( ListItem ( "Unauthorized Flap Kick" )
+          ListItem ( "Zero-Time Pot Interest Accumulation" )
+          ListItem ( "PotChi PotPie VatPot" )
+          ListItem ( "Pot Interest Accumulation After End" )
+          ListItem ( "Total Bound on Debt" )
+          ListItem ( "Unauthorized Flip Kick" ) , ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
+          ListItem ( GenStep ( b"a0" , transact "Alice" Vat . move "Alice" Vow 24 /Rat 5 ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( "Alice" , Vat . move "Alice" Vow 24 /Rat 5 ) )
+          ListItem ( GenStep ( b"a3" , transact "Bobby" GemJoin "gold" . join "Bobby" 51 /Rat 10 ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 26 /Rat 5
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 24 /Rat 5 , 1 , 0 ) )
+          ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 51 /Rat 10 ) )
+          ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 51 /Rat 10 ) )
+          ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 51 /Rat 10 ) )
+          ListItem ( GenStep ( b"a" , transact "Alice" Vat . hope Flap ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 26 /Rat 5
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 24 /Rat 5 , 1 , 0 ) )
+          ListItem ( LogNote ( "Alice" , Vat . hope Flap ) )
+          ListItem ( GenStep ( b"o0Z" , transact "Alice" Flap . kick 312 /Rat 125 18 ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 26 /Rat 5
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 24 /Rat 5 , 1 , 0 ) )
+          ListItem ( Exception ( Flap . kick 312 /Rat 125 18 ) )
+          ListItem ( GenStep ( b"a" , transact ADMIN End . cage ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 26 /Rat 5
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 24 /Rat 5 , 1 , 0 ) )
+          ListItem ( LogNote ( ADMIN , Vat . cage ) )
+          ListItem ( LogNote ( ADMIN , Cat . cage ) )
+          ListItem ( LogNote ( Vow , Vat . move Flap Vow 0 ) )
+          ListItem ( LogNote ( End , Flap . cage 0 ) )
+          ListItem ( LogNote ( End , Flop . cage ) )
+          ListItem ( LogNote ( End , Vat . heal 0 ) )
+          ListItem ( LogNote ( ADMIN , Vow . cage ) )
+          ListItem ( LogNote ( ADMIN , Pot . cage ) )
+          ListItem ( LogNote ( ADMIN , End . cage ) )
+          ListItem ( GenStepFailed ( b"a" , GenFlapYank ) ) )
         </k>
         <return-value>
           .
@@ -686,89 +775,11 @@
       Flap |-> 0
       Pot |-> 0
       Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
-      ListItem ( GenStep ( b"a0" , transact "Alice" Vat . move "Alice" Vow 24 /Rat 5 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( "Alice" , Vat . move "Alice" Vow 24 /Rat 5 ) )
-      ListItem ( GenStep ( b"a3" , transact "Bobby" GemJoin "gold" . join "Bobby" 51 /Rat 10 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 26 /Rat 5
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 24 /Rat 5 , 1 , 0 ) )
-      ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 51 /Rat 10 ) )
-      ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 51 /Rat 10 ) )
-      ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 51 /Rat 10 ) )
-      ListItem ( GenStep ( b"a" , transact "Alice" Vat . hope Flap ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 26 /Rat 5
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 24 /Rat 5 , 1 , 0 ) )
-      ListItem ( LogNote ( "Alice" , Vat . hope Flap ) )
-      ListItem ( GenStep ( b"o0Z" , transact "Alice" Flap . kick 312 /Rat 125 18 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 26 /Rat 5
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 24 /Rat 5 , 1 , 0 ) )
-      ListItem ( Exception ( Flap . kick 312 /Rat 125 18 ) )
-      ListItem ( GenStep ( b"a" , transact ADMIN End . cage ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 26 /Rat 5
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 24 /Rat 5 , 1 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vat . cage ) )
-      ListItem ( LogNote ( ADMIN , Cat . cage ) )
-      ListItem ( LogNote ( Vow , Vat . move Flap Vow 0 ) )
-      ListItem ( LogNote ( End , Flap . cage 0 ) )
-      ListItem ( LogNote ( End , Flop . cage ) )
-      ListItem ( LogNote ( End , Vat . heal 0 ) )
-      ListItem ( LogNote ( ADMIN , Vow . cage ) )
-      ListItem ( LogNote ( ADMIN , Pot . cage ) )
-      ListItem ( LogNote ( ADMIN , End . cage ) )
-      ListItem ( GenStepFailed ( b"a" , GenFlapYank ) )
     </processed-events>
     <properties>
-      "Pot Interest Accumulation After End" |-> potEndInterestEnd
+      "Pot Interest Accumulation After End" |-> potEndInterest
+      "PotChi PotPie VatPot" |-> potChiPieDai
+      "Total Bound on Debt" |-> Violated
       "Unauthorized Flap Kick" |-> unAuthFlapKick
       "Unauthorized Flip Kick" |-> unAuthFlipKick
       "Zero-Time Pot Interest Accumulation" |-> zeroTimePotInterest

--- a/tests/attacks/lucash-flap-end.random.mcd.expected
+++ b/tests/attacks/lucash-flap-end.random.mcd.expected
@@ -764,6 +764,12 @@
         </vow>
       </kmcd-state>
     </kmcd>
+    <processed-events>
+      .List
+    </processed-events>
+    <properties>
+      .Map
+    </properties>
     <violation>
       false
     </violation>

--- a/tests/attacks/lucash-flap-end.random.mcd.expected
+++ b/tests/attacks/lucash-flap-end.random.mcd.expected
@@ -3,96 +3,7 @@
     <kmcd>
       <kmcd-driver>
         <k>
-          checkViolated ( "Total Bound on Debt" ) ~> deriveVFSM ( ListItem ( "Unauthorized Flip Kick" ) , Measure ( 10 , "Alice" |-> 10
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) ) ~> deriveAll ( ListItem ( "Unauthorized Flap Kick" )
-          ListItem ( "Zero-Time Pot Interest Accumulation" )
-          ListItem ( "PotChi PotPie VatPot" )
-          ListItem ( "Pot Interest Accumulation After End" )
-          ListItem ( "Total Bound on Debt" )
-          ListItem ( "Unauthorized Flip Kick" ) , ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
-          ListItem ( GenStep ( b"a0" , transact "Alice" Vat . move "Alice" Vow 24 /Rat 5 ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Alice" , Vat . move "Alice" Vow 24 /Rat 5 ) )
-          ListItem ( GenStep ( b"a3" , transact "Bobby" GemJoin "gold" . join "Bobby" 51 /Rat 10 ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 26 /Rat 5
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 24 /Rat 5 , 1 , 0 ) )
-          ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 51 /Rat 10 ) )
-          ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 51 /Rat 10 ) )
-          ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 51 /Rat 10 ) )
-          ListItem ( GenStep ( b"a" , transact "Alice" Vat . hope Flap ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 26 /Rat 5
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 24 /Rat 5 , 1 , 0 ) )
-          ListItem ( LogNote ( "Alice" , Vat . hope Flap ) )
-          ListItem ( GenStep ( b"o0Z" , transact "Alice" Flap . kick 312 /Rat 125 18 ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 26 /Rat 5
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 24 /Rat 5 , 1 , 0 ) )
-          ListItem ( Exception ( Flap . kick 312 /Rat 125 18 ) )
-          ListItem ( GenStep ( b"a" , transact ADMIN End . cage ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 26 /Rat 5
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 24 /Rat 5 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . cage ) )
-          ListItem ( LogNote ( ADMIN , Cat . cage ) )
-          ListItem ( LogNote ( Vow , Vat . move Flap Vow 0 ) )
-          ListItem ( LogNote ( End , Flap . cage 0 ) )
-          ListItem ( LogNote ( End , Flop . cage ) )
-          ListItem ( LogNote ( End , Vat . heal 0 ) )
-          ListItem ( LogNote ( ADMIN , Vow . cage ) )
-          ListItem ( LogNote ( ADMIN , Pot . cage ) )
-          ListItem ( LogNote ( ADMIN , End . cage ) )
-          ListItem ( GenStepFailed ( b"a" , GenFlapYank ) ) )
+          .
         </k>
         <return-value>
           .
@@ -775,11 +686,91 @@
       Flap |-> 0
       Pot |-> 0
       Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
+      ListItem ( GenStep ( b"a0" , transact "Alice" Vat . move "Alice" Vow 24 /Rat 5 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Alice" , Vat . move "Alice" Vow 24 /Rat 5 ) )
+      ListItem ( GenStep ( b"a3" , transact "Bobby" GemJoin "gold" . join "Bobby" 51 /Rat 10 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 26 /Rat 5
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 24 /Rat 5 , 1 , 0 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 51 /Rat 10 ) )
+      ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 51 /Rat 10 ) )
+      ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 51 /Rat 10 ) )
+      ListItem ( GenStep ( b"a" , transact "Alice" Vat . hope Flap ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 26 /Rat 5
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 24 /Rat 5 , 1 , 0 ) )
+      ListItem ( LogNote ( "Alice" , Vat . hope Flap ) )
+      ListItem ( GenStep ( b"o0Z" , transact "Alice" Flap . kick 312 /Rat 125 18 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 26 /Rat 5
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 24 /Rat 5 , 1 , 0 ) )
+      ListItem ( Exception ( Flap . kick 312 /Rat 125 18 ) )
+      ListItem ( GenStep ( b"a" , transact ADMIN End . cage ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 26 /Rat 5
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 24 /Rat 5 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . cage ) )
+      ListItem ( LogNote ( ADMIN , Cat . cage ) )
+      ListItem ( LogNote ( Vow , Vat . move Flap Vow 0 ) )
+      ListItem ( LogNote ( End , Flap . cage 0 ) )
+      ListItem ( LogNote ( End , Flop . cage ) )
+      ListItem ( LogNote ( End , Vat . heal 0 ) )
+      ListItem ( LogNote ( ADMIN , Vow . cage ) )
+      ListItem ( LogNote ( ADMIN , Pot . cage ) )
+      ListItem ( LogNote ( ADMIN , End . cage ) )
+      ListItem ( GenStepFailed ( b"a" , GenFlapYank ) )
     </processed-events>
     <properties>
-      "Pot Interest Accumulation After End" |-> potEndInterest
+      "Pot Interest Accumulation After End" |-> potEndInterestEnd
       "PotChi PotPie VatPot" |-> potChiPieDai
-      "Total Bound on Debt" |-> Violated
+      "Total Bound on Debt" |-> totalDebtBoundedEnd ( 20 )
       "Unauthorized Flap Kick" |-> unAuthFlapKick
       "Unauthorized Flip Kick" |-> unAuthFlipKick
       "Zero-Time Pot Interest Accumulation" |-> zeroTimePotInterest

--- a/tests/attacks/lucash-flap-end.random.mcd.expected
+++ b/tests/attacks/lucash-flap-end.random.mcd.expected
@@ -24,373 +24,7 @@
           .
         </pre-state>
         <events>
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . rely Pot ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . rely End ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Pot . rely End ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vow . rely Pot ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vow . rely End ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Cat . rely End ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Flap . rely Vow ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Flop . rely Vow ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initUser Vow ) )
-          ListItem ( Measure ( 0 , Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initUser Pot ) )
-          ListItem ( Measure ( 0 , Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initUser Flap ) )
-          ListItem ( Measure ( 0 , Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initUser End ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Pot . file vow-file Vow ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "gold" . init ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , GemJoin "gold" . init ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . rely GemJoin "gold" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initGem "gold" End ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initGem "gold" Flip "gold" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" End ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Spot . init "gold" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 1 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Flip "gold" . init ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Flip "gold" . rely End ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initGap "gold" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "MKR" . init ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , GemJoin "MKR" . init ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Vow ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Flap ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "MKR" . mint Flap 20 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . file Line 1000000000000 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initIlk "gold" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . file spot "gold" 3000000000 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vow . file bump 1000000000 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Alice" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Bobby" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Alice" 20 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Bobby" 20 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Alice" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Bobby" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Pot . initUser "Alice" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Pot . initUser "Bobby" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initUser "Alice" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Alice" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Alice" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initUser "Bobby" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Bobby" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Bobby" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Alice" , Vat . hope Pot ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Alice" , Vat . hope Flip "gold" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Alice" , Vat . hope End ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Bobby" , Vat . hope Pot ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Bobby" , Vat . hope Flip "gold" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Bobby" , Vat . hope End ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Alice" , Vat . slip "gold" "Alice" 10 ) )
-          ListItem ( LogNote ( "Alice" , Gem "gold" . transferFrom "Alice" GemJoin "gold" 10 ) )
-          ListItem ( LogNote ( "Alice" , GemJoin "gold" . join "Alice" 10 ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 10 ) )
-          ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 10 ) )
-          ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 10 ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Alice" , Vat . frob "gold" "Alice" "Alice" "Alice" 10 10 ) )
-          ListItem ( Measure ( 10 , "Alice" |-> 10
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
-          ListItem ( GenStep ( b"a0" , transact "Alice" Vat . move "Alice" Vow 24 /Rat 5 ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Alice" , Vat . move "Alice" Vow 24 /Rat 5 ) )
-          ListItem ( GenStep ( b"a3" , transact "Bobby" GemJoin "gold" . join "Bobby" 51 /Rat 10 ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 26 /Rat 5
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 24 /Rat 5 , 1 , 0 ) )
-          ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 51 /Rat 10 ) )
-          ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 51 /Rat 10 ) )
-          ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 51 /Rat 10 ) )
-          ListItem ( GenStep ( b"a" , transact "Alice" Vat . hope Flap ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 26 /Rat 5
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 24 /Rat 5 , 1 , 0 ) )
-          ListItem ( LogNote ( "Alice" , Vat . hope Flap ) )
-          ListItem ( GenStep ( b"o0Z" , transact "Alice" Flap . kick 312 /Rat 125 18 ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 26 /Rat 5
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 24 /Rat 5 , 1 , 0 ) )
-          ListItem ( Exception ( Flap . kick 312 /Rat 125 18 ) )
-          ListItem ( GenStep ( b"a" , transact ADMIN End . cage ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 26 /Rat 5
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 24 /Rat 5 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . cage ) )
-          ListItem ( LogNote ( ADMIN , Cat . cage ) )
-          ListItem ( LogNote ( Vow , Vat . move Flap Vow 0 ) )
-          ListItem ( LogNote ( End , Flap . cage 0 ) )
-          ListItem ( LogNote ( End , Flop . cage ) )
-          ListItem ( LogNote ( End , Vat . heal 0 ) )
-          ListItem ( LogNote ( ADMIN , Vow . cage ) )
-          ListItem ( LogNote ( ADMIN , Pot . cage ) )
-          ListItem ( LogNote ( ADMIN , End . cage ) )
-          ListItem ( GenStepFailed ( b"a" , GenFlapYank ) )
+          .List
         </events>
         <frame-events>
           .List
@@ -765,14 +399,380 @@
       </kmcd-state>
     </kmcd>
     <processed-events>
-      .List
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . rely Pot ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . rely End ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Pot . rely End ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vow . rely Pot ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vow . rely End ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Cat . rely End ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Flap . rely Vow ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Flop . rely Vow ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser Vow ) )
+      ListItem ( Measure ( 0 , Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser Pot ) )
+      ListItem ( Measure ( 0 , Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser Flap ) )
+      ListItem ( Measure ( 0 , Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Pot . file vow-file Vow ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , GemJoin "gold" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . rely GemJoin "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" Flip "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Spot . init "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 1 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Flip "gold" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Flip "gold" . rely End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initGap "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "MKR" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , GemJoin "MKR" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Vow ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Flap ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "MKR" . mint Flap 20 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . file Line 1000000000000 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initIlk "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . file spot "gold" 3000000000 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vow . file bump 1000000000 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Alice" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Bobby" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Alice" 20 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Bobby" 20 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Alice" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Bobby" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Pot . initUser "Alice" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Pot . initUser "Bobby" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser "Alice" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Alice" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Alice" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser "Bobby" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Bobby" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Bobby" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Alice" , Vat . hope Pot ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Alice" , Vat . hope Flip "gold" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Alice" , Vat . hope End ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . hope Pot ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . hope Flip "gold" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . hope End ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Alice" , Vat . slip "gold" "Alice" 10 ) )
+      ListItem ( LogNote ( "Alice" , Gem "gold" . transferFrom "Alice" GemJoin "gold" 10 ) )
+      ListItem ( LogNote ( "Alice" , GemJoin "gold" . join "Alice" 10 ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 10 ) )
+      ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 10 ) )
+      ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 10 ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Alice" , Vat . frob "gold" "Alice" "Alice" "Alice" 10 10 ) )
+      ListItem ( Measure ( 10 , "Alice" |-> 10
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
+      ListItem ( GenStep ( b"a0" , transact "Alice" Vat . move "Alice" Vow 24 /Rat 5 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Alice" , Vat . move "Alice" Vow 24 /Rat 5 ) )
+      ListItem ( GenStep ( b"a3" , transact "Bobby" GemJoin "gold" . join "Bobby" 51 /Rat 10 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 26 /Rat 5
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 24 /Rat 5 , 1 , 0 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 51 /Rat 10 ) )
+      ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 51 /Rat 10 ) )
+      ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 51 /Rat 10 ) )
+      ListItem ( GenStep ( b"a" , transact "Alice" Vat . hope Flap ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 26 /Rat 5
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 24 /Rat 5 , 1 , 0 ) )
+      ListItem ( LogNote ( "Alice" , Vat . hope Flap ) )
+      ListItem ( GenStep ( b"o0Z" , transact "Alice" Flap . kick 312 /Rat 125 18 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 26 /Rat 5
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 24 /Rat 5 , 1 , 0 ) )
+      ListItem ( Exception ( Flap . kick 312 /Rat 125 18 ) )
+      ListItem ( GenStep ( b"a" , transact ADMIN End . cage ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 26 /Rat 5
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 24 /Rat 5 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . cage ) )
+      ListItem ( LogNote ( ADMIN , Cat . cage ) )
+      ListItem ( LogNote ( Vow , Vat . move Flap Vow 0 ) )
+      ListItem ( LogNote ( End , Flap . cage 0 ) )
+      ListItem ( LogNote ( End , Flop . cage ) )
+      ListItem ( LogNote ( End , Vat . heal 0 ) )
+      ListItem ( LogNote ( ADMIN , Vow . cage ) )
+      ListItem ( LogNote ( ADMIN , Pot . cage ) )
+      ListItem ( LogNote ( ADMIN , End . cage ) )
+      ListItem ( GenStepFailed ( b"a" , GenFlapYank ) )
     </processed-events>
     <properties>
-      .Map
+      "Pot Interest Accumulation After End" |-> potEndInterestEnd
+      "Unauthorized Flap Kick" |-> unAuthFlapKick
+      "Unauthorized Flip Kick" |-> unAuthFlipKick
+      "Zero-Time Pot Interest Accumulation" |-> zeroTimePotInterest
     </properties>
-    <violation>
-      false
-    </violation>
   </kmcd-properties>
   <kmcd-gen>
     <random>

--- a/tests/attacks/lucash-flip-end.mcd.expected
+++ b/tests/attacks/lucash-flip-end.mcd.expected
@@ -3,7 +3,105 @@
     <kmcd>
       <kmcd-driver>
         <k>
-          .
+          checkViolated ( "Total Bound on Debt" ) ~> deriveVFSM ( ListItem ( "Unauthorized Flip Kick" ) , Measure ( 10 , "Alice" |-> 10
+          "Bobby" |-> 0
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) ) ~> deriveAll ( ListItem ( "Unauthorized Flap Kick" )
+          ListItem ( "Zero-Time Pot Interest Accumulation" )
+          ListItem ( "PotChi PotPie VatPot" )
+          ListItem ( "Pot Interest Accumulation After End" )
+          ListItem ( "Total Bound on Debt" )
+          ListItem ( "Unauthorized Flip Kick" ) , ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 1 ) )
+          ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 1 ) )
+          ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 1 ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( ADMIN , Vat . cage ) )
+          ListItem ( LogNote ( ADMIN , Cat . cage ) )
+          ListItem ( LogNote ( Vow , Vat . move Flap Vow 0 ) )
+          ListItem ( LogNote ( End , Flap . cage 0 ) )
+          ListItem ( LogNote ( End , Flop . cage ) )
+          ListItem ( LogNote ( End , Vat . heal 0 ) )
+          ListItem ( LogNote ( ADMIN , Vow . cage ) )
+          ListItem ( LogNote ( ADMIN , Pot . cage ) )
+          ListItem ( LogNote ( ADMIN , End . cage ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( ADMIN , End . cage "gold" ) )
+          ListItem ( TimeStep ( 3600 , 3600 ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( ADMIN , End . thaw ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( ADMIN , End . flow "gold" ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( Exception ( Flip "gold" . kick End "Bobby" 1001000000000 1 1000000000000 ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( Exception ( End . skip "gold" 1 ) ) ) ~> .MCDSteps
         </k>
         <return-value>
           .
@@ -685,101 +783,14 @@
       Flap |-> 0
       Pot |-> 0
       Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 1 ) )
-      ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 1 ) )
-      ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 1 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vat . cage ) )
-      ListItem ( LogNote ( ADMIN , Cat . cage ) )
-      ListItem ( LogNote ( Vow , Vat . move Flap Vow 0 ) )
-      ListItem ( LogNote ( End , Flap . cage 0 ) )
-      ListItem ( LogNote ( End , Flop . cage ) )
-      ListItem ( LogNote ( End , Vat . heal 0 ) )
-      ListItem ( LogNote ( ADMIN , Vow . cage ) )
-      ListItem ( LogNote ( ADMIN , Pot . cage ) )
-      ListItem ( LogNote ( ADMIN , End . cage ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( ADMIN , End . cage "gold" ) )
-      ListItem ( TimeStep ( 3600 , 3600 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( ADMIN , End . thaw ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( ADMIN , End . flow "gold" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( Exception ( Flip "gold" . kick End "Bobby" 1001000000000 1 1000000000000 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( Exception ( End . skip "gold" 1 ) )
     </processed-events>
     <properties>
-      "Pot Interest Accumulation After End" |-> potEndInterestEnd
+      "Pot Interest Accumulation After End" |-> potEndInterest
+      "PotChi PotPie VatPot" |-> potChiPieDai
+      "Total Bound on Debt" |-> Violated
       "Unauthorized Flap Kick" |-> unAuthFlapKick
       "Unauthorized Flip Kick" |-> unAuthFlipKick
-      "Zero-Time Pot Interest Accumulation" |-> zeroTimePotInterestEnd
+      "Zero-Time Pot Interest Accumulation" |-> zeroTimePotInterest
     </properties>
   </kmcd-properties>
   <kmcd-gen>

--- a/tests/attacks/lucash-flip-end.mcd.expected
+++ b/tests/attacks/lucash-flip-end.mcd.expected
@@ -772,6 +772,12 @@
         </vow>
       </kmcd-state>
     </kmcd>
+    <processed-events>
+      .List
+    </processed-events>
+    <properties>
+      .Map
+    </properties>
     <violation>
       false
     </violation>

--- a/tests/attacks/lucash-flip-end.mcd.expected
+++ b/tests/attacks/lucash-flip-end.mcd.expected
@@ -24,382 +24,7 @@
           .
         </pre-state>
         <events>
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . rely Pot ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . rely End ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Pot . rely End ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vow . rely Pot ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vow . rely End ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Cat . rely End ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Flap . rely Vow ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Flop . rely Vow ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initUser Vow ) )
-          ListItem ( Measure ( 0 , Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initUser Pot ) )
-          ListItem ( Measure ( 0 , Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initUser Flap ) )
-          ListItem ( Measure ( 0 , Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initUser End ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Pot . file vow-file Vow ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "gold" . init ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , GemJoin "gold" . init ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . rely GemJoin "gold" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initGem "gold" End ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initGem "gold" Flip "gold" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" End ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Spot . init "gold" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 1 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Flip "gold" . init ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Flip "gold" . rely End ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initGap "gold" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "MKR" . init ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , GemJoin "MKR" . init ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Vow ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Flap ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "MKR" . mint Flap 20 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . file Line 1000000000000 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initIlk "gold" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . file spot "gold" 3000000000 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vow . file bump 1000000000 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Alice" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Bobby" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Alice" 20 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Bobby" 20 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Alice" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Bobby" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Pot . initUser "Alice" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Pot . initUser "Bobby" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initUser "Alice" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Alice" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Alice" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initUser "Bobby" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Bobby" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Bobby" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Alice" , Vat . hope Pot ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Alice" , Vat . hope Flip "gold" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Alice" , Vat . hope End ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Bobby" , Vat . hope Pot ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Bobby" , Vat . hope Flip "gold" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Bobby" , Vat . hope End ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Alice" , Vat . slip "gold" "Alice" 10 ) )
-          ListItem ( LogNote ( "Alice" , Gem "gold" . transferFrom "Alice" GemJoin "gold" 10 ) )
-          ListItem ( LogNote ( "Alice" , GemJoin "gold" . join "Alice" 10 ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 10 ) )
-          ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 10 ) )
-          ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 10 ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Alice" , Vat . frob "gold" "Alice" "Alice" "Alice" 10 10 ) )
-          ListItem ( Measure ( 10 , "Alice" |-> 10
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 1 ) )
-          ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 1 ) )
-          ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 1 ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . cage ) )
-          ListItem ( LogNote ( ADMIN , Cat . cage ) )
-          ListItem ( LogNote ( Vow , Vat . move Flap Vow 0 ) )
-          ListItem ( LogNote ( End , Flap . cage 0 ) )
-          ListItem ( LogNote ( End , Flop . cage ) )
-          ListItem ( LogNote ( End , Vat . heal 0 ) )
-          ListItem ( LogNote ( ADMIN , Vow . cage ) )
-          ListItem ( LogNote ( ADMIN , Pot . cage ) )
-          ListItem ( LogNote ( ADMIN , End . cage ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . cage "gold" ) )
-          ListItem ( TimeStep ( 3600 , 3600 ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . thaw ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . flow "gold" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( Exception ( Flip "gold" . kick End "Bobby" 1001000000000 1 1000000000000 ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( Exception ( End . skip "gold" 1 ) )
+          .List
         </events>
         <frame-events>
           .List
@@ -773,14 +398,389 @@
       </kmcd-state>
     </kmcd>
     <processed-events>
-      .List
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . rely Pot ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . rely End ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Pot . rely End ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vow . rely Pot ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vow . rely End ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Cat . rely End ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Flap . rely Vow ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Flop . rely Vow ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser Vow ) )
+      ListItem ( Measure ( 0 , Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser Pot ) )
+      ListItem ( Measure ( 0 , Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser Flap ) )
+      ListItem ( Measure ( 0 , Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Pot . file vow-file Vow ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , GemJoin "gold" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . rely GemJoin "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" Flip "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Spot . init "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 1 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Flip "gold" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Flip "gold" . rely End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initGap "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "MKR" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , GemJoin "MKR" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Vow ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Flap ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "MKR" . mint Flap 20 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . file Line 1000000000000 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initIlk "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . file spot "gold" 3000000000 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vow . file bump 1000000000 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Alice" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Bobby" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Alice" 20 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Bobby" 20 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Alice" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Bobby" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Pot . initUser "Alice" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Pot . initUser "Bobby" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser "Alice" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Alice" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Alice" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser "Bobby" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Bobby" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Bobby" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Alice" , Vat . hope Pot ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Alice" , Vat . hope Flip "gold" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Alice" , Vat . hope End ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . hope Pot ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . hope Flip "gold" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . hope End ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Alice" , Vat . slip "gold" "Alice" 10 ) )
+      ListItem ( LogNote ( "Alice" , Gem "gold" . transferFrom "Alice" GemJoin "gold" 10 ) )
+      ListItem ( LogNote ( "Alice" , GemJoin "gold" . join "Alice" 10 ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 10 ) )
+      ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 10 ) )
+      ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 10 ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Alice" , Vat . frob "gold" "Alice" "Alice" "Alice" 10 10 ) )
+      ListItem ( Measure ( 10 , "Alice" |-> 10
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 1 ) )
+      ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 1 ) )
+      ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 1 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . cage ) )
+      ListItem ( LogNote ( ADMIN , Cat . cage ) )
+      ListItem ( LogNote ( Vow , Vat . move Flap Vow 0 ) )
+      ListItem ( LogNote ( End , Flap . cage 0 ) )
+      ListItem ( LogNote ( End , Flop . cage ) )
+      ListItem ( LogNote ( End , Vat . heal 0 ) )
+      ListItem ( LogNote ( ADMIN , Vow . cage ) )
+      ListItem ( LogNote ( ADMIN , Pot . cage ) )
+      ListItem ( LogNote ( ADMIN , End . cage ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . cage "gold" ) )
+      ListItem ( TimeStep ( 3600 , 3600 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . thaw ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . flow "gold" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( Exception ( Flip "gold" . kick End "Bobby" 1001000000000 1 1000000000000 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( Exception ( End . skip "gold" 1 ) )
     </processed-events>
     <properties>
-      .Map
+      "Pot Interest Accumulation After End" |-> potEndInterestEnd
+      "Unauthorized Flap Kick" |-> unAuthFlapKick
+      "Unauthorized Flip Kick" |-> unAuthFlipKick
+      "Zero-Time Pot Interest Accumulation" |-> zeroTimePotInterestEnd
     </properties>
-    <violation>
-      false
-    </violation>
   </kmcd-properties>
   <kmcd-gen>
     <random>

--- a/tests/attacks/lucash-flip-end.mcd.expected
+++ b/tests/attacks/lucash-flip-end.mcd.expected
@@ -3,105 +3,7 @@
     <kmcd>
       <kmcd-driver>
         <k>
-          checkViolated ( "Total Bound on Debt" ) ~> deriveVFSM ( ListItem ( "Unauthorized Flip Kick" ) , Measure ( 10 , "Alice" |-> 10
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) ) ~> deriveAll ( ListItem ( "Unauthorized Flap Kick" )
-          ListItem ( "Zero-Time Pot Interest Accumulation" )
-          ListItem ( "PotChi PotPie VatPot" )
-          ListItem ( "Pot Interest Accumulation After End" )
-          ListItem ( "Total Bound on Debt" )
-          ListItem ( "Unauthorized Flip Kick" ) , ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 1 ) )
-          ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 1 ) )
-          ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 1 ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . cage ) )
-          ListItem ( LogNote ( ADMIN , Cat . cage ) )
-          ListItem ( LogNote ( Vow , Vat . move Flap Vow 0 ) )
-          ListItem ( LogNote ( End , Flap . cage 0 ) )
-          ListItem ( LogNote ( End , Flop . cage ) )
-          ListItem ( LogNote ( End , Vat . heal 0 ) )
-          ListItem ( LogNote ( ADMIN , Vow . cage ) )
-          ListItem ( LogNote ( ADMIN , Pot . cage ) )
-          ListItem ( LogNote ( ADMIN , End . cage ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . cage "gold" ) )
-          ListItem ( TimeStep ( 3600 , 3600 ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . thaw ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . flow "gold" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( Exception ( Flip "gold" . kick End "Bobby" 1001000000000 1 1000000000000 ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( Exception ( End . skip "gold" 1 ) ) ) ~> .MCDSteps
+          .
         </k>
         <return-value>
           .
@@ -783,14 +685,103 @@
       Flap |-> 0
       Pot |-> 0
       Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 1 ) )
+      ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 1 ) )
+      ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 1 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . cage ) )
+      ListItem ( LogNote ( ADMIN , Cat . cage ) )
+      ListItem ( LogNote ( Vow , Vat . move Flap Vow 0 ) )
+      ListItem ( LogNote ( End , Flap . cage 0 ) )
+      ListItem ( LogNote ( End , Flop . cage ) )
+      ListItem ( LogNote ( End , Vat . heal 0 ) )
+      ListItem ( LogNote ( ADMIN , Vow . cage ) )
+      ListItem ( LogNote ( ADMIN , Pot . cage ) )
+      ListItem ( LogNote ( ADMIN , End . cage ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . cage "gold" ) )
+      ListItem ( TimeStep ( 3600 , 3600 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . thaw ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . flow "gold" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( Exception ( Flip "gold" . kick End "Bobby" 1001000000000 1 1000000000000 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( Exception ( End . skip "gold" 1 ) )
     </processed-events>
     <properties>
-      "Pot Interest Accumulation After End" |-> potEndInterest
+      "Pot Interest Accumulation After End" |-> potEndInterestEnd
       "PotChi PotPie VatPot" |-> potChiPieDai
-      "Total Bound on Debt" |-> Violated
+      "Total Bound on Debt" |-> totalDebtBoundedEnd ( 20 )
       "Unauthorized Flap Kick" |-> unAuthFlapKick
       "Unauthorized Flip Kick" |-> unAuthFlipKick
-      "Zero-Time Pot Interest Accumulation" |-> zeroTimePotInterest
+      "Zero-Time Pot Interest Accumulation" |-> zeroTimePotInterestEnd
     </properties>
   </kmcd-properties>
   <kmcd-gen>

--- a/tests/attacks/lucash-flip-end.random.mcd.expected
+++ b/tests/attacks/lucash-flip-end.random.mcd.expected
@@ -773,6 +773,12 @@
         </vow>
       </kmcd-state>
     </kmcd>
+    <processed-events>
+      .List
+    </processed-events>
+    <properties>
+      .Map
+    </properties>
     <violation>
       false
     </violation>

--- a/tests/attacks/lucash-flip-end.random.mcd.expected
+++ b/tests/attacks/lucash-flip-end.random.mcd.expected
@@ -3,7 +3,106 @@
     <kmcd>
       <kmcd-driver>
         <k>
-          .
+          checkViolated ( "Total Bound on Debt" ) ~> deriveVFSM ( ListItem ( "Unauthorized Flip Kick" ) , Measure ( 10 , "Alice" |-> 10
+          "Bobby" |-> 0
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) ) ~> deriveAll ( ListItem ( "Unauthorized Flap Kick" )
+          ListItem ( "Zero-Time Pot Interest Accumulation" )
+          ListItem ( "PotChi PotPie VatPot" )
+          ListItem ( "Pot Interest Accumulation After End" )
+          ListItem ( "Total Bound on Debt" )
+          ListItem ( "Unauthorized Flip Kick" ) , ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
+          ListItem ( GenStep ( b"aa" , transact "Bobby" GemJoin "gold" . join "Bobby" 97 /Rat 10 ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 97 /Rat 10 ) )
+          ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 97 /Rat 10 ) )
+          ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 97 /Rat 10 ) )
+          ListItem ( GenStep ( b"a" , transact ADMIN End . cage ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( ADMIN , Vat . cage ) )
+          ListItem ( LogNote ( ADMIN , Cat . cage ) )
+          ListItem ( LogNote ( Vow , Vat . move Flap Vow 0 ) )
+          ListItem ( LogNote ( End , Flap . cage 0 ) )
+          ListItem ( LogNote ( End , Flop . cage ) )
+          ListItem ( LogNote ( End , Vat . heal 0 ) )
+          ListItem ( LogNote ( ADMIN , Vow . cage ) )
+          ListItem ( LogNote ( ADMIN , Pot . cage ) )
+          ListItem ( LogNote ( ADMIN , End . cage ) )
+          ListItem ( GenStep ( b"aa" , transact ANYONE End . cage "gold" ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( ANYONE , End . cage "gold" ) )
+          ListItem ( GenStep ( b"aa" , TimeStep 2 ) )
+          ListItem ( TimeStep ( 2 , 2 ) )
+          ListItem ( GenStep ( b"a" , transact ANYONE End . thaw ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( ANYONE , End . thaw ) )
+          ListItem ( GenStep ( b"aa" , transact ANYONE End . flow "gold" ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( ANYONE , End . flow "gold" ) )
+          ListItem ( GenStep ( b"aaa" , transact "Bobby" Flip "gold" . kick End Flap 1000 9409 /Rat 1000 970 ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( Exception ( Flip "gold" . kick End Flap 1000 9409 /Rat 1000 970 ) )
+          ListItem ( GenStepFailed ( b"a" , GenEndSkip "gold" ) ) )
         </k>
         <return-value>
           .
@@ -685,102 +784,14 @@
       Flap |-> 0
       Pot |-> 0
       Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
-      ListItem ( GenStep ( b"aa" , transact "Bobby" GemJoin "gold" . join "Bobby" 97 /Rat 10 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 97 /Rat 10 ) )
-      ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 97 /Rat 10 ) )
-      ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 97 /Rat 10 ) )
-      ListItem ( GenStep ( b"a" , transact ADMIN End . cage ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vat . cage ) )
-      ListItem ( LogNote ( ADMIN , Cat . cage ) )
-      ListItem ( LogNote ( Vow , Vat . move Flap Vow 0 ) )
-      ListItem ( LogNote ( End , Flap . cage 0 ) )
-      ListItem ( LogNote ( End , Flop . cage ) )
-      ListItem ( LogNote ( End , Vat . heal 0 ) )
-      ListItem ( LogNote ( ADMIN , Vow . cage ) )
-      ListItem ( LogNote ( ADMIN , Pot . cage ) )
-      ListItem ( LogNote ( ADMIN , End . cage ) )
-      ListItem ( GenStep ( b"aa" , transact ANYONE End . cage "gold" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( ANYONE , End . cage "gold" ) )
-      ListItem ( GenStep ( b"aa" , TimeStep 2 ) )
-      ListItem ( TimeStep ( 2 , 2 ) )
-      ListItem ( GenStep ( b"a" , transact ANYONE End . thaw ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( ANYONE , End . thaw ) )
-      ListItem ( GenStep ( b"aa" , transact ANYONE End . flow "gold" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( ANYONE , End . flow "gold" ) )
-      ListItem ( GenStep ( b"aaa" , transact "Bobby" Flip "gold" . kick End Flap 1000 9409 /Rat 1000 970 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( Exception ( Flip "gold" . kick End Flap 1000 9409 /Rat 1000 970 ) )
-      ListItem ( GenStepFailed ( b"a" , GenEndSkip "gold" ) )
     </processed-events>
     <properties>
-      "Pot Interest Accumulation After End" |-> potEndInterestEnd
+      "Pot Interest Accumulation After End" |-> potEndInterest
+      "PotChi PotPie VatPot" |-> potChiPieDai
+      "Total Bound on Debt" |-> Violated
       "Unauthorized Flap Kick" |-> unAuthFlapKick
       "Unauthorized Flip Kick" |-> unAuthFlipKick
-      "Zero-Time Pot Interest Accumulation" |-> zeroTimePotInterestEnd
+      "Zero-Time Pot Interest Accumulation" |-> zeroTimePotInterest
     </properties>
   </kmcd-properties>
   <kmcd-gen>

--- a/tests/attacks/lucash-flip-end.random.mcd.expected
+++ b/tests/attacks/lucash-flip-end.random.mcd.expected
@@ -3,106 +3,7 @@
     <kmcd>
       <kmcd-driver>
         <k>
-          checkViolated ( "Total Bound on Debt" ) ~> deriveVFSM ( ListItem ( "Unauthorized Flip Kick" ) , Measure ( 10 , "Alice" |-> 10
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) ) ~> deriveAll ( ListItem ( "Unauthorized Flap Kick" )
-          ListItem ( "Zero-Time Pot Interest Accumulation" )
-          ListItem ( "PotChi PotPie VatPot" )
-          ListItem ( "Pot Interest Accumulation After End" )
-          ListItem ( "Total Bound on Debt" )
-          ListItem ( "Unauthorized Flip Kick" ) , ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
-          ListItem ( GenStep ( b"aa" , transact "Bobby" GemJoin "gold" . join "Bobby" 97 /Rat 10 ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 97 /Rat 10 ) )
-          ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 97 /Rat 10 ) )
-          ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 97 /Rat 10 ) )
-          ListItem ( GenStep ( b"a" , transact ADMIN End . cage ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . cage ) )
-          ListItem ( LogNote ( ADMIN , Cat . cage ) )
-          ListItem ( LogNote ( Vow , Vat . move Flap Vow 0 ) )
-          ListItem ( LogNote ( End , Flap . cage 0 ) )
-          ListItem ( LogNote ( End , Flop . cage ) )
-          ListItem ( LogNote ( End , Vat . heal 0 ) )
-          ListItem ( LogNote ( ADMIN , Vow . cage ) )
-          ListItem ( LogNote ( ADMIN , Pot . cage ) )
-          ListItem ( LogNote ( ADMIN , End . cage ) )
-          ListItem ( GenStep ( b"aa" , transact ANYONE End . cage "gold" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ANYONE , End . cage "gold" ) )
-          ListItem ( GenStep ( b"aa" , TimeStep 2 ) )
-          ListItem ( TimeStep ( 2 , 2 ) )
-          ListItem ( GenStep ( b"a" , transact ANYONE End . thaw ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ANYONE , End . thaw ) )
-          ListItem ( GenStep ( b"aa" , transact ANYONE End . flow "gold" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ANYONE , End . flow "gold" ) )
-          ListItem ( GenStep ( b"aaa" , transact "Bobby" Flip "gold" . kick End Flap 1000 9409 /Rat 1000 970 ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( Exception ( Flip "gold" . kick End Flap 1000 9409 /Rat 1000 970 ) )
-          ListItem ( GenStepFailed ( b"a" , GenEndSkip "gold" ) ) )
+          .
         </k>
         <return-value>
           .
@@ -784,14 +685,104 @@
       Flap |-> 0
       Pot |-> 0
       Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
+      ListItem ( GenStep ( b"aa" , transact "Bobby" GemJoin "gold" . join "Bobby" 97 /Rat 10 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 97 /Rat 10 ) )
+      ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 97 /Rat 10 ) )
+      ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 97 /Rat 10 ) )
+      ListItem ( GenStep ( b"a" , transact ADMIN End . cage ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . cage ) )
+      ListItem ( LogNote ( ADMIN , Cat . cage ) )
+      ListItem ( LogNote ( Vow , Vat . move Flap Vow 0 ) )
+      ListItem ( LogNote ( End , Flap . cage 0 ) )
+      ListItem ( LogNote ( End , Flop . cage ) )
+      ListItem ( LogNote ( End , Vat . heal 0 ) )
+      ListItem ( LogNote ( ADMIN , Vow . cage ) )
+      ListItem ( LogNote ( ADMIN , Pot . cage ) )
+      ListItem ( LogNote ( ADMIN , End . cage ) )
+      ListItem ( GenStep ( b"aa" , transact ANYONE End . cage "gold" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ANYONE , End . cage "gold" ) )
+      ListItem ( GenStep ( b"aa" , TimeStep 2 ) )
+      ListItem ( TimeStep ( 2 , 2 ) )
+      ListItem ( GenStep ( b"a" , transact ANYONE End . thaw ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ANYONE , End . thaw ) )
+      ListItem ( GenStep ( b"aa" , transact ANYONE End . flow "gold" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ANYONE , End . flow "gold" ) )
+      ListItem ( GenStep ( b"aaa" , transact "Bobby" Flip "gold" . kick End Flap 1000 9409 /Rat 1000 970 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( Exception ( Flip "gold" . kick End Flap 1000 9409 /Rat 1000 970 ) )
+      ListItem ( GenStepFailed ( b"a" , GenEndSkip "gold" ) )
     </processed-events>
     <properties>
-      "Pot Interest Accumulation After End" |-> potEndInterest
+      "Pot Interest Accumulation After End" |-> potEndInterestEnd
       "PotChi PotPie VatPot" |-> potChiPieDai
-      "Total Bound on Debt" |-> Violated
+      "Total Bound on Debt" |-> totalDebtBoundedEnd ( 20 )
       "Unauthorized Flap Kick" |-> unAuthFlapKick
       "Unauthorized Flip Kick" |-> unAuthFlipKick
-      "Zero-Time Pot Interest Accumulation" |-> zeroTimePotInterest
+      "Zero-Time Pot Interest Accumulation" |-> zeroTimePotInterestEnd
     </properties>
   </kmcd-properties>
   <kmcd-gen>

--- a/tests/attacks/lucash-flip-end.random.mcd.expected
+++ b/tests/attacks/lucash-flip-end.random.mcd.expected
@@ -24,383 +24,7 @@
           .
         </pre-state>
         <events>
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . rely Pot ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . rely End ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Pot . rely End ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vow . rely Pot ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vow . rely End ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Cat . rely End ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Flap . rely Vow ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Flop . rely Vow ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initUser Vow ) )
-          ListItem ( Measure ( 0 , Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initUser Pot ) )
-          ListItem ( Measure ( 0 , Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initUser Flap ) )
-          ListItem ( Measure ( 0 , Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initUser End ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Pot . file vow-file Vow ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "gold" . init ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , GemJoin "gold" . init ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . rely GemJoin "gold" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initGem "gold" End ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initGem "gold" Flip "gold" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" End ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Spot . init "gold" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 1 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Flip "gold" . init ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Flip "gold" . rely End ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initGap "gold" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "MKR" . init ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , GemJoin "MKR" . init ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Vow ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Flap ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "MKR" . mint Flap 20 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . file Line 1000000000000 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initIlk "gold" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . file spot "gold" 3000000000 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vow . file bump 1000000000 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Alice" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Bobby" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Alice" 20 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Bobby" 20 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Alice" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Bobby" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Pot . initUser "Alice" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Pot . initUser "Bobby" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initUser "Alice" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Alice" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Alice" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initUser "Bobby" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Bobby" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Bobby" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Alice" , Vat . hope Pot ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Alice" , Vat . hope Flip "gold" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Alice" , Vat . hope End ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Bobby" , Vat . hope Pot ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Bobby" , Vat . hope Flip "gold" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Bobby" , Vat . hope End ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Alice" , Vat . slip "gold" "Alice" 10 ) )
-          ListItem ( LogNote ( "Alice" , Gem "gold" . transferFrom "Alice" GemJoin "gold" 10 ) )
-          ListItem ( LogNote ( "Alice" , GemJoin "gold" . join "Alice" 10 ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 10 ) )
-          ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 10 ) )
-          ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 10 ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Alice" , Vat . frob "gold" "Alice" "Alice" "Alice" 10 10 ) )
-          ListItem ( Measure ( 10 , "Alice" |-> 10
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
-          ListItem ( GenStep ( b"aa" , transact "Bobby" GemJoin "gold" . join "Bobby" 97 /Rat 10 ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 97 /Rat 10 ) )
-          ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 97 /Rat 10 ) )
-          ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 97 /Rat 10 ) )
-          ListItem ( GenStep ( b"a" , transact ADMIN End . cage ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . cage ) )
-          ListItem ( LogNote ( ADMIN , Cat . cage ) )
-          ListItem ( LogNote ( Vow , Vat . move Flap Vow 0 ) )
-          ListItem ( LogNote ( End , Flap . cage 0 ) )
-          ListItem ( LogNote ( End , Flop . cage ) )
-          ListItem ( LogNote ( End , Vat . heal 0 ) )
-          ListItem ( LogNote ( ADMIN , Vow . cage ) )
-          ListItem ( LogNote ( ADMIN , Pot . cage ) )
-          ListItem ( LogNote ( ADMIN , End . cage ) )
-          ListItem ( GenStep ( b"aa" , transact ANYONE End . cage "gold" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ANYONE , End . cage "gold" ) )
-          ListItem ( GenStep ( b"aa" , TimeStep 2 ) )
-          ListItem ( TimeStep ( 2 , 2 ) )
-          ListItem ( GenStep ( b"a" , transact ANYONE End . thaw ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ANYONE , End . thaw ) )
-          ListItem ( GenStep ( b"aa" , transact ANYONE End . flow "gold" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ANYONE , End . flow "gold" ) )
-          ListItem ( GenStep ( b"aaa" , transact "Bobby" Flip "gold" . kick End Flap 1000 9409 /Rat 1000 970 ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( Exception ( Flip "gold" . kick End Flap 1000 9409 /Rat 1000 970 ) )
-          ListItem ( GenStepFailed ( b"a" , GenEndSkip "gold" ) )
+          .List
         </events>
         <frame-events>
           .List
@@ -774,14 +398,390 @@
       </kmcd-state>
     </kmcd>
     <processed-events>
-      .List
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . rely Pot ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . rely End ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Pot . rely End ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vow . rely Pot ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vow . rely End ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Cat . rely End ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Flap . rely Vow ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Flop . rely Vow ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser Vow ) )
+      ListItem ( Measure ( 0 , Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser Pot ) )
+      ListItem ( Measure ( 0 , Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser Flap ) )
+      ListItem ( Measure ( 0 , Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Pot . file vow-file Vow ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , GemJoin "gold" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . rely GemJoin "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" Flip "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Spot . init "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 1 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Flip "gold" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Flip "gold" . rely End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initGap "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "MKR" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , GemJoin "MKR" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Vow ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Flap ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "MKR" . mint Flap 20 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . file Line 1000000000000 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initIlk "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . file spot "gold" 3000000000 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vow . file bump 1000000000 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Alice" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Bobby" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Alice" 20 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Bobby" 20 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Alice" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Bobby" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Pot . initUser "Alice" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Pot . initUser "Bobby" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser "Alice" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Alice" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Alice" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser "Bobby" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Bobby" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Bobby" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Alice" , Vat . hope Pot ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Alice" , Vat . hope Flip "gold" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Alice" , Vat . hope End ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . hope Pot ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . hope Flip "gold" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . hope End ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Alice" , Vat . slip "gold" "Alice" 10 ) )
+      ListItem ( LogNote ( "Alice" , Gem "gold" . transferFrom "Alice" GemJoin "gold" 10 ) )
+      ListItem ( LogNote ( "Alice" , GemJoin "gold" . join "Alice" 10 ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 10 ) )
+      ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 10 ) )
+      ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 10 ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Alice" , Vat . frob "gold" "Alice" "Alice" "Alice" 10 10 ) )
+      ListItem ( Measure ( 10 , "Alice" |-> 10
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
+      ListItem ( GenStep ( b"aa" , transact "Bobby" GemJoin "gold" . join "Bobby" 97 /Rat 10 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 97 /Rat 10 ) )
+      ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 97 /Rat 10 ) )
+      ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 97 /Rat 10 ) )
+      ListItem ( GenStep ( b"a" , transact ADMIN End . cage ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . cage ) )
+      ListItem ( LogNote ( ADMIN , Cat . cage ) )
+      ListItem ( LogNote ( Vow , Vat . move Flap Vow 0 ) )
+      ListItem ( LogNote ( End , Flap . cage 0 ) )
+      ListItem ( LogNote ( End , Flop . cage ) )
+      ListItem ( LogNote ( End , Vat . heal 0 ) )
+      ListItem ( LogNote ( ADMIN , Vow . cage ) )
+      ListItem ( LogNote ( ADMIN , Pot . cage ) )
+      ListItem ( LogNote ( ADMIN , End . cage ) )
+      ListItem ( GenStep ( b"aa" , transact ANYONE End . cage "gold" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ANYONE , End . cage "gold" ) )
+      ListItem ( GenStep ( b"aa" , TimeStep 2 ) )
+      ListItem ( TimeStep ( 2 , 2 ) )
+      ListItem ( GenStep ( b"a" , transact ANYONE End . thaw ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ANYONE , End . thaw ) )
+      ListItem ( GenStep ( b"aa" , transact ANYONE End . flow "gold" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ANYONE , End . flow "gold" ) )
+      ListItem ( GenStep ( b"aaa" , transact "Bobby" Flip "gold" . kick End Flap 1000 9409 /Rat 1000 970 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( Exception ( Flip "gold" . kick End Flap 1000 9409 /Rat 1000 970 ) )
+      ListItem ( GenStepFailed ( b"a" , GenEndSkip "gold" ) )
     </processed-events>
     <properties>
-      .Map
+      "Pot Interest Accumulation After End" |-> potEndInterestEnd
+      "Unauthorized Flap Kick" |-> unAuthFlapKick
+      "Unauthorized Flip Kick" |-> unAuthFlipKick
+      "Zero-Time Pot Interest Accumulation" |-> zeroTimePotInterestEnd
     </properties>
-    <violation>
-      false
-    </violation>
   </kmcd-properties>
   <kmcd-gen>
     <random>

--- a/tests/attacks/lucash-pot-end.mcd.expected
+++ b/tests/attacks/lucash-pot-end.mcd.expected
@@ -3,129 +3,7 @@
     <kmcd>
       <kmcd-driver>
         <k>
-          checkViolated ( "Total Bound on Debt" ) ~> deriveVFSM ( ListItem ( "Unauthorized Flip Kick" ) , Measure ( 10 , "Alice" |-> 10
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) ) ~> deriveAll ( ListItem ( "Unauthorized Flap Kick" )
-          ListItem ( "Zero-Time Pot Interest Accumulation" )
-          ListItem ( "PotChi PotPie VatPot" )
-          ListItem ( "Pot Interest Accumulation After End" )
-          ListItem ( "Total Bound on Debt" )
-          ListItem ( "Unauthorized Flip Kick" ) , ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . cage ) )
-          ListItem ( LogNote ( ADMIN , Cat . cage ) )
-          ListItem ( LogNote ( Vow , Vat . move Flap Vow 0 ) )
-          ListItem ( LogNote ( End , Flap . cage 0 ) )
-          ListItem ( LogNote ( End , Flop . cage ) )
-          ListItem ( LogNote ( End , Vat . heal 0 ) )
-          ListItem ( LogNote ( ADMIN , Vow . cage ) )
-          ListItem ( LogNote ( ADMIN , Pot . cage ) )
-          ListItem ( LogNote ( ADMIN , End . cage ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . cage "gold" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . grab "gold" "Alice" End Vow -10 -10 ) )
-          ListItem ( LogNote ( ADMIN , End . skim "gold" "Alice" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . grab "gold" "Bobby" End Vow -10 -10 ) )
-          ListItem ( LogNote ( ADMIN , End . skim "gold" "Bobby" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . thaw ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . flow "gold" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Alice" , Vat . move "Alice" Pot 10 ) )
-          ListItem ( LogNote ( "Alice" , Pot . join 10 ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 10
-          Vow |-> 0 , 1 , 10 ) )
-          ListItem ( Exception ( Pot . file dsr 2 ) )
-          ListItem ( TimeStep ( 1 , 1 ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 10
-          Vow |-> 0 , 1 , 10 ) )
-          ListItem ( LogNote ( "Alice" , Vat . suck Vow Pot 0 ) )
-          ListItem ( LogNote ( "Alice" , Pot . drip ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 10
-          Vow |-> 0 , 1 , 10 ) )
-          ListItem ( LogNote ( "Alice" , Vat . move Pot "Alice" 10 ) )
-          ListItem ( LogNote ( "Alice" , Pot . exit 10 ) ) ) ~> .MCDSteps
+          .
         </k>
         <return-value>
           .
@@ -807,11 +685,124 @@
       Flap |-> 0
       Pot |-> 0
       Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . cage ) )
+      ListItem ( LogNote ( ADMIN , Cat . cage ) )
+      ListItem ( LogNote ( Vow , Vat . move Flap Vow 0 ) )
+      ListItem ( LogNote ( End , Flap . cage 0 ) )
+      ListItem ( LogNote ( End , Flop . cage ) )
+      ListItem ( LogNote ( End , Vat . heal 0 ) )
+      ListItem ( LogNote ( ADMIN , Vow . cage ) )
+      ListItem ( LogNote ( ADMIN , Pot . cage ) )
+      ListItem ( LogNote ( ADMIN , End . cage ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . cage "gold" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . grab "gold" "Alice" End Vow -10 -10 ) )
+      ListItem ( LogNote ( ADMIN , End . skim "gold" "Alice" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . grab "gold" "Bobby" End Vow -10 -10 ) )
+      ListItem ( LogNote ( ADMIN , End . skim "gold" "Bobby" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . thaw ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . flow "gold" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Alice" , Vat . move "Alice" Pot 10 ) )
+      ListItem ( LogNote ( "Alice" , Pot . join 10 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 10
+      Vow |-> 0 , 1 , 10 ) )
+      ListItem ( Exception ( Pot . file dsr 2 ) )
+      ListItem ( TimeStep ( 1 , 1 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 10
+      Vow |-> 0 , 1 , 10 ) )
+      ListItem ( LogNote ( "Alice" , Vat . suck Vow Pot 0 ) )
+      ListItem ( LogNote ( "Alice" , Pot . drip ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 10
+      Vow |-> 0 , 1 , 10 ) )
+      ListItem ( LogNote ( "Alice" , Vat . move Pot "Alice" 10 ) )
+      ListItem ( LogNote ( "Alice" , Pot . exit 10 ) )
     </processed-events>
     <properties>
-      "Pot Interest Accumulation After End" |-> potEndInterest
+      "Pot Interest Accumulation After End" |-> potEndInterestEnd
       "PotChi PotPie VatPot" |-> potChiPieDai
-      "Total Bound on Debt" |-> Violated
+      "Total Bound on Debt" |-> totalDebtBoundedEnd ( 20 )
       "Unauthorized Flap Kick" |-> unAuthFlapKick
       "Unauthorized Flip Kick" |-> unAuthFlipKick
       "Zero-Time Pot Interest Accumulation" |-> zeroTimePotInterest

--- a/tests/attacks/lucash-pot-end.mcd.expected
+++ b/tests/attacks/lucash-pot-end.mcd.expected
@@ -796,6 +796,12 @@
         </vow>
       </kmcd-state>
     </kmcd>
+    <processed-events>
+      .List
+    </processed-events>
+    <properties>
+      .Map
+    </properties>
     <violation>
       false
     </violation>

--- a/tests/attacks/lucash-pot-end.mcd.expected
+++ b/tests/attacks/lucash-pot-end.mcd.expected
@@ -3,7 +3,129 @@
     <kmcd>
       <kmcd-driver>
         <k>
-          .
+          checkViolated ( "Total Bound on Debt" ) ~> deriveVFSM ( ListItem ( "Unauthorized Flip Kick" ) , Measure ( 10 , "Alice" |-> 10
+          "Bobby" |-> 0
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) ) ~> deriveAll ( ListItem ( "Unauthorized Flap Kick" )
+          ListItem ( "Zero-Time Pot Interest Accumulation" )
+          ListItem ( "PotChi PotPie VatPot" )
+          ListItem ( "Pot Interest Accumulation After End" )
+          ListItem ( "Total Bound on Debt" )
+          ListItem ( "Unauthorized Flip Kick" ) , ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( ADMIN , Vat . cage ) )
+          ListItem ( LogNote ( ADMIN , Cat . cage ) )
+          ListItem ( LogNote ( Vow , Vat . move Flap Vow 0 ) )
+          ListItem ( LogNote ( End , Flap . cage 0 ) )
+          ListItem ( LogNote ( End , Flop . cage ) )
+          ListItem ( LogNote ( End , Vat . heal 0 ) )
+          ListItem ( LogNote ( ADMIN , Vow . cage ) )
+          ListItem ( LogNote ( ADMIN , Pot . cage ) )
+          ListItem ( LogNote ( ADMIN , End . cage ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( ADMIN , End . cage "gold" ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( ADMIN , Vat . grab "gold" "Alice" End Vow -10 -10 ) )
+          ListItem ( LogNote ( ADMIN , End . skim "gold" "Alice" ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( ADMIN , Vat . grab "gold" "Bobby" End Vow -10 -10 ) )
+          ListItem ( LogNote ( ADMIN , End . skim "gold" "Bobby" ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( ADMIN , End . thaw ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( ADMIN , End . flow "gold" ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( "Alice" , Vat . move "Alice" Pot 10 ) )
+          ListItem ( LogNote ( "Alice" , Pot . join 10 ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 10
+          Vow |-> 0 , 1 , 10 ) )
+          ListItem ( Exception ( Pot . file dsr 2 ) )
+          ListItem ( TimeStep ( 1 , 1 ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 10
+          Vow |-> 0 , 1 , 10 ) )
+          ListItem ( LogNote ( "Alice" , Vat . suck Vow Pot 0 ) )
+          ListItem ( LogNote ( "Alice" , Pot . drip ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 10
+          Vow |-> 0 , 1 , 10 ) )
+          ListItem ( LogNote ( "Alice" , Vat . move Pot "Alice" 10 ) )
+          ListItem ( LogNote ( "Alice" , Pot . exit 10 ) ) ) ~> .MCDSteps
         </k>
         <return-value>
           .
@@ -685,122 +807,11 @@
       Flap |-> 0
       Pot |-> 0
       Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vat . cage ) )
-      ListItem ( LogNote ( ADMIN , Cat . cage ) )
-      ListItem ( LogNote ( Vow , Vat . move Flap Vow 0 ) )
-      ListItem ( LogNote ( End , Flap . cage 0 ) )
-      ListItem ( LogNote ( End , Flop . cage ) )
-      ListItem ( LogNote ( End , Vat . heal 0 ) )
-      ListItem ( LogNote ( ADMIN , Vow . cage ) )
-      ListItem ( LogNote ( ADMIN , Pot . cage ) )
-      ListItem ( LogNote ( ADMIN , End . cage ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( ADMIN , End . cage "gold" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vat . grab "gold" "Alice" End Vow -10 -10 ) )
-      ListItem ( LogNote ( ADMIN , End . skim "gold" "Alice" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vat . grab "gold" "Bobby" End Vow -10 -10 ) )
-      ListItem ( LogNote ( ADMIN , End . skim "gold" "Bobby" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( ADMIN , End . thaw ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( ADMIN , End . flow "gold" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( "Alice" , Vat . move "Alice" Pot 10 ) )
-      ListItem ( LogNote ( "Alice" , Pot . join 10 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 10
-      Vow |-> 0 , 1 , 10 ) )
-      ListItem ( Exception ( Pot . file dsr 2 ) )
-      ListItem ( TimeStep ( 1 , 1 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 10
-      Vow |-> 0 , 1 , 10 ) )
-      ListItem ( LogNote ( "Alice" , Vat . suck Vow Pot 0 ) )
-      ListItem ( LogNote ( "Alice" , Pot . drip ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 10
-      Vow |-> 0 , 1 , 10 ) )
-      ListItem ( LogNote ( "Alice" , Vat . move Pot "Alice" 10 ) )
-      ListItem ( LogNote ( "Alice" , Pot . exit 10 ) )
     </processed-events>
     <properties>
-      "Pot Interest Accumulation After End" |-> potEndInterestEnd
+      "Pot Interest Accumulation After End" |-> potEndInterest
+      "PotChi PotPie VatPot" |-> potChiPieDai
+      "Total Bound on Debt" |-> Violated
       "Unauthorized Flap Kick" |-> unAuthFlapKick
       "Unauthorized Flip Kick" |-> unAuthFlipKick
       "Zero-Time Pot Interest Accumulation" |-> zeroTimePotInterest

--- a/tests/attacks/lucash-pot-end.mcd.expected
+++ b/tests/attacks/lucash-pot-end.mcd.expected
@@ -24,406 +24,7 @@
           .
         </pre-state>
         <events>
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . rely Pot ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . rely End ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Pot . rely End ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vow . rely Pot ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vow . rely End ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Cat . rely End ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Flap . rely Vow ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Flop . rely Vow ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initUser Vow ) )
-          ListItem ( Measure ( 0 , Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initUser Pot ) )
-          ListItem ( Measure ( 0 , Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initUser Flap ) )
-          ListItem ( Measure ( 0 , Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initUser End ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Pot . file vow-file Vow ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "gold" . init ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , GemJoin "gold" . init ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . rely GemJoin "gold" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initGem "gold" End ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initGem "gold" Flip "gold" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" End ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Spot . init "gold" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 1 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Flip "gold" . init ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Flip "gold" . rely End ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initGap "gold" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "MKR" . init ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , GemJoin "MKR" . init ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Vow ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Flap ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "MKR" . mint Flap 20 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . file Line 1000000000000 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initIlk "gold" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . file spot "gold" 3000000000 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vow . file bump 1000000000 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Alice" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Bobby" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Alice" 20 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Bobby" 20 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Alice" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Bobby" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Pot . initUser "Alice" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Pot . initUser "Bobby" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initUser "Alice" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Alice" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Alice" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initUser "Bobby" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Bobby" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Bobby" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Alice" , Vat . hope Pot ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Alice" , Vat . hope Flip "gold" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Alice" , Vat . hope End ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Bobby" , Vat . hope Pot ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Bobby" , Vat . hope Flip "gold" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Bobby" , Vat . hope End ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Alice" , Vat . slip "gold" "Alice" 10 ) )
-          ListItem ( LogNote ( "Alice" , Gem "gold" . transferFrom "Alice" GemJoin "gold" 10 ) )
-          ListItem ( LogNote ( "Alice" , GemJoin "gold" . join "Alice" 10 ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 10 ) )
-          ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 10 ) )
-          ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 10 ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Alice" , Vat . frob "gold" "Alice" "Alice" "Alice" 10 10 ) )
-          ListItem ( Measure ( 10 , "Alice" |-> 10
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . cage ) )
-          ListItem ( LogNote ( ADMIN , Cat . cage ) )
-          ListItem ( LogNote ( Vow , Vat . move Flap Vow 0 ) )
-          ListItem ( LogNote ( End , Flap . cage 0 ) )
-          ListItem ( LogNote ( End , Flop . cage ) )
-          ListItem ( LogNote ( End , Vat . heal 0 ) )
-          ListItem ( LogNote ( ADMIN , Vow . cage ) )
-          ListItem ( LogNote ( ADMIN , Pot . cage ) )
-          ListItem ( LogNote ( ADMIN , End . cage ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . cage "gold" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . grab "gold" "Alice" End Vow -10 -10 ) )
-          ListItem ( LogNote ( ADMIN , End . skim "gold" "Alice" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . grab "gold" "Bobby" End Vow -10 -10 ) )
-          ListItem ( LogNote ( ADMIN , End . skim "gold" "Bobby" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . thaw ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . flow "gold" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Alice" , Vat . move "Alice" Pot 10 ) )
-          ListItem ( LogNote ( "Alice" , Pot . join 10 ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 10
-          Vow |-> 0 , 1 , 10 ) )
-          ListItem ( Exception ( Pot . file dsr 2 ) )
-          ListItem ( TimeStep ( 1 , 1 ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 10
-          Vow |-> 0 , 1 , 10 ) )
-          ListItem ( LogNote ( "Alice" , Vat . suck Vow Pot 0 ) )
-          ListItem ( LogNote ( "Alice" , Pot . drip ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 10
-          Vow |-> 0 , 1 , 10 ) )
-          ListItem ( LogNote ( "Alice" , Vat . move Pot "Alice" 10 ) )
-          ListItem ( LogNote ( "Alice" , Pot . exit 10 ) )
+          .List
         </events>
         <frame-events>
           .List
@@ -797,14 +398,413 @@
       </kmcd-state>
     </kmcd>
     <processed-events>
-      .List
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . rely Pot ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . rely End ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Pot . rely End ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vow . rely Pot ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vow . rely End ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Cat . rely End ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Flap . rely Vow ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Flop . rely Vow ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser Vow ) )
+      ListItem ( Measure ( 0 , Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser Pot ) )
+      ListItem ( Measure ( 0 , Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser Flap ) )
+      ListItem ( Measure ( 0 , Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Pot . file vow-file Vow ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , GemJoin "gold" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . rely GemJoin "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" Flip "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Spot . init "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 1 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Flip "gold" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Flip "gold" . rely End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initGap "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "MKR" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , GemJoin "MKR" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Vow ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Flap ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "MKR" . mint Flap 20 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . file Line 1000000000000 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initIlk "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . file spot "gold" 3000000000 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vow . file bump 1000000000 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Alice" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Bobby" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Alice" 20 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Bobby" 20 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Alice" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Bobby" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Pot . initUser "Alice" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Pot . initUser "Bobby" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser "Alice" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Alice" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Alice" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser "Bobby" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Bobby" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Bobby" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Alice" , Vat . hope Pot ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Alice" , Vat . hope Flip "gold" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Alice" , Vat . hope End ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . hope Pot ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . hope Flip "gold" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . hope End ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Alice" , Vat . slip "gold" "Alice" 10 ) )
+      ListItem ( LogNote ( "Alice" , Gem "gold" . transferFrom "Alice" GemJoin "gold" 10 ) )
+      ListItem ( LogNote ( "Alice" , GemJoin "gold" . join "Alice" 10 ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 10 ) )
+      ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 10 ) )
+      ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 10 ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Alice" , Vat . frob "gold" "Alice" "Alice" "Alice" 10 10 ) )
+      ListItem ( Measure ( 10 , "Alice" |-> 10
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . cage ) )
+      ListItem ( LogNote ( ADMIN , Cat . cage ) )
+      ListItem ( LogNote ( Vow , Vat . move Flap Vow 0 ) )
+      ListItem ( LogNote ( End , Flap . cage 0 ) )
+      ListItem ( LogNote ( End , Flop . cage ) )
+      ListItem ( LogNote ( End , Vat . heal 0 ) )
+      ListItem ( LogNote ( ADMIN , Vow . cage ) )
+      ListItem ( LogNote ( ADMIN , Pot . cage ) )
+      ListItem ( LogNote ( ADMIN , End . cage ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . cage "gold" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . grab "gold" "Alice" End Vow -10 -10 ) )
+      ListItem ( LogNote ( ADMIN , End . skim "gold" "Alice" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . grab "gold" "Bobby" End Vow -10 -10 ) )
+      ListItem ( LogNote ( ADMIN , End . skim "gold" "Bobby" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . thaw ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . flow "gold" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Alice" , Vat . move "Alice" Pot 10 ) )
+      ListItem ( LogNote ( "Alice" , Pot . join 10 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 10
+      Vow |-> 0 , 1 , 10 ) )
+      ListItem ( Exception ( Pot . file dsr 2 ) )
+      ListItem ( TimeStep ( 1 , 1 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 10
+      Vow |-> 0 , 1 , 10 ) )
+      ListItem ( LogNote ( "Alice" , Vat . suck Vow Pot 0 ) )
+      ListItem ( LogNote ( "Alice" , Pot . drip ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 10
+      Vow |-> 0 , 1 , 10 ) )
+      ListItem ( LogNote ( "Alice" , Vat . move Pot "Alice" 10 ) )
+      ListItem ( LogNote ( "Alice" , Pot . exit 10 ) )
     </processed-events>
     <properties>
-      .Map
+      "Pot Interest Accumulation After End" |-> potEndInterestEnd
+      "Unauthorized Flap Kick" |-> unAuthFlapKick
+      "Unauthorized Flip Kick" |-> unAuthFlipKick
+      "Zero-Time Pot Interest Accumulation" |-> zeroTimePotInterest
     </properties>
-    <violation>
-      false
-    </violation>
   </kmcd-properties>
   <kmcd-gen>
     <random>

--- a/tests/attacks/lucash-pot-end.random.mcd.expected
+++ b/tests/attacks/lucash-pot-end.random.mcd.expected
@@ -24,417 +24,7 @@
           .
         </pre-state>
         <events>
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . rely Pot ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . rely End ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Pot . rely End ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vow . rely Pot ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vow . rely End ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Cat . rely End ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Flap . rely Vow ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Flop . rely Vow ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initUser Vow ) )
-          ListItem ( Measure ( 0 , Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initUser Pot ) )
-          ListItem ( Measure ( 0 , Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initUser Flap ) )
-          ListItem ( Measure ( 0 , Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initUser End ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Pot . file vow-file Vow ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "gold" . init ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , GemJoin "gold" . init ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . rely GemJoin "gold" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initGem "gold" End ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initGem "gold" Flip "gold" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" End ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Spot . init "gold" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 1 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Flip "gold" . init ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Flip "gold" . rely End ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initGap "gold" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "MKR" . init ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , GemJoin "MKR" . init ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Vow ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Flap ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "MKR" . mint Flap 20 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . file Line 1000000000000 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initIlk "gold" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . file spot "gold" 3000000000 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vow . file bump 1000000000 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Alice" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Bobby" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Alice" 20 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Bobby" 20 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Alice" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Bobby" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Pot . initUser "Alice" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Pot . initUser "Bobby" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initUser "Alice" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Alice" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Alice" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initUser "Bobby" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Bobby" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Bobby" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Alice" , Vat . hope Pot ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Alice" , Vat . hope Flip "gold" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Alice" , Vat . hope End ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Bobby" , Vat . hope Pot ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Bobby" , Vat . hope Flip "gold" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Bobby" , Vat . hope End ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Alice" , Vat . slip "gold" "Alice" 10 ) )
-          ListItem ( LogNote ( "Alice" , Gem "gold" . transferFrom "Alice" GemJoin "gold" 10 ) )
-          ListItem ( LogNote ( "Alice" , GemJoin "gold" . join "Alice" 10 ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 10 ) )
-          ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 10 ) )
-          ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 10 ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Alice" , Vat . frob "gold" "Alice" "Alice" "Alice" 10 10 ) )
-          ListItem ( Measure ( 10 , "Alice" |-> 10
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
-          ListItem ( GenStep ( b"a" , transact ADMIN End . cage ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . cage ) )
-          ListItem ( LogNote ( ADMIN , Cat . cage ) )
-          ListItem ( LogNote ( Vow , Vat . move Flap Vow 0 ) )
-          ListItem ( LogNote ( End , Flap . cage 0 ) )
-          ListItem ( LogNote ( End , Flop . cage ) )
-          ListItem ( LogNote ( End , Vat . heal 0 ) )
-          ListItem ( LogNote ( ADMIN , Vow . cage ) )
-          ListItem ( LogNote ( ADMIN , Pot . cage ) )
-          ListItem ( LogNote ( ADMIN , End . cage ) )
-          ListItem ( GenStep ( b"aa" , transact ANYONE End . cage "gold" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ANYONE , End . cage "gold" ) )
-          ListItem ( GenStep ( b"a" , transact ANYONE End . skim "gold" "Alice" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ANYONE , Vat . grab "gold" "Alice" End Vow -10 -10 ) )
-          ListItem ( LogNote ( ANYONE , End . skim "gold" "Alice" ) )
-          ListItem ( GenStep ( b"a" , transact ANYONE End . skim "gold" "Bobby" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ANYONE , Vat . grab "gold" "Bobby" End Vow -10 -10 ) )
-          ListItem ( LogNote ( ANYONE , End . skim "gold" "Bobby" ) )
-          ListItem ( GenStep ( b"a" , transact ANYONE End . thaw ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ANYONE , End . thaw ) )
-          ListItem ( GenStep ( b"aa" , transact ANYONE End . flow "gold" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ANYONE , End . flow "gold" ) )
-          ListItem ( GenStep ( b"aa" , transact "Alice" Pot . join 97 /Rat 10 ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Alice" , Vat . move "Alice" Pot 97 /Rat 10 ) )
-          ListItem ( LogNote ( "Alice" , Pot . join 97 /Rat 10 ) )
-          ListItem ( GenStep ( b"aa" , transact ADMIN Pot . file dsr 597 /Rat 500 ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 97 /Rat 10
-          Vow |-> 0 , 1 , 97 /Rat 10 ) )
-          ListItem ( Exception ( Pot . file dsr 597 /Rat 500 ) )
-          ListItem ( GenStep ( b"aa" , TimeStep 2 ) )
-          ListItem ( TimeStep ( 2 , 2 ) )
-          ListItem ( GenStep ( b"a" , transact ANYONE Pot . drip ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 97 /Rat 10
-          Vow |-> 0 , 1 , 97 /Rat 10 ) )
-          ListItem ( LogNote ( ANYONE , Vat . suck Vow Pot 0 ) )
-          ListItem ( LogNote ( ANYONE , Pot . drip ) )
-          ListItem ( GenStep ( b"a" , transact "Alice" Pot . exit 97 /Rat 10 ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 97 /Rat 10
-          Vow |-> 0 , 1 , 97 /Rat 10 ) )
-          ListItem ( LogNote ( "Alice" , Vat . move Pot "Alice" 97 /Rat 10 ) )
-          ListItem ( LogNote ( "Alice" , Pot . exit 97 /Rat 10 ) )
+          .List
         </events>
         <frame-events>
           .List
@@ -808,14 +398,424 @@
       </kmcd-state>
     </kmcd>
     <processed-events>
-      .List
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . rely Pot ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . rely End ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Pot . rely End ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vow . rely Pot ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vow . rely End ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Cat . rely End ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Flap . rely Vow ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Flop . rely Vow ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser Vow ) )
+      ListItem ( Measure ( 0 , Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser Pot ) )
+      ListItem ( Measure ( 0 , Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser Flap ) )
+      ListItem ( Measure ( 0 , Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Pot . file vow-file Vow ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , GemJoin "gold" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . rely GemJoin "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" Flip "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Spot . init "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 1 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Flip "gold" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Flip "gold" . rely End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initGap "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "MKR" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , GemJoin "MKR" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Vow ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Flap ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "MKR" . mint Flap 20 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . file Line 1000000000000 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initIlk "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . file spot "gold" 3000000000 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vow . file bump 1000000000 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Alice" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Bobby" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Alice" 20 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Bobby" 20 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Alice" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Bobby" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Pot . initUser "Alice" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Pot . initUser "Bobby" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser "Alice" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Alice" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Alice" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser "Bobby" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Bobby" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Bobby" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Alice" , Vat . hope Pot ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Alice" , Vat . hope Flip "gold" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Alice" , Vat . hope End ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . hope Pot ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . hope Flip "gold" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . hope End ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Alice" , Vat . slip "gold" "Alice" 10 ) )
+      ListItem ( LogNote ( "Alice" , Gem "gold" . transferFrom "Alice" GemJoin "gold" 10 ) )
+      ListItem ( LogNote ( "Alice" , GemJoin "gold" . join "Alice" 10 ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 10 ) )
+      ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 10 ) )
+      ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 10 ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Alice" , Vat . frob "gold" "Alice" "Alice" "Alice" 10 10 ) )
+      ListItem ( Measure ( 10 , "Alice" |-> 10
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
+      ListItem ( GenStep ( b"a" , transact ADMIN End . cage ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . cage ) )
+      ListItem ( LogNote ( ADMIN , Cat . cage ) )
+      ListItem ( LogNote ( Vow , Vat . move Flap Vow 0 ) )
+      ListItem ( LogNote ( End , Flap . cage 0 ) )
+      ListItem ( LogNote ( End , Flop . cage ) )
+      ListItem ( LogNote ( End , Vat . heal 0 ) )
+      ListItem ( LogNote ( ADMIN , Vow . cage ) )
+      ListItem ( LogNote ( ADMIN , Pot . cage ) )
+      ListItem ( LogNote ( ADMIN , End . cage ) )
+      ListItem ( GenStep ( b"aa" , transact ANYONE End . cage "gold" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ANYONE , End . cage "gold" ) )
+      ListItem ( GenStep ( b"a" , transact ANYONE End . skim "gold" "Alice" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ANYONE , Vat . grab "gold" "Alice" End Vow -10 -10 ) )
+      ListItem ( LogNote ( ANYONE , End . skim "gold" "Alice" ) )
+      ListItem ( GenStep ( b"a" , transact ANYONE End . skim "gold" "Bobby" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ANYONE , Vat . grab "gold" "Bobby" End Vow -10 -10 ) )
+      ListItem ( LogNote ( ANYONE , End . skim "gold" "Bobby" ) )
+      ListItem ( GenStep ( b"a" , transact ANYONE End . thaw ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ANYONE , End . thaw ) )
+      ListItem ( GenStep ( b"aa" , transact ANYONE End . flow "gold" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ANYONE , End . flow "gold" ) )
+      ListItem ( GenStep ( b"aa" , transact "Alice" Pot . join 97 /Rat 10 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Alice" , Vat . move "Alice" Pot 97 /Rat 10 ) )
+      ListItem ( LogNote ( "Alice" , Pot . join 97 /Rat 10 ) )
+      ListItem ( GenStep ( b"aa" , transact ADMIN Pot . file dsr 597 /Rat 500 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 97 /Rat 10
+      Vow |-> 0 , 1 , 97 /Rat 10 ) )
+      ListItem ( Exception ( Pot . file dsr 597 /Rat 500 ) )
+      ListItem ( GenStep ( b"aa" , TimeStep 2 ) )
+      ListItem ( TimeStep ( 2 , 2 ) )
+      ListItem ( GenStep ( b"a" , transact ANYONE Pot . drip ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 97 /Rat 10
+      Vow |-> 0 , 1 , 97 /Rat 10 ) )
+      ListItem ( LogNote ( ANYONE , Vat . suck Vow Pot 0 ) )
+      ListItem ( LogNote ( ANYONE , Pot . drip ) )
+      ListItem ( GenStep ( b"a" , transact "Alice" Pot . exit 97 /Rat 10 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 97 /Rat 10
+      Vow |-> 0 , 1 , 97 /Rat 10 ) )
+      ListItem ( LogNote ( "Alice" , Vat . move Pot "Alice" 97 /Rat 10 ) )
+      ListItem ( LogNote ( "Alice" , Pot . exit 97 /Rat 10 ) )
     </processed-events>
     <properties>
-      .Map
+      "Pot Interest Accumulation After End" |-> potEndInterestEnd
+      "Unauthorized Flap Kick" |-> unAuthFlapKick
+      "Unauthorized Flip Kick" |-> unAuthFlipKick
+      "Zero-Time Pot Interest Accumulation" |-> zeroTimePotInterest
     </properties>
-    <violation>
-      false
-    </violation>
   </kmcd-properties>
   <kmcd-gen>
     <random>

--- a/tests/attacks/lucash-pot-end.random.mcd.expected
+++ b/tests/attacks/lucash-pot-end.random.mcd.expected
@@ -3,7 +3,140 @@
     <kmcd>
       <kmcd-driver>
         <k>
-          .
+          checkViolated ( "Total Bound on Debt" ) ~> deriveVFSM ( ListItem ( "Unauthorized Flip Kick" ) , Measure ( 10 , "Alice" |-> 10
+          "Bobby" |-> 0
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) ) ~> deriveAll ( ListItem ( "Unauthorized Flap Kick" )
+          ListItem ( "Zero-Time Pot Interest Accumulation" )
+          ListItem ( "PotChi PotPie VatPot" )
+          ListItem ( "Pot Interest Accumulation After End" )
+          ListItem ( "Total Bound on Debt" )
+          ListItem ( "Unauthorized Flip Kick" ) , ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
+          ListItem ( GenStep ( b"a" , transact ADMIN End . cage ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( ADMIN , Vat . cage ) )
+          ListItem ( LogNote ( ADMIN , Cat . cage ) )
+          ListItem ( LogNote ( Vow , Vat . move Flap Vow 0 ) )
+          ListItem ( LogNote ( End , Flap . cage 0 ) )
+          ListItem ( LogNote ( End , Flop . cage ) )
+          ListItem ( LogNote ( End , Vat . heal 0 ) )
+          ListItem ( LogNote ( ADMIN , Vow . cage ) )
+          ListItem ( LogNote ( ADMIN , Pot . cage ) )
+          ListItem ( LogNote ( ADMIN , End . cage ) )
+          ListItem ( GenStep ( b"aa" , transact ANYONE End . cage "gold" ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( ANYONE , End . cage "gold" ) )
+          ListItem ( GenStep ( b"a" , transact ANYONE End . skim "gold" "Alice" ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( ANYONE , Vat . grab "gold" "Alice" End Vow -10 -10 ) )
+          ListItem ( LogNote ( ANYONE , End . skim "gold" "Alice" ) )
+          ListItem ( GenStep ( b"a" , transact ANYONE End . skim "gold" "Bobby" ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( ANYONE , Vat . grab "gold" "Bobby" End Vow -10 -10 ) )
+          ListItem ( LogNote ( ANYONE , End . skim "gold" "Bobby" ) )
+          ListItem ( GenStep ( b"a" , transact ANYONE End . thaw ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( ANYONE , End . thaw ) )
+          ListItem ( GenStep ( b"aa" , transact ANYONE End . flow "gold" ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( ANYONE , End . flow "gold" ) )
+          ListItem ( GenStep ( b"aa" , transact "Alice" Pot . join 97 /Rat 10 ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( "Alice" , Vat . move "Alice" Pot 97 /Rat 10 ) )
+          ListItem ( LogNote ( "Alice" , Pot . join 97 /Rat 10 ) )
+          ListItem ( GenStep ( b"aa" , transact ADMIN Pot . file dsr 597 /Rat 500 ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 97 /Rat 10
+          Vow |-> 0 , 1 , 97 /Rat 10 ) )
+          ListItem ( Exception ( Pot . file dsr 597 /Rat 500 ) )
+          ListItem ( GenStep ( b"aa" , TimeStep 2 ) )
+          ListItem ( TimeStep ( 2 , 2 ) )
+          ListItem ( GenStep ( b"a" , transact ANYONE Pot . drip ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 97 /Rat 10
+          Vow |-> 0 , 1 , 97 /Rat 10 ) )
+          ListItem ( LogNote ( ANYONE , Vat . suck Vow Pot 0 ) )
+          ListItem ( LogNote ( ANYONE , Pot . drip ) )
+          ListItem ( GenStep ( b"a" , transact "Alice" Pot . exit 97 /Rat 10 ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 97 /Rat 10
+          Vow |-> 0 , 1 , 97 /Rat 10 ) )
+          ListItem ( LogNote ( "Alice" , Vat . move Pot "Alice" 97 /Rat 10 ) )
+          ListItem ( LogNote ( "Alice" , Pot . exit 97 /Rat 10 ) ) )
         </k>
         <return-value>
           .
@@ -685,133 +818,11 @@
       Flap |-> 0
       Pot |-> 0
       Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
-      ListItem ( GenStep ( b"a" , transact ADMIN End . cage ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vat . cage ) )
-      ListItem ( LogNote ( ADMIN , Cat . cage ) )
-      ListItem ( LogNote ( Vow , Vat . move Flap Vow 0 ) )
-      ListItem ( LogNote ( End , Flap . cage 0 ) )
-      ListItem ( LogNote ( End , Flop . cage ) )
-      ListItem ( LogNote ( End , Vat . heal 0 ) )
-      ListItem ( LogNote ( ADMIN , Vow . cage ) )
-      ListItem ( LogNote ( ADMIN , Pot . cage ) )
-      ListItem ( LogNote ( ADMIN , End . cage ) )
-      ListItem ( GenStep ( b"aa" , transact ANYONE End . cage "gold" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( ANYONE , End . cage "gold" ) )
-      ListItem ( GenStep ( b"a" , transact ANYONE End . skim "gold" "Alice" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( ANYONE , Vat . grab "gold" "Alice" End Vow -10 -10 ) )
-      ListItem ( LogNote ( ANYONE , End . skim "gold" "Alice" ) )
-      ListItem ( GenStep ( b"a" , transact ANYONE End . skim "gold" "Bobby" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( ANYONE , Vat . grab "gold" "Bobby" End Vow -10 -10 ) )
-      ListItem ( LogNote ( ANYONE , End . skim "gold" "Bobby" ) )
-      ListItem ( GenStep ( b"a" , transact ANYONE End . thaw ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( ANYONE , End . thaw ) )
-      ListItem ( GenStep ( b"aa" , transact ANYONE End . flow "gold" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( ANYONE , End . flow "gold" ) )
-      ListItem ( GenStep ( b"aa" , transact "Alice" Pot . join 97 /Rat 10 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( "Alice" , Vat . move "Alice" Pot 97 /Rat 10 ) )
-      ListItem ( LogNote ( "Alice" , Pot . join 97 /Rat 10 ) )
-      ListItem ( GenStep ( b"aa" , transact ADMIN Pot . file dsr 597 /Rat 500 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 97 /Rat 10
-      Vow |-> 0 , 1 , 97 /Rat 10 ) )
-      ListItem ( Exception ( Pot . file dsr 597 /Rat 500 ) )
-      ListItem ( GenStep ( b"aa" , TimeStep 2 ) )
-      ListItem ( TimeStep ( 2 , 2 ) )
-      ListItem ( GenStep ( b"a" , transact ANYONE Pot . drip ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 97 /Rat 10
-      Vow |-> 0 , 1 , 97 /Rat 10 ) )
-      ListItem ( LogNote ( ANYONE , Vat . suck Vow Pot 0 ) )
-      ListItem ( LogNote ( ANYONE , Pot . drip ) )
-      ListItem ( GenStep ( b"a" , transact "Alice" Pot . exit 97 /Rat 10 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 97 /Rat 10
-      Vow |-> 0 , 1 , 97 /Rat 10 ) )
-      ListItem ( LogNote ( "Alice" , Vat . move Pot "Alice" 97 /Rat 10 ) )
-      ListItem ( LogNote ( "Alice" , Pot . exit 97 /Rat 10 ) )
     </processed-events>
     <properties>
-      "Pot Interest Accumulation After End" |-> potEndInterestEnd
+      "Pot Interest Accumulation After End" |-> potEndInterest
+      "PotChi PotPie VatPot" |-> potChiPieDai
+      "Total Bound on Debt" |-> Violated
       "Unauthorized Flap Kick" |-> unAuthFlapKick
       "Unauthorized Flip Kick" |-> unAuthFlipKick
       "Zero-Time Pot Interest Accumulation" |-> zeroTimePotInterest

--- a/tests/attacks/lucash-pot-end.random.mcd.expected
+++ b/tests/attacks/lucash-pot-end.random.mcd.expected
@@ -3,140 +3,7 @@
     <kmcd>
       <kmcd-driver>
         <k>
-          checkViolated ( "Total Bound on Debt" ) ~> deriveVFSM ( ListItem ( "Unauthorized Flip Kick" ) , Measure ( 10 , "Alice" |-> 10
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) ) ~> deriveAll ( ListItem ( "Unauthorized Flap Kick" )
-          ListItem ( "Zero-Time Pot Interest Accumulation" )
-          ListItem ( "PotChi PotPie VatPot" )
-          ListItem ( "Pot Interest Accumulation After End" )
-          ListItem ( "Total Bound on Debt" )
-          ListItem ( "Unauthorized Flip Kick" ) , ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
-          ListItem ( GenStep ( b"a" , transact ADMIN End . cage ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . cage ) )
-          ListItem ( LogNote ( ADMIN , Cat . cage ) )
-          ListItem ( LogNote ( Vow , Vat . move Flap Vow 0 ) )
-          ListItem ( LogNote ( End , Flap . cage 0 ) )
-          ListItem ( LogNote ( End , Flop . cage ) )
-          ListItem ( LogNote ( End , Vat . heal 0 ) )
-          ListItem ( LogNote ( ADMIN , Vow . cage ) )
-          ListItem ( LogNote ( ADMIN , Pot . cage ) )
-          ListItem ( LogNote ( ADMIN , End . cage ) )
-          ListItem ( GenStep ( b"aa" , transact ANYONE End . cage "gold" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ANYONE , End . cage "gold" ) )
-          ListItem ( GenStep ( b"a" , transact ANYONE End . skim "gold" "Alice" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ANYONE , Vat . grab "gold" "Alice" End Vow -10 -10 ) )
-          ListItem ( LogNote ( ANYONE , End . skim "gold" "Alice" ) )
-          ListItem ( GenStep ( b"a" , transact ANYONE End . skim "gold" "Bobby" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ANYONE , Vat . grab "gold" "Bobby" End Vow -10 -10 ) )
-          ListItem ( LogNote ( ANYONE , End . skim "gold" "Bobby" ) )
-          ListItem ( GenStep ( b"a" , transact ANYONE End . thaw ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ANYONE , End . thaw ) )
-          ListItem ( GenStep ( b"aa" , transact ANYONE End . flow "gold" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ANYONE , End . flow "gold" ) )
-          ListItem ( GenStep ( b"aa" , transact "Alice" Pot . join 97 /Rat 10 ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Alice" , Vat . move "Alice" Pot 97 /Rat 10 ) )
-          ListItem ( LogNote ( "Alice" , Pot . join 97 /Rat 10 ) )
-          ListItem ( GenStep ( b"aa" , transact ADMIN Pot . file dsr 597 /Rat 500 ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 97 /Rat 10
-          Vow |-> 0 , 1 , 97 /Rat 10 ) )
-          ListItem ( Exception ( Pot . file dsr 597 /Rat 500 ) )
-          ListItem ( GenStep ( b"aa" , TimeStep 2 ) )
-          ListItem ( TimeStep ( 2 , 2 ) )
-          ListItem ( GenStep ( b"a" , transact ANYONE Pot . drip ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 97 /Rat 10
-          Vow |-> 0 , 1 , 97 /Rat 10 ) )
-          ListItem ( LogNote ( ANYONE , Vat . suck Vow Pot 0 ) )
-          ListItem ( LogNote ( ANYONE , Pot . drip ) )
-          ListItem ( GenStep ( b"a" , transact "Alice" Pot . exit 97 /Rat 10 ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 97 /Rat 10
-          Vow |-> 0 , 1 , 97 /Rat 10 ) )
-          ListItem ( LogNote ( "Alice" , Vat . move Pot "Alice" 97 /Rat 10 ) )
-          ListItem ( LogNote ( "Alice" , Pot . exit 97 /Rat 10 ) ) )
+          .
         </k>
         <return-value>
           .
@@ -818,11 +685,135 @@
       Flap |-> 0
       Pot |-> 0
       Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
+      ListItem ( GenStep ( b"a" , transact ADMIN End . cage ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . cage ) )
+      ListItem ( LogNote ( ADMIN , Cat . cage ) )
+      ListItem ( LogNote ( Vow , Vat . move Flap Vow 0 ) )
+      ListItem ( LogNote ( End , Flap . cage 0 ) )
+      ListItem ( LogNote ( End , Flop . cage ) )
+      ListItem ( LogNote ( End , Vat . heal 0 ) )
+      ListItem ( LogNote ( ADMIN , Vow . cage ) )
+      ListItem ( LogNote ( ADMIN , Pot . cage ) )
+      ListItem ( LogNote ( ADMIN , End . cage ) )
+      ListItem ( GenStep ( b"aa" , transact ANYONE End . cage "gold" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ANYONE , End . cage "gold" ) )
+      ListItem ( GenStep ( b"a" , transact ANYONE End . skim "gold" "Alice" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ANYONE , Vat . grab "gold" "Alice" End Vow -10 -10 ) )
+      ListItem ( LogNote ( ANYONE , End . skim "gold" "Alice" ) )
+      ListItem ( GenStep ( b"a" , transact ANYONE End . skim "gold" "Bobby" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ANYONE , Vat . grab "gold" "Bobby" End Vow -10 -10 ) )
+      ListItem ( LogNote ( ANYONE , End . skim "gold" "Bobby" ) )
+      ListItem ( GenStep ( b"a" , transact ANYONE End . thaw ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ANYONE , End . thaw ) )
+      ListItem ( GenStep ( b"aa" , transact ANYONE End . flow "gold" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ANYONE , End . flow "gold" ) )
+      ListItem ( GenStep ( b"aa" , transact "Alice" Pot . join 97 /Rat 10 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Alice" , Vat . move "Alice" Pot 97 /Rat 10 ) )
+      ListItem ( LogNote ( "Alice" , Pot . join 97 /Rat 10 ) )
+      ListItem ( GenStep ( b"aa" , transact ADMIN Pot . file dsr 597 /Rat 500 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 97 /Rat 10
+      Vow |-> 0 , 1 , 97 /Rat 10 ) )
+      ListItem ( Exception ( Pot . file dsr 597 /Rat 500 ) )
+      ListItem ( GenStep ( b"aa" , TimeStep 2 ) )
+      ListItem ( TimeStep ( 2 , 2 ) )
+      ListItem ( GenStep ( b"a" , transact ANYONE Pot . drip ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 97 /Rat 10
+      Vow |-> 0 , 1 , 97 /Rat 10 ) )
+      ListItem ( LogNote ( ANYONE , Vat . suck Vow Pot 0 ) )
+      ListItem ( LogNote ( ANYONE , Pot . drip ) )
+      ListItem ( GenStep ( b"a" , transact "Alice" Pot . exit 97 /Rat 10 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 97 /Rat 10
+      Vow |-> 0 , 1 , 97 /Rat 10 ) )
+      ListItem ( LogNote ( "Alice" , Vat . move Pot "Alice" 97 /Rat 10 ) )
+      ListItem ( LogNote ( "Alice" , Pot . exit 97 /Rat 10 ) )
     </processed-events>
     <properties>
-      "Pot Interest Accumulation After End" |-> potEndInterest
+      "Pot Interest Accumulation After End" |-> potEndInterestEnd
       "PotChi PotPie VatPot" |-> potChiPieDai
-      "Total Bound on Debt" |-> Violated
+      "Total Bound on Debt" |-> totalDebtBoundedEnd ( 20 )
       "Unauthorized Flap Kick" |-> unAuthFlapKick
       "Unauthorized Flip Kick" |-> unAuthFlipKick
       "Zero-Time Pot Interest Accumulation" |-> zeroTimePotInterest

--- a/tests/attacks/lucash-pot-end.random.mcd.expected
+++ b/tests/attacks/lucash-pot-end.random.mcd.expected
@@ -807,6 +807,12 @@
         </vow>
       </kmcd-state>
     </kmcd>
+    <processed-events>
+      .List
+    </processed-events>
+    <properties>
+      .Map
+    </properties>
     <violation>
       false
     </violation>

--- a/tests/attacks/lucash-pot.mcd.expected
+++ b/tests/attacks/lucash-pot.mcd.expected
@@ -3,7 +3,75 @@
     <kmcd>
       <kmcd-driver>
         <k>
-          .
+          checkViolated ( "Total Bound on Debt" ) ~> deriveVFSM ( ListItem ( "Unauthorized Flip Kick" ) , Measure ( 10 , "Alice" |-> 10
+          "Bobby" |-> 0
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) ) ~> deriveAll ( ListItem ( "Unauthorized Flap Kick" )
+          ListItem ( "Zero-Time Pot Interest Accumulation" )
+          ListItem ( "PotChi PotPie VatPot" )
+          ListItem ( "Pot Interest Accumulation After End" )
+          ListItem ( "Total Bound on Debt" )
+          ListItem ( "Unauthorized Flip Kick" ) , ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( ADMIN , Pot . file dsr 5 ) )
+          ListItem ( TimeStep ( 1 , 1 ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( Exception ( Pot . join 10 ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( "Alice" , Vat . suck Vow Pot 0 ) )
+          ListItem ( LogNote ( "Alice" , Pot . drip ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 5 , 0 ) )
+          ListItem ( Exception ( Vat . move Pot "Alice" 50 ) ) ) ~> .MCDSteps
         </k>
         <return-value>
           .
@@ -685,68 +753,11 @@
       Flap |-> 0
       Pot |-> 0
       Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Pot . file dsr 5 ) )
-      ListItem ( TimeStep ( 1 , 1 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( Exception ( Pot . join 10 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( "Alice" , Vat . suck Vow Pot 0 ) )
-      ListItem ( LogNote ( "Alice" , Pot . drip ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 5 , 0 ) )
-      ListItem ( Exception ( Vat . move Pot "Alice" 50 ) )
     </processed-events>
     <properties>
       "Pot Interest Accumulation After End" |-> potEndInterest
+      "PotChi PotPie VatPot" |-> potChiPieDai
+      "Total Bound on Debt" |-> Violated
       "Unauthorized Flap Kick" |-> unAuthFlapKick
       "Unauthorized Flip Kick" |-> unAuthFlipKick
       "Zero-Time Pot Interest Accumulation" |-> zeroTimePotInterest

--- a/tests/attacks/lucash-pot.mcd.expected
+++ b/tests/attacks/lucash-pot.mcd.expected
@@ -748,7 +748,7 @@
     <properties>
       "Pot Interest Accumulation After End" |-> potEndInterest
       "PotChi PotPie VatPot" |-> potChiPieDai
-      "Total Bound on Debt" |-> totalDebtBounded ( 20 , 5 )
+      "Total Bound on Debt" |-> totalDebtBoundedRun ( 20 , 5 )
       "Unauthorized Flap Kick" |-> unAuthFlapKick
       "Unauthorized Flip Kick" |-> unAuthFlipKick
       "Zero-Time Pot Interest Accumulation" |-> zeroTimePotInterest

--- a/tests/attacks/lucash-pot.mcd.expected
+++ b/tests/attacks/lucash-pot.mcd.expected
@@ -24,352 +24,7 @@
           .
         </pre-state>
         <events>
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . rely Pot ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . rely End ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Pot . rely End ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vow . rely Pot ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vow . rely End ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Cat . rely End ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Flap . rely Vow ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Flop . rely Vow ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initUser Vow ) )
-          ListItem ( Measure ( 0 , Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initUser Pot ) )
-          ListItem ( Measure ( 0 , Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initUser Flap ) )
-          ListItem ( Measure ( 0 , Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initUser End ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Pot . file vow-file Vow ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "gold" . init ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , GemJoin "gold" . init ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . rely GemJoin "gold" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initGem "gold" End ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initGem "gold" Flip "gold" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" End ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Spot . init "gold" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 1 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Flip "gold" . init ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Flip "gold" . rely End ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initGap "gold" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "MKR" . init ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , GemJoin "MKR" . init ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Vow ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Flap ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "MKR" . mint Flap 20 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . file Line 1000000000000 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initIlk "gold" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . file spot "gold" 3000000000 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vow . file bump 1000000000 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Alice" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Bobby" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Alice" 20 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Bobby" 20 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Alice" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Bobby" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Pot . initUser "Alice" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Pot . initUser "Bobby" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initUser "Alice" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Alice" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Alice" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initUser "Bobby" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Bobby" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Bobby" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Alice" , Vat . hope Pot ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Alice" , Vat . hope Flip "gold" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Alice" , Vat . hope End ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Bobby" , Vat . hope Pot ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Bobby" , Vat . hope Flip "gold" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Bobby" , Vat . hope End ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Alice" , Vat . slip "gold" "Alice" 10 ) )
-          ListItem ( LogNote ( "Alice" , Gem "gold" . transferFrom "Alice" GemJoin "gold" 10 ) )
-          ListItem ( LogNote ( "Alice" , GemJoin "gold" . join "Alice" 10 ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 10 ) )
-          ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 10 ) )
-          ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 10 ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Alice" , Vat . frob "gold" "Alice" "Alice" "Alice" 10 10 ) )
-          ListItem ( Measure ( 10 , "Alice" |-> 10
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Pot . file dsr 5 ) )
-          ListItem ( TimeStep ( 1 , 1 ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( Exception ( Pot . join 10 ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Alice" , Vat . suck Vow Pot 0 ) )
-          ListItem ( LogNote ( "Alice" , Pot . drip ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 5 , 0 ) )
-          ListItem ( Exception ( Vat . move Pot "Alice" 50 ) )
+          .List
         </events>
         <frame-events>
           .List
@@ -743,14 +398,359 @@
       </kmcd-state>
     </kmcd>
     <processed-events>
-      .List
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . rely Pot ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . rely End ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Pot . rely End ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vow . rely Pot ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vow . rely End ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Cat . rely End ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Flap . rely Vow ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Flop . rely Vow ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser Vow ) )
+      ListItem ( Measure ( 0 , Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser Pot ) )
+      ListItem ( Measure ( 0 , Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser Flap ) )
+      ListItem ( Measure ( 0 , Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Pot . file vow-file Vow ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , GemJoin "gold" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . rely GemJoin "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" Flip "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Spot . init "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 1 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Flip "gold" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Flip "gold" . rely End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initGap "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "MKR" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , GemJoin "MKR" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Vow ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Flap ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "MKR" . mint Flap 20 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . file Line 1000000000000 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initIlk "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . file spot "gold" 3000000000 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vow . file bump 1000000000 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Alice" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Bobby" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Alice" 20 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Bobby" 20 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Alice" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Bobby" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Pot . initUser "Alice" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Pot . initUser "Bobby" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser "Alice" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Alice" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Alice" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser "Bobby" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Bobby" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Bobby" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Alice" , Vat . hope Pot ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Alice" , Vat . hope Flip "gold" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Alice" , Vat . hope End ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . hope Pot ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . hope Flip "gold" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . hope End ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Alice" , Vat . slip "gold" "Alice" 10 ) )
+      ListItem ( LogNote ( "Alice" , Gem "gold" . transferFrom "Alice" GemJoin "gold" 10 ) )
+      ListItem ( LogNote ( "Alice" , GemJoin "gold" . join "Alice" 10 ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 10 ) )
+      ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 10 ) )
+      ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 10 ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Alice" , Vat . frob "gold" "Alice" "Alice" "Alice" 10 10 ) )
+      ListItem ( Measure ( 10 , "Alice" |-> 10
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Pot . file dsr 5 ) )
+      ListItem ( TimeStep ( 1 , 1 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( Exception ( Pot . join 10 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Alice" , Vat . suck Vow Pot 0 ) )
+      ListItem ( LogNote ( "Alice" , Pot . drip ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 5 , 0 ) )
+      ListItem ( Exception ( Vat . move Pot "Alice" 50 ) )
     </processed-events>
     <properties>
-      .Map
+      "Pot Interest Accumulation After End" |-> potEndInterest
+      "Unauthorized Flap Kick" |-> unAuthFlapKick
+      "Unauthorized Flip Kick" |-> unAuthFlipKick
+      "Zero-Time Pot Interest Accumulation" |-> zeroTimePotInterest
     </properties>
-    <violation>
-      false
-    </violation>
   </kmcd-properties>
   <kmcd-gen>
     <random>

--- a/tests/attacks/lucash-pot.mcd.expected
+++ b/tests/attacks/lucash-pot.mcd.expected
@@ -3,75 +3,7 @@
     <kmcd>
       <kmcd-driver>
         <k>
-          checkViolated ( "Total Bound on Debt" ) ~> deriveVFSM ( ListItem ( "Unauthorized Flip Kick" ) , Measure ( 10 , "Alice" |-> 10
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) ) ~> deriveAll ( ListItem ( "Unauthorized Flap Kick" )
-          ListItem ( "Zero-Time Pot Interest Accumulation" )
-          ListItem ( "PotChi PotPie VatPot" )
-          ListItem ( "Pot Interest Accumulation After End" )
-          ListItem ( "Total Bound on Debt" )
-          ListItem ( "Unauthorized Flip Kick" ) , ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Pot . file dsr 5 ) )
-          ListItem ( TimeStep ( 1 , 1 ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( Exception ( Pot . join 10 ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Alice" , Vat . suck Vow Pot 0 ) )
-          ListItem ( LogNote ( "Alice" , Pot . drip ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 5 , 0 ) )
-          ListItem ( Exception ( Vat . move Pot "Alice" 50 ) ) ) ~> .MCDSteps
+          .
         </k>
         <return-value>
           .
@@ -753,11 +685,70 @@
       Flap |-> 0
       Pot |-> 0
       Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Pot . file dsr 5 ) )
+      ListItem ( TimeStep ( 1 , 1 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( Exception ( Pot . join 10 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Alice" , Vat . suck Vow Pot 0 ) )
+      ListItem ( LogNote ( "Alice" , Pot . drip ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 5 , 0 ) )
+      ListItem ( Exception ( Vat . move Pot "Alice" 50 ) )
     </processed-events>
     <properties>
       "Pot Interest Accumulation After End" |-> potEndInterest
       "PotChi PotPie VatPot" |-> potChiPieDai
-      "Total Bound on Debt" |-> Violated
+      "Total Bound on Debt" |-> totalDebtBounded ( 20 , 5 )
       "Unauthorized Flap Kick" |-> unAuthFlapKick
       "Unauthorized Flip Kick" |-> unAuthFlipKick
       "Zero-Time Pot Interest Accumulation" |-> zeroTimePotInterest

--- a/tests/attacks/lucash-pot.mcd.expected
+++ b/tests/attacks/lucash-pot.mcd.expected
@@ -742,6 +742,12 @@
         </vow>
       </kmcd-state>
     </kmcd>
+    <processed-events>
+      .List
+    </processed-events>
+    <properties>
+      .Map
+    </properties>
     <violation>
       false
     </violation>

--- a/tests/attacks/lucash-pot.random.mcd.expected
+++ b/tests/attacks/lucash-pot.random.mcd.expected
@@ -754,7 +754,7 @@
     <properties>
       "Pot Interest Accumulation After End" |-> potEndInterest
       "PotChi PotPie VatPot" |-> potChiPieDai
-      "Total Bound on Debt" |-> totalDebtBounded ( 20 , 597 /Rat 500 )
+      "Total Bound on Debt" |-> totalDebtBoundedRun ( 20 , 597 /Rat 500 )
       "Unauthorized Flap Kick" |-> unAuthFlapKick
       "Unauthorized Flip Kick" |-> unAuthFlipKick
       "Zero-Time Pot Interest Accumulation" |-> zeroTimePotInterest

--- a/tests/attacks/lucash-pot.random.mcd.expected
+++ b/tests/attacks/lucash-pot.random.mcd.expected
@@ -24,358 +24,7 @@
           .
         </pre-state>
         <events>
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . rely Pot ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . rely End ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Pot . rely End ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vow . rely Pot ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vow . rely End ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Cat . rely End ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Flap . rely Vow ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Flop . rely Vow ) )
-          ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initUser Vow ) )
-          ListItem ( Measure ( 0 , Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initUser Pot ) )
-          ListItem ( Measure ( 0 , Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initUser Flap ) )
-          ListItem ( Measure ( 0 , Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initUser End ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Pot . file vow-file Vow ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "gold" . init ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , GemJoin "gold" . init ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . rely GemJoin "gold" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initGem "gold" End ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initGem "gold" Flip "gold" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" End ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Spot . init "gold" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 1 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Flip "gold" . init ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Flip "gold" . rely End ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initGap "gold" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "MKR" . init ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , GemJoin "MKR" . init ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Vow ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Flap ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "MKR" . mint Flap 20 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . file Line 1000000000000 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initIlk "gold" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . file spot "gold" 3000000000 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vow . file bump 1000000000 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Alice" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Bobby" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Alice" 20 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Bobby" 20 ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Alice" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Bobby" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Pot . initUser "Alice" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Pot . initUser "Bobby" ) )
-          ListItem ( Measure ( 0 , End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initUser "Alice" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Alice" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Alice" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initUser "Bobby" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Bobby" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Bobby" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Alice" , Vat . hope Pot ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Alice" , Vat . hope Flip "gold" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Alice" , Vat . hope End ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Bobby" , Vat . hope Pot ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Bobby" , Vat . hope Flip "gold" ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Bobby" , Vat . hope End ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Alice" , Vat . slip "gold" "Alice" 10 ) )
-          ListItem ( LogNote ( "Alice" , Gem "gold" . transferFrom "Alice" GemJoin "gold" 10 ) )
-          ListItem ( LogNote ( "Alice" , GemJoin "gold" . join "Alice" 10 ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 10 ) )
-          ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 10 ) )
-          ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 10 ) )
-          ListItem ( Measure ( 0 , "Alice" |-> 0
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Alice" , Vat . frob "gold" "Alice" "Alice" "Alice" 10 10 ) )
-          ListItem ( Measure ( 10 , "Alice" |-> 10
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
-          ListItem ( GenStep ( b"aa" , transact ADMIN Pot . file dsr 597 /Rat 500 ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Pot . file dsr 597 /Rat 500 ) )
-          ListItem ( GenStep ( b"aa" , TimeStep 2 ) )
-          ListItem ( TimeStep ( 2 , 2 ) )
-          ListItem ( GenStep ( b"aa" , transact "Alice" Pot . join 97 /Rat 10 ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( Exception ( Pot . join 97 /Rat 10 ) )
-          ListItem ( GenStep ( b"a" , transact ANYONE Pot . drip ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ANYONE , Vat . suck Vow Pot 0 ) )
-          ListItem ( LogNote ( ANYONE , Pot . drip ) )
-          ListItem ( GenStep ( b"a" , transact "Alice" Pot . exit 0 ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 356409 /Rat 250000 , 0 ) )
-          ListItem ( LogNote ( "Alice" , Vat . move Pot "Alice" 0 ) )
-          ListItem ( LogNote ( "Alice" , Pot . exit 0 ) )
+          .List
         </events>
         <frame-events>
           .List
@@ -749,14 +398,365 @@
       </kmcd-state>
     </kmcd>
     <processed-events>
-      .List
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . rely Pot ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . rely End ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Pot . rely End ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vow . rely Pot ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vow . rely End ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Cat . rely End ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Flap . rely Vow ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Flop . rely Vow ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser Vow ) )
+      ListItem ( Measure ( 0 , Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser Pot ) )
+      ListItem ( Measure ( 0 , Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser Flap ) )
+      ListItem ( Measure ( 0 , Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Pot . file vow-file Vow ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , GemJoin "gold" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . rely GemJoin "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" Flip "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Spot . init "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 1 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Flip "gold" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Flip "gold" . rely End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initGap "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "MKR" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , GemJoin "MKR" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Vow ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Flap ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "MKR" . mint Flap 20 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . file Line 1000000000000 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initIlk "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . file spot "gold" 3000000000 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vow . file bump 1000000000 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Alice" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Bobby" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Alice" 20 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Bobby" 20 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Alice" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Bobby" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Pot . initUser "Alice" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Pot . initUser "Bobby" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser "Alice" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Alice" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Alice" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initUser "Bobby" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Bobby" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Bobby" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Alice" , Vat . hope Pot ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Alice" , Vat . hope Flip "gold" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Alice" , Vat . hope End ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . hope Pot ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . hope Flip "gold" ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . hope End ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Alice" , Vat . slip "gold" "Alice" 10 ) )
+      ListItem ( LogNote ( "Alice" , Gem "gold" . transferFrom "Alice" GemJoin "gold" 10 ) )
+      ListItem ( LogNote ( "Alice" , GemJoin "gold" . join "Alice" 10 ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 10 ) )
+      ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 10 ) )
+      ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 10 ) )
+      ListItem ( Measure ( 0 , "Alice" |-> 0
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Alice" , Vat . frob "gold" "Alice" "Alice" "Alice" 10 10 ) )
+      ListItem ( Measure ( 10 , "Alice" |-> 10
+      "Bobby" |-> 0
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
+      ListItem ( GenStep ( b"aa" , transact ADMIN Pot . file dsr 597 /Rat 500 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Pot . file dsr 597 /Rat 500 ) )
+      ListItem ( GenStep ( b"aa" , TimeStep 2 ) )
+      ListItem ( TimeStep ( 2 , 2 ) )
+      ListItem ( GenStep ( b"aa" , transact "Alice" Pot . join 97 /Rat 10 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( Exception ( Pot . join 97 /Rat 10 ) )
+      ListItem ( GenStep ( b"a" , transact ANYONE Pot . drip ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ANYONE , Vat . suck Vow Pot 0 ) )
+      ListItem ( LogNote ( ANYONE , Pot . drip ) )
+      ListItem ( GenStep ( b"a" , transact "Alice" Pot . exit 0 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 356409 /Rat 250000 , 0 ) )
+      ListItem ( LogNote ( "Alice" , Vat . move Pot "Alice" 0 ) )
+      ListItem ( LogNote ( "Alice" , Pot . exit 0 ) )
     </processed-events>
     <properties>
-      .Map
+      "Pot Interest Accumulation After End" |-> potEndInterest
+      "Unauthorized Flap Kick" |-> unAuthFlapKick
+      "Unauthorized Flip Kick" |-> unAuthFlipKick
+      "Zero-Time Pot Interest Accumulation" |-> zeroTimePotInterest
     </properties>
-    <violation>
-      false
-    </violation>
   </kmcd-properties>
   <kmcd-gen>
     <random>

--- a/tests/attacks/lucash-pot.random.mcd.expected
+++ b/tests/attacks/lucash-pot.random.mcd.expected
@@ -748,6 +748,12 @@
         </vow>
       </kmcd-state>
     </kmcd>
+    <processed-events>
+      .List
+    </processed-events>
+    <properties>
+      .Map
+    </properties>
     <violation>
       false
     </violation>

--- a/tests/attacks/lucash-pot.random.mcd.expected
+++ b/tests/attacks/lucash-pot.random.mcd.expected
@@ -3,7 +3,81 @@
     <kmcd>
       <kmcd-driver>
         <k>
-          .
+          checkViolated ( "Total Bound on Debt" ) ~> deriveVFSM ( ListItem ( "Unauthorized Flip Kick" ) , Measure ( 10 , "Alice" |-> 10
+          "Bobby" |-> 0
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) ) ~> deriveAll ( ListItem ( "Unauthorized Flap Kick" )
+          ListItem ( "Zero-Time Pot Interest Accumulation" )
+          ListItem ( "PotChi PotPie VatPot" )
+          ListItem ( "Pot Interest Accumulation After End" )
+          ListItem ( "Total Bound on Debt" )
+          ListItem ( "Unauthorized Flip Kick" ) , ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
+          ListItem ( GenStep ( b"aa" , transact ADMIN Pot . file dsr 597 /Rat 500 ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( ADMIN , Pot . file dsr 597 /Rat 500 ) )
+          ListItem ( GenStep ( b"aa" , TimeStep 2 ) )
+          ListItem ( TimeStep ( 2 , 2 ) )
+          ListItem ( GenStep ( b"aa" , transact "Alice" Pot . join 97 /Rat 10 ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( Exception ( Pot . join 97 /Rat 10 ) )
+          ListItem ( GenStep ( b"a" , transact ANYONE Pot . drip ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 1 , 0 ) )
+          ListItem ( LogNote ( ANYONE , Vat . suck Vow Pot 0 ) )
+          ListItem ( LogNote ( ANYONE , Pot . drip ) )
+          ListItem ( GenStep ( b"a" , transact "Alice" Pot . exit 0 ) )
+          ListItem ( Measure ( 20 , "Alice" |-> 10
+          "Bobby" |-> 10
+          End |-> 0
+          Flap |-> 0
+          Pot |-> 0
+          Vow |-> 0 , 356409 /Rat 250000 , 0 ) )
+          ListItem ( LogNote ( "Alice" , Vat . move Pot "Alice" 0 ) )
+          ListItem ( LogNote ( "Alice" , Pot . exit 0 ) ) )
         </k>
         <return-value>
           .
@@ -685,74 +759,11 @@
       Flap |-> 0
       Pot |-> 0
       Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
-      ListItem ( GenStep ( b"aa" , transact ADMIN Pot . file dsr 597 /Rat 500 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Pot . file dsr 597 /Rat 500 ) )
-      ListItem ( GenStep ( b"aa" , TimeStep 2 ) )
-      ListItem ( TimeStep ( 2 , 2 ) )
-      ListItem ( GenStep ( b"aa" , transact "Alice" Pot . join 97 /Rat 10 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( Exception ( Pot . join 97 /Rat 10 ) )
-      ListItem ( GenStep ( b"a" , transact ANYONE Pot . drip ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 ) )
-      ListItem ( LogNote ( ANYONE , Vat . suck Vow Pot 0 ) )
-      ListItem ( LogNote ( ANYONE , Pot . drip ) )
-      ListItem ( GenStep ( b"a" , transact "Alice" Pot . exit 0 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 356409 /Rat 250000 , 0 ) )
-      ListItem ( LogNote ( "Alice" , Vat . move Pot "Alice" 0 ) )
-      ListItem ( LogNote ( "Alice" , Pot . exit 0 ) )
     </processed-events>
     <properties>
       "Pot Interest Accumulation After End" |-> potEndInterest
+      "PotChi PotPie VatPot" |-> potChiPieDai
+      "Total Bound on Debt" |-> Violated
       "Unauthorized Flap Kick" |-> unAuthFlapKick
       "Unauthorized Flip Kick" |-> unAuthFlipKick
       "Zero-Time Pot Interest Accumulation" |-> zeroTimePotInterest

--- a/tests/attacks/lucash-pot.random.mcd.expected
+++ b/tests/attacks/lucash-pot.random.mcd.expected
@@ -3,81 +3,7 @@
     <kmcd>
       <kmcd-driver>
         <k>
-          checkViolated ( "Total Bound on Debt" ) ~> deriveVFSM ( ListItem ( "Unauthorized Flip Kick" ) , Measure ( 10 , "Alice" |-> 10
-          "Bobby" |-> 0
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) ) ~> deriveAll ( ListItem ( "Unauthorized Flap Kick" )
-          ListItem ( "Zero-Time Pot Interest Accumulation" )
-          ListItem ( "PotChi PotPie VatPot" )
-          ListItem ( "Pot Interest Accumulation After End" )
-          ListItem ( "Total Bound on Debt" )
-          ListItem ( "Unauthorized Flip Kick" ) , ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
-          ListItem ( GenStep ( b"aa" , transact ADMIN Pot . file dsr 597 /Rat 500 ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ADMIN , Pot . file dsr 597 /Rat 500 ) )
-          ListItem ( GenStep ( b"aa" , TimeStep 2 ) )
-          ListItem ( TimeStep ( 2 , 2 ) )
-          ListItem ( GenStep ( b"aa" , transact "Alice" Pot . join 97 /Rat 10 ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( Exception ( Pot . join 97 /Rat 10 ) )
-          ListItem ( GenStep ( b"a" , transact ANYONE Pot . drip ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 1 , 0 ) )
-          ListItem ( LogNote ( ANYONE , Vat . suck Vow Pot 0 ) )
-          ListItem ( LogNote ( ANYONE , Pot . drip ) )
-          ListItem ( GenStep ( b"a" , transact "Alice" Pot . exit 0 ) )
-          ListItem ( Measure ( 20 , "Alice" |-> 10
-          "Bobby" |-> 10
-          End |-> 0
-          Flap |-> 0
-          Pot |-> 0
-          Vow |-> 0 , 356409 /Rat 250000 , 0 ) )
-          ListItem ( LogNote ( "Alice" , Vat . move Pot "Alice" 0 ) )
-          ListItem ( LogNote ( "Alice" , Pot . exit 0 ) ) )
+          .
         </k>
         <return-value>
           .
@@ -759,11 +685,76 @@
       Flap |-> 0
       Pot |-> 0
       Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
+      ListItem ( GenStep ( b"aa" , transact ADMIN Pot . file dsr 597 /Rat 500 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Pot . file dsr 597 /Rat 500 ) )
+      ListItem ( GenStep ( b"aa" , TimeStep 2 ) )
+      ListItem ( TimeStep ( 2 , 2 ) )
+      ListItem ( GenStep ( b"aa" , transact "Alice" Pot . join 97 /Rat 10 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( Exception ( Pot . join 97 /Rat 10 ) )
+      ListItem ( GenStep ( b"a" , transact ANYONE Pot . drip ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 ) )
+      ListItem ( LogNote ( ANYONE , Vat . suck Vow Pot 0 ) )
+      ListItem ( LogNote ( ANYONE , Pot . drip ) )
+      ListItem ( GenStep ( b"a" , transact "Alice" Pot . exit 0 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 356409 /Rat 250000 , 0 ) )
+      ListItem ( LogNote ( "Alice" , Vat . move Pot "Alice" 0 ) )
+      ListItem ( LogNote ( "Alice" , Pot . exit 0 ) )
     </processed-events>
     <properties>
       "Pot Interest Accumulation After End" |-> potEndInterest
       "PotChi PotPie VatPot" |-> potChiPieDai
-      "Total Bound on Debt" |-> Violated
+      "Total Bound on Debt" |-> totalDebtBounded ( 20 , 597 /Rat 500 )
       "Unauthorized Flap Kick" |-> unAuthFlapKick
       "Unauthorized Flip Kick" |-> unAuthFlipKick
       "Zero-Time Pot Interest Accumulation" |-> zeroTimePotInterest


### PR DESCRIPTION
Makes it easier to see why a given trace violates some properties by:

-   Turning properties into `ViolationFSM`s instead of having them just be boolean formulas,
-   Having each property being checked be in its own entry in a `Map` with a given name.