### PR TITLE
Initial solidity test emission from random tester

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ test-python-generator: $(execution_tests_random:=.python-out)
 init_random_seeds :=
 
 test-random: mcd-pyk.py
-	python3 $< random-test 1 1 $(init_random_seeds)
+	python3 $< random-test 1 1 $(init_random_seeds) --emit-solidity
 
 ### Testing Parameters
 

--- a/mcd-pyk.py
+++ b/mcd-pyk.py
@@ -300,7 +300,8 @@ def extractCallEvent(logEvent):
         return [ caller + '.' + contract + '_' + function + '(' + ', '.join(args) + ');' ]
     elif pyk.isKApply(logEvent) and logEvent['label'] == 'TimeStep(_,_)_KMCD-DRIVER_Event_Int_Int':
         return [ 'hevm.warp(' + printIt(logEvent['args'][0]) + ');' ]
-    return []
+    else:
+        return [ 'UNIMPLEMENTED << ' + printIt(logEvent) + ' >>' ]
 
 def extractTrace(config):
     (_, subst) = pyk.splitConfigFrom(config)

--- a/mcd-pyk.py
+++ b/mcd-pyk.py
@@ -281,7 +281,7 @@ def extractCallEvent(logEvent):
                 args = [ argify(printIt(arg)) for arg in functionCall['args'] ]
             return [ caller + '.' + contract + '_' + function + '(' + ', '.join(args) + ');' ]
         elif pyk.isKApply(item) and item['label'] == 'TimeStep(_,_)_KMCD-DRIVER_Event_Int_Int':
-            return 'hevm.warp(' + printIt(item['args'][0]) + ');'
+            return [ 'hevm.warp(' + printIt(item['args'][0]) + ');' ]
     return []
 
 def extractTrace(config):

--- a/mcd-pyk.py
+++ b/mcd-pyk.py
@@ -260,7 +260,7 @@ def extractCallEvent(logEvent):
     if pyk.isKApply(logEvent) and logEvent['label'] == 'ListItem':
         item = logEvent['args'][0]
         if pyk.isKApply(item) and item['label'] == 'LogNote(_,_)_KMCD-DRIVER_Event_Address_MCDStep':
-            caller = 'account' + solidify(printIt(item['args'][0]))
+            caller = solidify(printIt(item['args'][0]))
             contract = solidify(printIt(item['args'][1]['args'][0]))
             functionCall = item['args'][1]['args'][1]
             function = functionCall['label'].split('_')[0]

--- a/mcd-pyk.py
+++ b/mcd-pyk.py
@@ -355,7 +355,7 @@ if __name__ == '__main__':
             if emitSol:
                 print('\n### Solidity')
                 print('------------')
-                print('  ' + '\n  '.join(extractTrace(output)))
+                print('    ' + '\n    '.join(extractTrace(output)))
             sys.stdout.flush()
     stopTime = time.time()
 

--- a/mcd-pyk.py
+++ b/mcd-pyk.py
@@ -307,8 +307,12 @@ def extractTrace(config):
     pEvents = subst['PROCESSED_EVENTS_CELL']
     log_events = flattenList(pEvents)
     call_events = []
+    last_event = None
     for event in log_events:
-        call_events.extend(extractCallEvent(event))
+        if pyk.isKApply(event) and event['label'] == 'Measure(_,_,_,_,_,_,_,_,_,_,_)_KMCD-PROPS_Measure_Rat_Map_Rat_Rat_Rat_Rat_Rat_Rat_Map_Rat_Map':
+            if last_event is not None:
+                call_events.extend(extractCallEvent(last_event))
+        last_event = event
     return call_events
 
 mcdArgs = argparse.ArgumentParser()

--- a/mcd-pyk.py
+++ b/mcd-pyk.py
@@ -252,9 +252,17 @@ def extractCallEvent(logEvent):
             contract = printIt(item['args'][1]['args'][0]).replace(' ', '').replace('"', '')
             functionCall = item['args'][1]['args'][1]
             function = functionCall['label'].split('_')[0]
-            args = [ printIt(arg) for arg in functionCall['args'] ]
             if function.startswith('init'):
                 return []
+            args = []
+            if function.endswith('file'):
+                fileable = functionCall['args'][0]['label']
+                fileargs = functionCall['args'][0]['args']
+                args.append('"' + fileable.split('_')[0] + '"')
+                for arg in fileargs:
+                    args.append(printIt(arg).replace(' ', '').replace('"', ''))
+            else:
+                args = [ printIt(arg) for arg in functionCall['args'] ]
             return [ caller + '.' + contract + function + '(' + ', '.join(args) + ');' ]
         elif pyk.isKApply(item) and item['label'] == 'TimeStep(_,_)_KMCD-DRIVER_Event_Int_Int':
             return 'hevm.warp(' + printIt(item['args'][0]) + ');'

--- a/mcd-pyk.py
+++ b/mcd-pyk.py
@@ -253,7 +253,7 @@ def argify(arg):
         newArg = 'UserLike(' + newArg + ')'
     if     newArg in ['Cat', 'Dai', 'End', 'Flap', 'Flop', 'Jug', 'Pot', 'Spot', 'Vat', 'Vow'] \
         or newArg.startswith('Flip_') or newArg.startswith('Gem_') or newArg.startswith('GemJoin_'):
-        newArg = newArg.replace('_', '') + "Like(" + newArg + ')'
+        newArg = newArg.split('_')[0] + "Like(" + newArg + ')'
     if newArg in ['gold']:
         newArg = '"' + newArg + '"'
     return newArg

--- a/mcd-pyk.py
+++ b/mcd-pyk.py
@@ -300,6 +300,8 @@ def extractCallEvent(logEvent):
         return [ caller + '.' + contract + '_' + function + '(' + ', '.join(args) + ');' ]
     elif pyk.isKApply(logEvent) and logEvent['label'] == 'TimeStep(_,_)_KMCD-DRIVER_Event_Int_Int':
         return [ 'hevm.warp(' + printIt(logEvent['args'][0]) + ');' ]
+    elif pyk.isKApply(logEvent) and logEvent['label'] == 'Measure(_,_,_,_,_,_,_,_,_,_,_)_KMCD-PROPS_Measure_Rat_Map_Rat_Rat_Rat_Rat_Rat_Rat_Map_Rat_Map':
+        return []
     else:
         return [ 'UNIMPLEMENTED << ' + printIt(logEvent) + ' >>' ]
 

--- a/mcd-pyk.py
+++ b/mcd-pyk.py
@@ -249,9 +249,11 @@ def solidify(input):
 
 def argify(arg):
     newArg = solidify(arg)
-    if    newArg in ['Alice', 'Bobby', 'ADMIN', 'ANYONE', 'Cat', 'Dai', 'End', 'Flap', 'Flop', 'Jug', 'Pot', 'Spot', 'Vat', 'Vow'] \
-       or newArg.startswith('Flip_') or newArg.startswith('Gem_') or newArg.startswith('GemJoin_'):
-        newArg = 'address(' + newArg + ')'
+    if newArg in ['Alice', 'Bobby', 'ADMIN', 'ANYONE']:
+        newArg = 'UserLike(' + newArg + ')'
+    if     newArg in ['Cat', 'Dai', 'End', 'Flap', 'Flop', 'Jug', 'Pot', 'Spot', 'Vat', 'Vow'] \
+        or newArg.startswith('Flip_') or newArg.startswith('Gem_') or newArg.startswith('GemJoin_'):
+        newArg = newArg.replace('_', '') + "Like(" + newArg + ')'
     if newArg in ['gold']:
         newArg = '"' + newArg + '"'
     return newArg


### PR DESCRIPTION
Adds an option `--emit-solidity` which attempts to emit valid solidity code which can be dumped into a testing harness for the actual Solidity implementation of this model.

This should help for conformance testing the semantics against the implementation.