### PR TITLE
Fail early when violation detected

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,10 +44,17 @@ pipeline {
                 '''
               }
             }
-            stage('Python Generator') {
+            stage('Python Generator (Lucash Attacks)') {
               steps {
                 sh '''
                   make test-python-generator
+                '''
+              }
+            }
+            stage('Python Generator') {
+              steps {
+                sh '''
+                  make test-random
                 '''
               }
             }

--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,7 @@ tests/%.mcd.out: tests/%.mcd $(TEST_KOMPILED)
 	RANDOMSEED=$(KMCD_RANDOMSEED) $(KMCD) run --backend $(TEST_BACKEND) $< > $@
 
 tests/%.mcd.python-out: mcd-pyk.py $(TEST_KOMPILED)
-	python3 $< 0 1 $(KMCD_RANDOMSEED) 2>&1 > $@
+	python3 $< random-test 0 1 $(KMCD_RANDOMSEED) 2>&1 > $@
 
 tests/%.mcd.run: tests/%.mcd.out
 	$(CHECK) tests/$*.mcd.out tests/$*.mcd.expected

--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ test-python-generator: $(execution_tests_random:=.python-out)
 init_random_seeds :=
 
 test-random: mcd-pyk.py
-	python3 $< 100 1000 $(init_random_seeds)
+	python3 $< random-test 1 1 $(init_random_seeds)
 
 ### Testing Parameters
 

--- a/README.md
+++ b/README.md
@@ -73,3 +73,21 @@ If you want to run all the attack tests (and check their output), run:
 ```sh
 make test-execution -j4
 ```
+
+Running Random Tester
+---------------------
+
+Make sure that `pyk` library is on `PYTHONPATH`, and `krun` is on `PATH`:
+
+```sh
+export PYTHONPATH=./deps/k/k-distribution/target/release/k/lib
+export PATH=./deps/k/k-distribution/target/release/k/bin:$PATH
+```
+
+Then you can start the random tester running, with depth 100, up to 3000 times:
+
+```sh
+./mcd-pyk.py random-test 100 3000 &> random-test.out
+```
+
+Then you can watch `random-test.out` for assertion violations it finds.

--- a/kmcd-driver.md
+++ b/kmcd-driver.md
@@ -90,7 +90,7 @@ Use `transact ...` for initiating top-level calls from a given user.
 ```k
     syntax AdminStep ::= "transact" Address MCDStep
  // -----------------------------------------------
-    rule <k> transact ADDR:Address MCD:MCDStep => measure ~> pushState ~> call MCD ~> dropState ... </k>
+    rule <k> transact ADDR:Address MCD:MCDStep => pushState ~> call MCD ~> assert ~> dropState ... </k>
          <this> _ => ADDR </this>
          <msg-sender> _ => ADDR </msg-sender>
          <call-stack> _ => .List </call-stack>
@@ -98,8 +98,8 @@ Use `transact ...` for initiating top-level calls from a given user.
          <frame-events> _ => .List </frame-events>
          <return-value> _ => .K </return-value>
 
-    syntax AdminStep ::= "pushState" | "dropState" | "popState" | "measure"
- // -----------------------------------------------------------------------
+    syntax AdminStep ::= "pushState" | "dropState" | "popState" | "assert"
+ // ----------------------------------------------------------------------
 ```
 
 Function Calls
@@ -145,12 +145,14 @@ On `exception`, the entire current call is discarded to trigger state roll-back 
     rule <k> exception E ~> _ => exception E ~> CONT </k>
          <msg-sender> MSGSENDER => PREVSENDER </msg-sender>
          <this> THIS => MSGSENDER </this>
-         <call-stack> ListItem(frame(PREVSENDER, PREVEVENTS, CONT)) => .List ...</call-stack>
+         <call-stack> ListItem(frame(PREVSENDER, PREVEVENTS, CONT)) => .List ... </call-stack>
          <frame-events> _ => PREVEVENTS </frame-events>
 
     rule <k> exception MCDSTEP ~> dropState => popState ... </k>
          <call-stack> .List </call-stack>
          <events> ... (.List => ListItem(Exception(MCDSTEP))) </events>
+
+    rule <k> exception _ ~> (assert => .) ... </k>
 ```
 
 Log Events

--- a/kmcd-driver.md
+++ b/kmcd-driver.md
@@ -215,7 +215,7 @@ We simulate that here.
  // ---------------------------------
     rule <k> TimeStep => TimeStep 1 ... </k>
 
-    rule <k> TimeStep N => . ... </k>
+    rule <k> TimeStep N => assert ... </k>
          <current-time> TIME => TIME +Int N </current-time>
          <events> ... (.List => ListItem(TimeStep(N, TIME +Int N))) </events>
       requires N >Int 0

--- a/kmcd-prelude.md
+++ b/kmcd-prelude.md
@@ -158,12 +158,12 @@ module KMCD-RANDOM-CHOICES
 ```k
     syntax Int ::= randIntBounded ( Int , Int ) [function]
  // ------------------------------------------------------
-    rule randIntBounded(RAND, 0)     => 0
-    rule randIntBounded(RAND, BOUND) => RAND modInt (BOUND +Int 1) requires BOUND =/=Int 0
+    rule randIntBounded(RAND, BOUND) => 0                          requires         BOUND <Int 0
+    rule randIntBounded(RAND, BOUND) => RAND modInt (BOUND +Int 1) requires notBool BOUND <Int 0
 
     syntax Rat ::= randRat ( Int ) [function]
  // -----------------------------------------
-    rule randRat(I) => (I modInt 101) /Rat 100
+    rule randRat(I) => I /Rat 256
 
     syntax Rat ::= randRatBounded ( Int , Rat ) [function]
  // ------------------------------------------------------

--- a/kmcd-prelude.md
+++ b/kmcd-prelude.md
@@ -150,78 +150,42 @@ endmodule
 Random Choices
 --------------
 
-**TODO**: Currently the Haskell backend doesn't support ?VAR variables.
-          For now, we don't give the implementations of these choice functions for the Haskell backend, which gives to broad of semantics.
-          The functions do implement "choice", but completely arbitrary choice in the relevant sorts, instead of bounded choices.
-
 ```k
 module KMCD-RANDOM-CHOICES
     imports KMCD-PRELUDE
+```
 
+```k
     syntax Int ::= randIntBounded ( Int , Int ) [function]
  // ------------------------------------------------------
-```
-
-```{.k .concrete}
     rule randIntBounded(RAND, 0)     => 0
     rule randIntBounded(RAND, BOUND) => RAND modInt (BOUND +Int 1) requires BOUND =/=Int 0
-```
 
-```
-    rule randIntBounded(_, BOUND) => ?I:Int ensures 0 <=Int ?I andBool ?I <=Int BOUND
-```
-
-```k
     syntax Rat ::= randRat ( Int ) [function]
  // -----------------------------------------
-```
-
-```{.k .concrete}
     rule randRat(I) => (I modInt 101) /Rat 100
-```
 
-```
-    rule randRat(_) => ?R:Rat ensures 0 <=Rat ?R andBool ?R <=Rat 100
-```
-
-```k
     syntax Rat ::= randRatBounded ( Int , Rat ) [function]
  // ------------------------------------------------------
-```
-
-```{.k .concrete}
     rule randRatBounded(I, BOUND) => BOUND *Rat randRat(I)
-```
 
-```
-    rule randRatBounded(_, BOUND) => ?R:Rat ensures 0 <=Rat ?R andBool ?R <=Rat BOUND
-```
-
-```k
     syntax Int     ::= chooseInt     ( Int , List ) [function]
     syntax String  ::= chooseString  ( Int , List ) [function]
     syntax Address ::= chooseAddress ( Int , List ) [function]
     syntax CDPID   ::= chooseCDPID   ( Int , List ) [function]
  // ----------------------------------------------------------
-```
-
-```{.k .concrete}
     rule chooseInt    (I, ITEMS) => { ITEMS [ I modInt size(ITEMS) ] }:>Int
     rule chooseString (I, ITEMS) => { ITEMS [ I modInt size(ITEMS) ] }:>String
     rule chooseAddress(I, ITEMS) => { ITEMS [ I modInt size(ITEMS) ] }:>Address
     rule chooseCDPID  (I, ITEMS) => { ITEMS [ I modInt size(ITEMS) ] }:>CDPID
 ```
 
-```
-    rule chooseInt    (_, ITEMS) => ?I:Int     ensures ?I in ITEMS
-    rule chooseString (_, ITEMS) => ?S:String  ensures ?S in ITEMS
-    rule chooseAddress(_, ITEMS) => ?A:Address ensures ?A in ITEMS
-    rule chooseCDPID  (_, ITEMS) => ?C:CDPID   ensures ?C in ITEMS
-```
-
 ```k
 endmodule
 ```
+
+Random Sequence Generation
+--------------------------
 
 ```k
 module KMCD-GEN

--- a/kmcd-props.md
+++ b/kmcd-props.md
@@ -25,7 +25,7 @@ Measurables
     syntax Measure ::= Measure () [function]
                      | Measure ( debt: Rat , controlDai: Map , potChi: Rat , potPie: Rat , sumOfScaledArts: Rat, vice: Rat, endDebt: Rat )
  // --------------------------------------------------------------------------------------------------------------------------------------
-    rule [[ Measure => Measure(... debt: DEBT, controlDai: controlDais(keys_list(VAT_DAIS)), potChi: POT_CHI, potPie: POT_PIE, sumOfScaledArts: calcSumOfScaledArts(VAT_ILKS, VAT_URNS), vice: VAT_VICE, endDebt: END_DEBT) ]]
+    rule [[ Measure() => Measure(... debt: DEBT, controlDai: controlDais(keys_list(VAT_DAIS)), potChi: POT_CHI, potPie: POT_PIE, sumOfScaledArts: calcSumOfScaledArts(VAT_ILKS, VAT_URNS), vice: VAT_VICE, endDebt: END_DEBT) ]]
          <vat-debt> DEBT     </vat-debt>
          <vat-dai>  VAT_DAIS </vat-dai>
          <vat-ilks> VAT_ILKS </vat-ilks>

--- a/kmcd-props.md
+++ b/kmcd-props.md
@@ -21,17 +21,18 @@ Measurables
 ### Measure Event
 
 ```k
-    syntax Event ::= Measure ( debt: Rat , controlDai: Map , potChi: Rat , potPie: Rat , sumOfScaledArts: Rat, vice: Rat, endDebt: Rat )
- // ------------------------------------------------------------------------------------------------------------------------------------
-    rule <k> measure => . ... </k>
-         <events> ... (.List => ListItem(Measure(... debt: DEBT, controlDai: controlDais(keys_list(VAT_DAIS)), potChi: POT_CHI, potPie: POT_PIE, sumOfScaledArts: calcSumOfScaledArts(VAT_ILKS, VAT_URNS), vice: VAT_VICE, endDebt: END_DEBT))) </events>
-         <vat-debt> DEBT </vat-debt>
-         <vat-dai> VAT_DAIS </vat-dai>
+    syntax Event ::= Measure
+    syntax Measure ::= Measure () [function]
+                     | Measure ( debt: Rat , controlDai: Map , potChi: Rat , potPie: Rat , sumOfScaledArts: Rat, vice: Rat, endDebt: Rat )
+ // --------------------------------------------------------------------------------------------------------------------------------------
+    rule [[ Measure => Measure(... debt: DEBT, controlDai: controlDais(keys_list(VAT_DAIS)), potChi: POT_CHI, potPie: POT_PIE, sumOfScaledArts: calcSumOfScaledArts(VAT_ILKS, VAT_URNS), vice: VAT_VICE, endDebt: END_DEBT) ]]
+         <vat-debt> DEBT     </vat-debt>
+         <vat-dai>  VAT_DAIS </vat-dai>
          <vat-ilks> VAT_ILKS </vat-ilks>
          <vat-urns> VAT_URNS </vat-urns>
          <vat-vice> VAT_VICE </vat-vice>
-         <pot-chi> POT_CHI </pot-chi>
-         <pot-pie> POT_PIE </pot-pie>
+         <pot-chi>  POT_CHI  </pot-chi>
+         <pot-pie>  POT_PIE  </pot-pie>
          <end-debt> END_DEBT </end-debt>
 ```
 
@@ -170,9 +171,9 @@ A violation can be checked using the Admin step `assert`. If a violation is dete
 it is recorded in the state and execution is immediately terminated.
 
 ```k
-    syntax AdminStep ::= "assert" | "#assert"
- // -----------------------------------------
-    rule <k> assert => deriveAll(keys_list(VFSMS), EVENTS) ~> #assert ... </k>
+    syntax AdminStep ::= "#assert"
+ // ------------------------------
+    rule <k> assert => deriveAll(keys_list(VFSMS), EVENTS ListItem(Measure())) ~> #assert ... </k>
          <events> EVENTS => .List </events>
          <properties> VFSMS </properties>
 

--- a/mcd-pyk.py
+++ b/mcd-pyk.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import argparse
 import difflib
 import json
 import random
@@ -240,13 +241,24 @@ generator_lucash_flap_end = generatorSequence( [ KConstant('GenVatMove_KMCD-GEN_
                                                ]
                                              )
 
-if __name__ == '__main__':
-    gendepth = int(sys.argv[1])
-    numruns  = int(sys.argv[2])
+mcdArgs = argparse.ArgumentParser()
 
-    randseeds = [""]
-    if len(sys.argv) > 3:
-        randseeds = sys.argv[3:]
+mcdCommands = mcdArgs.add_subparsers()
+
+mcdRandomTestArgs = mcdCommands.add_parser('random-test', help = 'Run random tester and check for property violations.')
+mcdRandomTestArgs.add_argument( 'depth'     , type = int ,               help = 'Number of bytes to feed as random input into each run' )
+mcdRandomTestArgs.add_argument( 'numRuns'   , type = int ,               help = 'Number of runs per random seed.'                       )
+mcdRandomTestArgs.add_argument( 'initSeeds' , type = str , nargs = '*' , help = 'Random seeds to use as run prefixes.'                  )
+
+if __name__ == '__main__':
+    args = vars(mcdArgs.parse_args())
+
+    gendepth  = args['depth']
+    numruns   = args['numRuns']
+    randseeds = args['initSeeds']
+
+    if len(randseeds) == 0:
+        randseeds = [""]
 
     config_loader = mcdSteps( [ steps(KConstant('ATTACK-PRELUDE'))
                               , addGenerator(generator_lucash_pot_end)

--- a/mcd-pyk.py
+++ b/mcd-pyk.py
@@ -271,8 +271,8 @@ if __name__ == '__main__':
     (symbolic_configuration, init_cells) = get_init_config(config_loader)
     print()
 
-    startTime = time.time()
     all_violations = []
+    startTime = time.time()
     for randseed in randseeds:
         for i in range(numruns):
             curRandSeed = bytearray(randseed, 'utf-8') + randombytes(gendepth)
@@ -285,7 +285,12 @@ if __name__ == '__main__':
             print()
             violations = detect_violations(output)
             if len(violations) > 0:
-                all_violations.append({ 'properties': violations , 'seed': str(curRandSeed), 'output': output })
+                violation = { 'properties': violations , 'seed': str(curRandSeed), 'output': output }
+                all_violations.append(violation)
+                print('\n### Violation Found!')
+                print('    Seed: ' + violation['seed'])
+                print('    Properties: ' + '\n              , '.join(violation['properties']))
+                print(pyk.prettyPrintKast(violation['output'], MCD_definition_llvm_symbols))
     stopTime = time.time()
 
     elapsedTime = stopTime - startTime
@@ -293,12 +298,5 @@ if __name__ == '__main__':
     print('\n\nTime Elapsed: ' + str(elapsedTime))
     print('\nTime Per Run: ' + str(perRunTime))
 
-    if len(all_violations) > 0:
-        print('\nViolations Found!')
-        print('=================')
-        for violation in all_violations:
-            print('\nViolation:')
-            print('    Seed: ' + violation['seed'])
-            print('    Properties: ' + '\n              , '.join(violation['properties']))
     sys.stdout.flush()
     sys.exit(len(all_violations))

--- a/tests/attacks/lucash-flap-end.mcd.expected
+++ b/tests/attacks/lucash-flap-end.mcd.expected
@@ -399,7 +399,6 @@
       </kmcd-state>
     </kmcd>
     <processed-events>
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . rely Pot ) )
       ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . rely End ) )
@@ -745,12 +744,6 @@
       Pot |-> 0
       Vow |-> 1 , 1 , 0 , 20 , 0 , 0 ) )
       ListItem ( Exception ( Flap . kick 1 20 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 9
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 1 , 1 , 0 , 20 , 0 , 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . cage ) )
       ListItem ( LogNote ( ADMIN , Cat . cage ) )
       ListItem ( LogNote ( Vow , Vat . move Flap Vow 0 ) )
@@ -767,6 +760,12 @@
       Pot |-> 0
       Vow |-> 1 , 1 , 0 , 20 , 0 , 0 ) )
       ListItem ( Exception ( Flap . yank 1 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 9
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 1 , 1 , 0 , 20 , 0 , 0 ) )
     </processed-events>
     <properties>
       "Debt Constant After Thaw" |-> debtConstantAfterThaw

--- a/tests/attacks/lucash-flap-end.random.mcd.expected
+++ b/tests/attacks/lucash-flap-end.random.mcd.expected
@@ -208,8 +208,8 @@
             </gem-wards>
             <gem-balances>
               "Alice" |-> 10
-              "Bobby" |-> 49 /Rat 10
-              GemJoin "gold" |-> 251 /Rat 10
+              "Bobby" |-> 1025 /Rat 128
+              GemJoin "gold" |-> 2815 /Rat 128
             </gem-balances>
           </gem>
         </gems>
@@ -330,17 +330,17 @@
           </vat-urns>
           <vat-gem>
             { "gold" , "Alice" } |-> 0
-            { "gold" , "Bobby" } |-> 51 /Rat 10
+            { "gold" , "Bobby" } |-> 255 /Rat 128
             { "gold" , End } |-> 0
             { "gold" , Flip "gold" } |-> 0
           </vat-gem>
           <vat-dai>
-            "Alice" |-> 26 /Rat 5
+            "Alice" |-> 65 /Rat 8
             "Bobby" |-> 10
             End |-> 0
             Flap |-> 0
             Pot |-> 0
-            Vow |-> 24 /Rat 5
+            Vow |-> 15 /Rat 8
           </vat-dai>
           <vat-sin>
             "Alice" |-> 0
@@ -399,7 +399,6 @@
       </kmcd-state>
     </kmcd>
     <processed-events>
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . rely Pot ) )
       ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . rely End ) )
@@ -715,47 +714,41 @@
       Pot |-> 0
       Vow |-> 0 , 1 , 0 , 20 , 0 , 0 ) )
       ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
-      ListItem ( GenStep ( b"b0" , transact "Alice" Vat . move "Alice" Vow 24 /Rat 5 ) )
       ListItem ( Measure ( 20 , "Alice" |-> 10
       "Bobby" |-> 10
       End |-> 0
       Flap |-> 0
       Pot |-> 0
       Vow |-> 0 , 1 , 0 , 20 , 0 , 0 ) )
-      ListItem ( LogNote ( "Alice" , Vat . move "Alice" Vow 24 /Rat 5 ) )
-      ListItem ( GenStep ( b"b3" , transact "Bobby" GemJoin "gold" . join "Bobby" 51 /Rat 10 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 26 /Rat 5
+      ListItem ( GenStep ( b"b0" , transact "Alice" Vat . move "Alice" Vow 15 /Rat 8 ) )
+      ListItem ( LogNote ( "Alice" , Vat . move "Alice" Vow 15 /Rat 8 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 65 /Rat 8
       "Bobby" |-> 10
       End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 24 /Rat 5 , 1 , 0 , 20 , 0 , 0 ) )
-      ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 51 /Rat 10 ) )
-      ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 51 /Rat 10 ) )
-      ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 51 /Rat 10 ) )
+      Vow |-> 15 /Rat 8 , 1 , 0 , 20 , 0 , 0 ) )
+      ListItem ( GenStep ( b"b3" , transact "Bobby" GemJoin "gold" . join "Bobby" 255 /Rat 128 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 255 /Rat 128 ) )
+      ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 255 /Rat 128 ) )
+      ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 255 /Rat 128 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 65 /Rat 8
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 15 /Rat 8 , 1 , 0 , 20 , 0 , 0 ) )
       ListItem ( GenStep ( b"b" , transact "Alice" Vat . hope Flap ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 26 /Rat 5
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 24 /Rat 5 , 1 , 0 , 20 , 0 , 0 ) )
       ListItem ( LogNote ( "Alice" , Vat . hope Flap ) )
-      ListItem ( GenStep ( b"b0Z" , transact "Alice" Flap . kick 312 /Rat 125 18 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 26 /Rat 5
+      ListItem ( Measure ( 20 , "Alice" |-> 65 /Rat 8
       "Bobby" |-> 10
       End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 24 /Rat 5 , 1 , 0 , 20 , 0 , 0 ) )
-      ListItem ( Exception ( Flap . kick 312 /Rat 125 18 ) )
+      Vow |-> 15 /Rat 8 , 1 , 0 , 20 , 0 , 0 ) )
+      ListItem ( GenStep ( b"b0Z" , transact "Alice" Flap . kick 195 /Rat 128 225 /Rat 32 ) )
+      ListItem ( Exception ( Flap . kick 195 /Rat 128 225 /Rat 32 ) )
       ListItem ( GenStep ( b"b" , transact ADMIN End . cage ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 26 /Rat 5
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 24 /Rat 5 , 1 , 0 , 20 , 0 , 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . cage ) )
       ListItem ( LogNote ( ADMIN , Cat . cage ) )
       ListItem ( LogNote ( Vow , Vat . move Flap Vow 0 ) )
@@ -765,7 +758,19 @@
       ListItem ( LogNote ( ADMIN , Vow . cage ) )
       ListItem ( LogNote ( ADMIN , Pot . cage ) )
       ListItem ( LogNote ( ADMIN , End . cage ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 65 /Rat 8
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 15 /Rat 8 , 1 , 0 , 20 , 0 , 0 ) )
       ListItem ( GenStepFailed ( b"b" , GenFlapYank ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 65 /Rat 8
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 15 /Rat 8 , 1 , 0 , 20 , 0 , 0 ) )
     </processed-events>
     <properties>
       "Debt Constant After Thaw" |-> debtConstantAfterThaw

--- a/tests/attacks/lucash-flip-end.mcd.expected
+++ b/tests/attacks/lucash-flip-end.mcd.expected
@@ -398,7 +398,6 @@
       </kmcd-state>
     </kmcd>
     <processed-events>
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . rely Pot ) )
       ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . rely End ) )
@@ -745,6 +744,12 @@
       Pot |-> 0
       Vow |-> 0 , 1 , 0 , 20 , 0 , 0 ) )
       ListItem ( LogNote ( ADMIN , End . cage "gold" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 ) )
       ListItem ( TimeStep ( 3600 , 3600 ) )
       ListItem ( Measure ( 20 , "Alice" |-> 10
       "Bobby" |-> 10
@@ -767,13 +772,13 @@
       Pot |-> 0
       Vow |-> 0 , 1 , 0 , 20 , 0 , 20 ) )
       ListItem ( Exception ( Flip "gold" . kick End "Bobby" 1001000000000 1 1000000000000 ) )
+      ListItem ( Exception ( End . skip "gold" 1 ) )
       ListItem ( Measure ( 20 , "Alice" |-> 10
       "Bobby" |-> 10
       End |-> 0
       Flap |-> 0
       Pot |-> 0
       Vow |-> 0 , 1 , 0 , 20 , 0 , 20 ) )
-      ListItem ( Exception ( End . skip "gold" 1 ) )
     </processed-events>
     <properties>
       "Debt Constant After Thaw" |-> debtConstantAfterThaw

--- a/tests/attacks/lucash-flip-end.random.mcd.expected
+++ b/tests/attacks/lucash-flip-end.random.mcd.expected
@@ -208,8 +208,8 @@
             </gem-wards>
             <gem-balances>
               "Alice" |-> 10
-              "Bobby" |-> 3 /Rat 10
-              GemJoin "gold" |-> 297 /Rat 10
+              "Bobby" |-> 795 /Rat 128
+              GemJoin "gold" |-> 3045 /Rat 128
             </gem-balances>
           </gem>
         </gems>
@@ -329,7 +329,7 @@
           </vat-urns>
           <vat-gem>
             { "gold" , "Alice" } |-> 0
-            { "gold" , "Bobby" } |-> 97 /Rat 10
+            { "gold" , "Bobby" } |-> 485 /Rat 128
             { "gold" , End } |-> 0
             { "gold" , Flip "gold" } |-> 0
           </vat-gem>
@@ -398,7 +398,6 @@
       </kmcd-state>
     </kmcd>
     <processed-events>
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . rely Pot ) )
       ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . rely End ) )
@@ -714,23 +713,23 @@
       Pot |-> 0
       Vow |-> 0 , 1 , 0 , 20 , 0 , 0 ) )
       ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
-      ListItem ( GenStep ( b"ca" , transact "Bobby" GemJoin "gold" . join "Bobby" 97 /Rat 10 ) )
       ListItem ( Measure ( 20 , "Alice" |-> 10
       "Bobby" |-> 10
       End |-> 0
       Flap |-> 0
       Pot |-> 0
       Vow |-> 0 , 1 , 0 , 20 , 0 , 0 ) )
-      ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 97 /Rat 10 ) )
-      ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 97 /Rat 10 ) )
-      ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 97 /Rat 10 ) )
+      ListItem ( GenStep ( b"ca" , transact "Bobby" GemJoin "gold" . join "Bobby" 485 /Rat 128 ) )
+      ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 485 /Rat 128 ) )
+      ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 485 /Rat 128 ) )
+      ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 485 /Rat 128 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 ) )
       ListItem ( GenStep ( b"c" , transact ADMIN End . cage ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . cage ) )
       ListItem ( LogNote ( ADMIN , Cat . cage ) )
       ListItem ( LogNote ( Vow , Vat . move Flap Vow 0 ) )
@@ -740,41 +739,53 @@
       ListItem ( LogNote ( ADMIN , Vow . cage ) )
       ListItem ( LogNote ( ADMIN , Pot . cage ) )
       ListItem ( LogNote ( ADMIN , End . cage ) )
-      ListItem ( GenStep ( b"ca" , transact ANYONE End . cage "gold" ) )
       ListItem ( Measure ( 20 , "Alice" |-> 10
       "Bobby" |-> 10
       End |-> 0
       Flap |-> 0
       Pot |-> 0
       Vow |-> 0 , 1 , 0 , 20 , 0 , 0 ) )
+      ListItem ( GenStep ( b"ca" , transact ANYONE End . cage "gold" ) )
       ListItem ( LogNote ( ANYONE , End . cage "gold" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 ) )
       ListItem ( GenStep ( b"ca" , TimeStep 2 ) )
       ListItem ( TimeStep ( 2 , 2 ) )
-      ListItem ( GenStep ( b"c" , transact ANYONE End . thaw ) )
       ListItem ( Measure ( 20 , "Alice" |-> 10
       "Bobby" |-> 10
       End |-> 0
       Flap |-> 0
       Pot |-> 0
       Vow |-> 0 , 1 , 0 , 20 , 0 , 0 ) )
+      ListItem ( GenStep ( b"c" , transact ANYONE End . thaw ) )
       ListItem ( LogNote ( ANYONE , End . thaw ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 20 , 0 , 20 ) )
       ListItem ( GenStep ( b"ca" , transact ANYONE End . flow "gold" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 20 ) )
       ListItem ( LogNote ( ANYONE , End . flow "gold" ) )
-      ListItem ( GenStep ( b"caa" , transact "Bobby" Flip "gold" . kick End Flap 1000 9409 /Rat 1000 970 ) )
       ListItem ( Measure ( 20 , "Alice" |-> 10
       "Bobby" |-> 10
       End |-> 0
       Flap |-> 0
       Pot |-> 0
       Vow |-> 0 , 1 , 0 , 20 , 0 , 20 ) )
-      ListItem ( Exception ( Flip "gold" . kick End Flap 1000 9409 /Rat 1000 970 ) )
+      ListItem ( GenStep ( b"caa" , transact "Bobby" Flip "gold" . kick End Flap 1000 47045 /Rat 32768 12125 /Rat 32 ) )
+      ListItem ( Exception ( Flip "gold" . kick End Flap 1000 47045 /Rat 32768 12125 /Rat 32 ) )
       ListItem ( GenStepFailed ( b"c" , GenEndSkip "gold" ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 20 , 0 , 20 ) )
     </processed-events>
     <properties>
       "Debt Constant After Thaw" |-> debtConstantAfterThaw

--- a/tests/attacks/lucash-pot-end.mcd.expected
+++ b/tests/attacks/lucash-pot-end.mcd.expected
@@ -398,7 +398,6 @@
       </kmcd-state>
     </kmcd>
     <processed-events>
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . rely Pot ) )
       ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . rely End ) )
@@ -798,6 +797,18 @@
       Vow |-> 0 , 1 , 10 , 0 , 20 , 20 ) )
       ListItem ( LogNote ( "Alice" , Vat . move Pot "Alice" 10 ) )
       ListItem ( LogNote ( "Alice" , Pot . exit 10 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 20 , 20 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 20 , 20 ) )
     </processed-events>
     <properties>
       "Debt Constant After Thaw" |-> debtConstantAfterThaw

--- a/tests/attacks/lucash-pot-end.random.mcd.expected
+++ b/tests/attacks/lucash-pot-end.random.mcd.expected
@@ -398,7 +398,6 @@
       </kmcd-state>
     </kmcd>
     <processed-events>
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . rely Pot ) )
       ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . rely End ) )
@@ -714,13 +713,13 @@
       Pot |-> 0
       Vow |-> 0 , 1 , 0 , 20 , 0 , 0 ) )
       ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
-      ListItem ( GenStep ( b"d" , transact ADMIN End . cage ) )
       ListItem ( Measure ( 20 , "Alice" |-> 10
       "Bobby" |-> 10
       End |-> 0
       Flap |-> 0
       Pot |-> 0
       Vow |-> 0 , 1 , 0 , 20 , 0 , 0 ) )
+      ListItem ( GenStep ( b"d" , transact ADMIN End . cage ) )
       ListItem ( LogNote ( ADMIN , Vat . cage ) )
       ListItem ( LogNote ( ADMIN , Cat . cage ) )
       ListItem ( LogNote ( Vow , Vat . move Flap Vow 0 ) )
@@ -730,85 +729,97 @@
       ListItem ( LogNote ( ADMIN , Vow . cage ) )
       ListItem ( LogNote ( ADMIN , Pot . cage ) )
       ListItem ( LogNote ( ADMIN , End . cage ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 ) )
       ListItem ( GenStep ( b"da" , transact ANYONE End . cage "gold" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 ) )
       ListItem ( LogNote ( ANYONE , End . cage "gold" ) )
-      ListItem ( GenStep ( b"d" , transact ANYONE End . skim "gold" "Alice" ) )
       ListItem ( Measure ( 20 , "Alice" |-> 10
       "Bobby" |-> 10
       End |-> 0
       Flap |-> 0
       Pot |-> 0
       Vow |-> 0 , 1 , 0 , 20 , 0 , 0 ) )
+      ListItem ( GenStep ( b"d" , transact ANYONE End . skim "gold" "Alice" ) )
       ListItem ( LogNote ( ANYONE , Vat . grab "gold" "Alice" End Vow -10 -10 ) )
       ListItem ( LogNote ( ANYONE , End . skim "gold" "Alice" ) )
-      ListItem ( GenStep ( b"d" , transact ANYONE End . skim "gold" "Bobby" ) )
       ListItem ( Measure ( 20 , "Alice" |-> 10
       "Bobby" |-> 10
       End |-> 0
       Flap |-> 0
       Pot |-> 0
       Vow |-> 0 , 1 , 0 , 10 , 10 , 0 ) )
+      ListItem ( GenStep ( b"d" , transact ANYONE End . skim "gold" "Bobby" ) )
       ListItem ( LogNote ( ANYONE , Vat . grab "gold" "Bobby" End Vow -10 -10 ) )
       ListItem ( LogNote ( ANYONE , End . skim "gold" "Bobby" ) )
-      ListItem ( GenStep ( b"d" , transact ANYONE End . thaw ) )
       ListItem ( Measure ( 20 , "Alice" |-> 10
       "Bobby" |-> 10
       End |-> 0
       Flap |-> 0
       Pot |-> 0
       Vow |-> 0 , 1 , 0 , 0 , 20 , 0 ) )
+      ListItem ( GenStep ( b"d" , transact ANYONE End . thaw ) )
       ListItem ( LogNote ( ANYONE , End . thaw ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 20 , 20 ) )
       ListItem ( GenStep ( b"da" , transact ANYONE End . flow "gold" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 20 , 20 ) )
       ListItem ( LogNote ( ANYONE , End . flow "gold" ) )
-      ListItem ( GenStep ( b"da" , transact "Alice" Pot . join 97 /Rat 10 ) )
       ListItem ( Measure ( 20 , "Alice" |-> 10
       "Bobby" |-> 10
       End |-> 0
       Flap |-> 0
       Pot |-> 0
       Vow |-> 0 , 1 , 0 , 0 , 20 , 20 ) )
-      ListItem ( LogNote ( "Alice" , Vat . move "Alice" Pot 97 /Rat 10 ) )
-      ListItem ( LogNote ( "Alice" , Pot . join 97 /Rat 10 ) )
-      ListItem ( GenStep ( b"da" , transact ADMIN Pot . file dsr 597 /Rat 500 ) )
+      ListItem ( GenStep ( b"da" , transact "Alice" Pot . join 485 /Rat 128 ) )
+      ListItem ( LogNote ( "Alice" , Vat . move "Alice" Pot 485 /Rat 128 ) )
+      ListItem ( LogNote ( "Alice" , Pot . join 485 /Rat 128 ) )
       ListItem ( Measure ( 20 , "Alice" |-> 10
       "Bobby" |-> 10
       End |-> 0
       Flap |-> 0
-      Pot |-> 97 /Rat 10
-      Vow |-> 0 , 1 , 97 /Rat 10 , 0 , 20 , 20 ) )
-      ListItem ( Exception ( Pot . file dsr 597 /Rat 500 ) )
+      Pot |-> 485 /Rat 128
+      Vow |-> 0 , 1 , 485 /Rat 128 , 0 , 20 , 20 ) )
+      ListItem ( GenStep ( b"da" , transact ADMIN Pot . file dsr 1377 /Rat 1280 ) )
+      ListItem ( Exception ( Pot . file dsr 1377 /Rat 1280 ) )
       ListItem ( GenStep ( b"da" , TimeStep 2 ) )
       ListItem ( TimeStep ( 2 , 2 ) )
-      ListItem ( GenStep ( b"d" , transact ANYONE Pot . drip ) )
       ListItem ( Measure ( 20 , "Alice" |-> 10
       "Bobby" |-> 10
       End |-> 0
       Flap |-> 0
-      Pot |-> 97 /Rat 10
-      Vow |-> 0 , 1 , 97 /Rat 10 , 0 , 20 , 20 ) )
+      Pot |-> 485 /Rat 128
+      Vow |-> 0 , 1 , 485 /Rat 128 , 0 , 20 , 20 ) )
+      ListItem ( GenStep ( b"d" , transact ANYONE Pot . drip ) )
       ListItem ( LogNote ( ANYONE , Vat . suck Vow Pot 0 ) )
       ListItem ( LogNote ( ANYONE , Pot . drip ) )
-      ListItem ( GenStep ( b"d" , transact "Alice" Pot . exit 97 /Rat 10 ) )
       ListItem ( Measure ( 20 , "Alice" |-> 10
       "Bobby" |-> 10
       End |-> 0
       Flap |-> 0
-      Pot |-> 97 /Rat 10
-      Vow |-> 0 , 1 , 97 /Rat 10 , 0 , 20 , 20 ) )
-      ListItem ( LogNote ( "Alice" , Vat . move Pot "Alice" 97 /Rat 10 ) )
-      ListItem ( LogNote ( "Alice" , Pot . exit 97 /Rat 10 ) )
+      Pot |-> 485 /Rat 128
+      Vow |-> 0 , 1 , 485 /Rat 128 , 0 , 20 , 20 ) )
+      ListItem ( GenStep ( b"d" , transact "Alice" Pot . exit 485 /Rat 128 ) )
+      ListItem ( LogNote ( "Alice" , Vat . move Pot "Alice" 485 /Rat 128 ) )
+      ListItem ( LogNote ( "Alice" , Pot . exit 485 /Rat 128 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 20 , 20 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 20 , 20 ) )
     </processed-events>
     <properties>
       "Debt Constant After Thaw" |-> debtConstantAfterThaw

--- a/tests/attacks/lucash-pot.mcd.expected
+++ b/tests/attacks/lucash-pot.mcd.expected
@@ -398,7 +398,6 @@
       </kmcd-state>
     </kmcd>
     <processed-events>
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . rely Pot ) )
       ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . rely End ) )
@@ -721,6 +720,12 @@
       Pot |-> 0
       Vow |-> 0 , 1 , 0 , 20 , 0 , 0 ) )
       ListItem ( LogNote ( ADMIN , Pot . file dsr 5 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 ) )
       ListItem ( TimeStep ( 1 , 1 ) )
       ListItem ( Measure ( 20 , "Alice" |-> 10
       "Bobby" |-> 10
@@ -729,12 +734,6 @@
       Pot |-> 0
       Vow |-> 0 , 1 , 0 , 20 , 0 , 0 ) )
       ListItem ( Exception ( Pot . join 10 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 ) )
       ListItem ( LogNote ( "Alice" , Vat . suck Vow Pot 0 ) )
       ListItem ( LogNote ( "Alice" , Pot . drip ) )
       ListItem ( Measure ( 20 , "Alice" |-> 10
@@ -744,6 +743,12 @@
       Pot |-> 0
       Vow |-> 0 , 5 , 0 , 20 , 0 , 0 ) )
       ListItem ( Exception ( Pot . exit 10 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 5 , 0 , 20 , 0 , 0 ) )
     </processed-events>
     <properties>
       "Debt Constant After Thaw" |-> debtConstantAfterThaw

--- a/tests/attacks/lucash-pot.random.mcd.expected
+++ b/tests/attacks/lucash-pot.random.mcd.expected
@@ -272,10 +272,10 @@
             0
           </pot-pie>
           <pot-dsr>
-            597 /Rat 500
+            1377 /Rat 1280
           </pot-dsr>
           <pot-chi>
-            356409 /Rat 250000
+            1896129 /Rat 1638400
           </pot-chi>
           <pot-vow>
             Vow
@@ -398,7 +398,6 @@
       </kmcd-state>
     </kmcd>
     <processed-events>
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . rely Pot ) )
       ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . rely End ) )
@@ -714,49 +713,61 @@
       Pot |-> 0
       Vow |-> 0 , 1 , 0 , 20 , 0 , 0 ) )
       ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
-      ListItem ( GenStep ( b"aa" , transact ADMIN Pot . file dsr 597 /Rat 500 ) )
       ListItem ( Measure ( 20 , "Alice" |-> 10
       "Bobby" |-> 10
       End |-> 0
       Flap |-> 0
       Pot |-> 0
       Vow |-> 0 , 1 , 0 , 20 , 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Pot . file dsr 597 /Rat 500 ) )
+      ListItem ( GenStep ( b"aa" , transact ADMIN Pot . file dsr 1377 /Rat 1280 ) )
+      ListItem ( LogNote ( ADMIN , Pot . file dsr 1377 /Rat 1280 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 ) )
       ListItem ( GenStep ( b"aa" , TimeStep 2 ) )
       ListItem ( TimeStep ( 2 , 2 ) )
-      ListItem ( GenStep ( b"aa" , transact "Alice" Pot . join 97 /Rat 10 ) )
       ListItem ( Measure ( 20 , "Alice" |-> 10
       "Bobby" |-> 10
       End |-> 0
       Flap |-> 0
       Pot |-> 0
       Vow |-> 0 , 1 , 0 , 20 , 0 , 0 ) )
-      ListItem ( Exception ( Pot . join 97 /Rat 10 ) )
+      ListItem ( GenStep ( b"aa" , transact "Alice" Pot . join 485 /Rat 128 ) )
+      ListItem ( Exception ( Pot . join 485 /Rat 128 ) )
       ListItem ( GenStep ( b"a" , transact ANYONE Pot . drip ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 ) )
       ListItem ( LogNote ( ANYONE , Vat . suck Vow Pot 0 ) )
       ListItem ( LogNote ( ANYONE , Pot . drip ) )
-      ListItem ( GenStep ( b"a" , transact "Alice" Pot . exit 0 ) )
       ListItem ( Measure ( 20 , "Alice" |-> 10
       "Bobby" |-> 10
       End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 356409 /Rat 250000 , 0 , 20 , 0 , 0 ) )
+      Vow |-> 0 , 1896129 /Rat 1638400 , 0 , 20 , 0 , 0 ) )
+      ListItem ( GenStep ( b"a" , transact "Alice" Pot . exit 0 ) )
       ListItem ( LogNote ( "Alice" , Vat . move Pot "Alice" 0 ) )
       ListItem ( LogNote ( "Alice" , Pot . exit 0 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1896129 /Rat 1638400 , 0 , 20 , 0 , 0 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1896129 /Rat 1638400 , 0 , 20 , 0 , 0 ) )
     </processed-events>
     <properties>
       "Debt Constant After Thaw" |-> debtConstantAfterThaw
       "Pot Interest Accumulation After End" |-> potEndInterest
       "PotChi PotPie VatPot" |-> potChiPieDai
       "Total Backed Debt Consistency" |-> totalBackedDebtConsistency
-      "Total Bound on Debt" |-> totalDebtBoundedRun ( 20 , 597 /Rat 500 )
+      "Total Bound on Debt" |-> totalDebtBoundedRun ( 20 , 1377 /Rat 1280 )
       "Unauthorized Flap Kick" |-> unAuthFlapKick
       "Unauthorized Flip Kick" |-> unAuthFlipKick
       "Zero-Time Pot Interest Accumulation" |-> zeroTimePotInterest


### PR DESCRIPTION
Run `./mcd-pyk.py --help` for information on how to run, try it yourself too!

-   `mcd-pyk.py` now prints out violating end-states/traces as soon as their found, so it can be started running and dumping to a file, and you can let it run all day and examine the log as it goes.
-   Assertion is called at the end of every transaction which does _not_ throw an exception.
-   Measures are injected only when checking the properties themselves, so that they show up at more sensible places in the logs.

I verified that we can still catch the 4 attacks with the 4 known breakages here.

I've also documented in the README how to run the random-tester, so that people can try it out.