### PR TITLE
Add DEPLOY_PRELUDE, improve lucash-flap-end attack

### DIFF
--- a/kmcd-prelude.md
+++ b/kmcd-prelude.md
@@ -39,13 +39,30 @@ module KMCD-PRELUDE
          // Authorize Vow for Flop
          transact ADMIN Flop . rely Vow
 
+         // Account Initializations
+         // -----------------------
+
          // Initialize Vat accounts for Vow/Pot/Flap/End
          transact ADMIN Vat . initUser Vow
          transact ADMIN Vat . initUser Pot
          transact ADMIN Vat . initUser Flap
          transact ADMIN Vat . initUser End
 
-         // File Vow contract for Pot (since Pot doesn't depend on Vow?)
+         // MKR Token Setup
+         // ---------------
+
+         // "MKR" collateral and joiner
+         transact ADMIN Gem "MKR" . init
+         transact ADMIN GemJoin "MKR" . init
+
+         // Setup Flap account on MKR
+         transact ADMIN Gem "MKR" . initUser Vow
+         transact ADMIN Gem "MKR" . initUser Flap
+
+         // Miscellaneous Setup
+         // -------------------
+
+         // File Vow contract for Pot
          transact ADMIN Pot . file vow-file Vow
 
          // Allow the Flap to manipulate the Vow's balances
@@ -56,10 +73,6 @@ module KMCD-PRELUDE
 
     rule ATTACK-PRELUDE
       =>
-         // Account Initializations
-         // -----------------------
-
-
          // Collateral Setup
          // ----------------
 
@@ -84,16 +97,9 @@ module KMCD-PRELUDE
          // Initialize "gold" for End
          transact ADMIN End . initGap "gold"
 
-         // MKR Collateral Setup
-         // --------------------
+         // MKR Balances Setup
+         // ------------------
 
-         // "MKR" collateral and joiner
-         transact ADMIN Gem "MKR" . init
-         transact ADMIN GemJoin "MKR" . init
-
-         // Setup Flap account on MKR
-         transact ADMIN Gem "MKR" . initUser Vow
-         transact ADMIN Gem "MKR" . initUser Flap
          transact ADMIN Gem "MKR" . mint Flap 20
 
          // File Parameters

--- a/kmcd-prelude.md
+++ b/kmcd-prelude.md
@@ -97,11 +97,6 @@ module KMCD-PRELUDE
          // Initialize "gold" for End
          transact ADMIN End . initGap "gold"
 
-         // MKR Balances Setup
-         // ------------------
-
-         transact ADMIN Gem "MKR" . mint Flap 20
-
          // File Parameters
          // ---------------
 
@@ -113,6 +108,7 @@ module KMCD-PRELUDE
 
          // Setup Vow
          transact ADMIN Vow . file bump 1 ether
+         transact ADMIN Vow . file hump 0
 
          // User Setup
          // ----------

--- a/kmcd-prelude.md
+++ b/kmcd-prelude.md
@@ -12,8 +12,9 @@ module KMCD-PRELUDE
     rule <k> STEPS ( MCDSTEPS ) => MCDSTEPS ... </k>
 
     syntax MCDSteps ::= "ATTACK-PRELUDE" [klabel(ATTACK-PRELUDE), symbol]
+                      | "DEPLOY-PRELUDE" [klabel(DEPLOY-PRELUDE), symbol]
  // ---------------------------------------------------------------------
-    rule ATTACK-PRELUDE
+    rule DEPLOY-PRELUDE
       =>
          // Contract Authorizations
          // -----------------------
@@ -38,9 +39,6 @@ module KMCD-PRELUDE
          // Authorize Vow for Flop
          transact ADMIN Flop . rely Vow
 
-         // Account Initializations
-         // -----------------------
-
          // Initialize Vat accounts for Vow/Pot/Flap/End
          transact ADMIN Vat . initUser Vow
          transact ADMIN Vat . initUser Pot
@@ -49,6 +47,18 @@ module KMCD-PRELUDE
 
          // File Vow contract for Pot (since Pot doesn't depend on Vow?)
          transact ADMIN Pot . file vow-file Vow
+
+         // Allow the Flap to manipulate the Vow's balances
+         transact Vow Vat . hope Flap
+
+         .MCDSteps
+      [macro]
+
+    rule ATTACK-PRELUDE
+      =>
+         // Account Initializations
+         // -----------------------
+
 
          // Collateral Setup
          // ----------------

--- a/kmcd-props.md
+++ b/kmcd-props.md
@@ -305,6 +305,7 @@ The Debt growth should be bounded in principle by the interest rates available i
     rule derive( totalDebtBoundedRun(... debt: DEBT, dsr: _  ) #as PREV , Measure(... debt: DEBT')            ) => Violated(PREV) requires DEBT' >Rat DEBT
     rule derive( totalDebtBoundedRun(... debt: DEBT, dsr: DSR)          , TimeStep(TIME, _)                   ) => totalDebtBoundedRun(... debt: DEBT +Rat (vatDaiForUser(Pot) *Rat ((DSR ^Rat TIME) -Rat 1)), dsr: DSR)
     rule derive( totalDebtBoundedRun(... debt: DEBT, dsr: DSR)          , LogNote(_ , Vat . frob _ _ _ _ _ _) ) => totalDebtBounded(... dsr: DSR)
+    rule derive( totalDebtBoundedRun(... debt: DEBT, dsr: DSR)          , LogNote(_ , Vat . suck _ _ _      ) ) => totalDebtBounded(... dsr: DSR)
     rule derive( totalDebtBoundedRun(... debt: DEBT, dsr: DSR)          , LogNote(_ , Pot . file dsr DSR')    ) => totalDebtBoundedRun(... debt: DEBT, dsr: DSR')
     rule derive( totalDebtBoundedRun(... debt: DEBT, dsr: _  )          , LogNote(_ , End . cage         )    ) => totalDebtBoundedEnd(... debt: DEBT)
 
@@ -374,9 +375,10 @@ The property checks if a successful `Pot . join` is preceded by a `TimeStep` mor
 ### Flap dai consistency
 
 ```k
-    syntax ViolationFSM ::= "flapDaiConsistency"
+    syntax ViolationFSM ::= "flapDaiConsistency" | "flapDaiConsistencyEnd"
  // --------------------------------------------
     rule derive(flapDaiConsistency, Measure(... sumOfAllFlapLots: SUM, dai: VAT_DAI)) => Violated(flapDaiConsistency) requires (SUM >Rat #lookup(VAT_DAI, Flap))
+    rule derive(flapDaiConsistency, LogNote(_ , End . cage)                         ) => flapDaiConsistencyEnd
 ```
 
 ### Flap MKR consistency

--- a/kmcd-props.md
+++ b/kmcd-props.md
@@ -305,7 +305,7 @@ The Debt growth should be bounded in principle by the interest rates available i
     rule derive( totalDebtBoundedRun(... debt: DEBT, dsr: _  ) #as PREV , Measure(... debt: DEBT')            ) => Violated(PREV) requires DEBT' >Rat DEBT
     rule derive( totalDebtBoundedRun(... debt: DEBT, dsr: DSR)          , TimeStep(TIME, _)                   ) => totalDebtBoundedRun(... debt: DEBT +Rat (vatDaiForUser(Pot) *Rat ((DSR ^Rat TIME) -Rat 1)), dsr: DSR)
     rule derive( totalDebtBoundedRun(... debt: DEBT, dsr: DSR)          , LogNote(_ , Vat . frob _ _ _ _ _ _) ) => totalDebtBounded(... dsr: DSR)
-    rule derive( totalDebtBoundedRun(... debt: DEBT, dsr: DSR)          , LogNote(_ , Vat . suck _ _ _      ) ) => totalDebtBounded(... dsr: DSR)
+    rule derive( totalDebtBoundedRun(... debt: DEBT, dsr: DSR)          , LogNote(_ , Vat . suck _ _ WAD    ) ) => totalDebtBoundedRun(... debt: DEBT +Rat WAD, dsr: DSR)
     rule derive( totalDebtBoundedRun(... debt: DEBT, dsr: DSR)          , LogNote(_ , Pot . file dsr DSR')    ) => totalDebtBoundedRun(... debt: DEBT, dsr: DSR')
     rule derive( totalDebtBoundedRun(... debt: DEBT, dsr: _  )          , LogNote(_ , End . cage         )    ) => totalDebtBoundedEnd(... debt: DEBT)
 

--- a/kmcd-props.md
+++ b/kmcd-props.md
@@ -376,7 +376,7 @@ The property checks if a successful `Pot . join` is preceded by a `TimeStep` mor
 
 ```k
     syntax ViolationFSM ::= "flapDaiConsistency" | "flapDaiConsistencyEnd"
- // --------------------------------------------
+ // ----------------------------------------------------------------------
     rule derive(flapDaiConsistency, Measure(... sumOfAllFlapLots: SUM, dai: VAT_DAI)) => Violated(flapDaiConsistency) requires (SUM >Rat #lookup(VAT_DAI, Flap))
     rule derive(flapDaiConsistency, LogNote(_ , End . cage)                         ) => flapDaiConsistencyEnd
 ```

--- a/tests/attacks/lucash-flap-end.mcd
+++ b/tests/attacks/lucash-flap-end.mcd
@@ -4,14 +4,22 @@ STEPS ( ATTACK-PRELUDE )
 // Attack Sequence
 // ---------------
 
-transact "Alice" Vat . move "Alice" Vow 1
-transact "Bobby" GemJoin "gold" . join "Bobby" 1
+// Give Bobby some MKR
+transact ADMIN Gem "MKR" . mint "Bobby" 20
+
+// Cheat a little to get a Flap auction started w/o going through full surplus generation cycle
+// (dump sin into the End, out-of-sight of the accounting logic)
+transact ADMIN Vat . suck End Vow 1 ether
+transact ADMIN Vow . flap
+
+// Bobby bids on flap auction
+transact "Bobby" Flap . tend 1 1 ether 20
 
 transact "Alice" Vat . hope Flap
 transact "Alice" Flap . kick 1 20 // step that shouldn't go through
 
 transact ADMIN End . cage
-transact "Alice" Flap . yank 1
+transact "Alice" Flap . yank 2
 
 // Now Alice has 20 MKR, at the cost of 1 Dai
 

--- a/tests/attacks/lucash-flap-end.mcd
+++ b/tests/attacks/lucash-flap-end.mcd
@@ -1,3 +1,4 @@
+STEPS ( DEPLOY-PRELUDE )
 STEPS ( ATTACK-PRELUDE )
 
 // Attack Sequence

--- a/tests/attacks/lucash-flap-end.mcd.expected
+++ b/tests/attacks/lucash-flap-end.mcd.expected
@@ -318,7 +318,7 @@
             End |-> .Set
             Flap |-> .Set
             Pot |-> .Set
-            Vow |-> .Set
+            Vow |-> SetItem ( Flap )
           </vat-can>
           <vat-ilks>
             "gold" |-> Ilk ( 20 , 1 , 3000000000 , 1000000000000 , 0 )
@@ -435,102 +435,6 @@
       Flap |-> 0
       Pot |-> 0
       Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Pot . file vow-file Vow ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Gem "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , GemJoin "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Vat . rely GemJoin "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" Flip "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Spot . init "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 1 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Flip "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Flip "gold" . rely End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , End . initGap "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . init ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
@@ -557,6 +461,136 @@
       Vow |-> 0 , 0 , GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Flap ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Pot . file vow-file Vow ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( Vow , Vat . hope Flap ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , GemJoin "gold" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . rely GemJoin "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" Flip "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Spot . init "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 1 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Flip "gold" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Flip "gold" . rely End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initGap "gold" ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0

--- a/tests/attacks/lucash-flap-end.mcd.expected
+++ b/tests/attacks/lucash-flap-end.mcd.expected
@@ -112,10 +112,10 @@
             SetItem ( Vow )
           </flap-wards>
           <flap-bids>
-            .Map
+            1 |-> FlapBid ( 20 , 1000000000 , "Bobby" , 10800 , 172800 )
           </flap-bids>
           <flap-kicks>
-            0
+            1
           </flap-kicks>
           <flap-live>
             false
@@ -208,8 +208,8 @@
             </gem-wards>
             <gem-balances>
               "Alice" |-> 10
-              "Bobby" |-> 9
-              GemJoin "gold" |-> 21
+              "Bobby" |-> 10
+              GemJoin "gold" |-> 20
             </gem-balances>
           </gem>
         </gems>
@@ -330,31 +330,31 @@
           </vat-urns>
           <vat-gem>
             { "gold" , "Alice" } |-> 0
-            { "gold" , "Bobby" } |-> 1
+            { "gold" , "Bobby" } |-> 0
             { "gold" , End } |-> 0
             { "gold" , Flip "gold" } |-> 0
           </vat-gem>
           <vat-dai>
-            "Alice" |-> 9
+            "Alice" |-> 10
             "Bobby" |-> 10
             End |-> 0
             Flap |-> 0
             Pot |-> 0
-            Vow |-> 1
+            Vow |-> 1000000000
           </vat-dai>
           <vat-sin>
             "Alice" |-> 0
             "Bobby" |-> 0
-            End |-> 0
+            End |-> 1000000000
             Flap |-> 0
             Pot |-> 0
             Vow |-> 0
           </vat-sin>
           <vat-debt>
-            20
+            1000000020
           </vat-debt>
           <vat-vice>
-            0
+            1000000000
           </vat-vice>
           <vat-Line>
             1000000000000
@@ -600,16 +600,6 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
-      ListItem ( LogNote ( ADMIN , Gem "MKR" . mint Flap 20 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . file Line 1000000000000 ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
@@ -617,7 +607,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initIlk "gold" ) )
@@ -627,7 +617,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . file spot "gold" 3000000000 ) )
@@ -637,7 +627,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
@@ -647,7 +637,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vow . file bump 1000000000 ) )
@@ -657,7 +647,17 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Vow . file hump 0 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Alice" ) )
@@ -667,7 +667,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Bobby" ) )
@@ -677,7 +677,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Alice" 20 ) )
@@ -687,7 +687,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Bobby" 20 ) )
@@ -697,7 +697,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Alice" ) )
@@ -708,7 +708,7 @@
       Flap |-> 0
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Bobby" ) )
@@ -720,7 +720,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Pot . initUser "Alice" ) )
@@ -732,7 +732,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Pot . initUser "Bobby" ) )
@@ -744,7 +744,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser "Alice" ) )
@@ -758,7 +758,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Alice" ) )
@@ -772,7 +772,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Alice" ) )
@@ -786,7 +786,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser "Bobby" ) )
@@ -802,7 +802,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Bobby" ) )
@@ -818,7 +818,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Bobby" ) )
@@ -834,7 +834,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Alice" , Vat . hope Pot ) )
@@ -850,7 +850,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Alice" , Vat . hope Flip "gold" ) )
@@ -866,7 +866,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Alice" , Vat . hope End ) )
@@ -882,7 +882,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope Pot ) )
@@ -898,7 +898,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope Flip "gold" ) )
@@ -914,7 +914,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope End ) )
@@ -930,7 +930,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Alice" , Vat . slip "gold" "Alice" 10 ) )
@@ -948,7 +948,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 10 ) )
@@ -966,7 +966,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Alice" , Vat . frob "gold" "Alice" "Alice" "Alice" 10 10 ) )
@@ -982,7 +982,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
@@ -998,7 +998,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
@@ -1014,7 +1014,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
@@ -1030,7 +1030,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
@@ -1046,7 +1046,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
@@ -1062,55 +1062,89 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
-      ListItem ( LogNote ( "Alice" , Vat . move "Alice" Vow 1 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 9
+      ListItem ( LogNote ( ADMIN , Gem "MKR" . mint "Bobby" 20 ) )
+      ListItem ( Measure ( 20 , "Alice" |-> 10
       "Bobby" |-> 10
       End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 1 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 9
+      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
       "Bobby" |-> 10
       End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 1 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 20
+      Vow |-> 0 , 0 , "Alice" |-> 0
+      "Bobby" |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
-      ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 1 ) )
-      ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 1 ) )
-      ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 1 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 9
+      ListItem ( LogNote ( ADMIN , Vat . suck End Vow 1000000000 ) )
+      ListItem ( Measure ( 1000000020 , "Alice" |-> 10
       "Bobby" |-> 10
       End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 1 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 9
+      Vow |-> 1000000000 , 1 , 0 , 20 , 1000000000 , 0 , 0 , "Alice" |-> 10
       "Bobby" |-> 10
       End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 1 , 0 , "Alice" |-> 0
+      Vow |-> 1000000000 , 0 , "Alice" |-> 0
+      "Bobby" |-> 20
+      Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( Vow , Vat . move Vow Flap 1000000000 ) )
+      ListItem ( FlapKick ( Vow , 1 , 1000000000 , 0 ) )
+      ListItem ( LogNote ( ADMIN , Vow . flap ) )
+      ListItem ( Measure ( 1000000020 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 1000000000
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 20 , 1000000000 , 0 , 1000000000 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 1000000000
+      Pot |-> 0
+      Vow |-> 0 , 0 , "Alice" |-> 0
+      "Bobby" |-> 20
+      Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( "Bobby" , Gem "MKR" . move "Bobby" Vow 0 ) )
+      ListItem ( LogNote ( "Bobby" , Gem "MKR" . move "Bobby" Flap 20 ) )
+      ListItem ( LogNote ( "Bobby" , Flap . tend 1 1000000000 20 ) )
+      ListItem ( Measure ( 1000000020 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 1000000000
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 20 , 1000000000 , 0 , 1000000000 , "Alice" |-> 10
+      "Bobby" |-> 10
+      End |-> 0
+      Flap |-> 1000000000
+      Pot |-> 0
+      Vow |-> 0 , 20 , "Alice" |-> 0
       "Bobby" |-> 0
       Flap |-> 20
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Alice" , Vat . hope Flap ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 9
+      ListItem ( Measure ( 1000000020 , "Alice" |-> 10
       "Bobby" |-> 10
       End |-> 0
-      Flap |-> 0
+      Flap |-> 1000000000
       Pot |-> 0
-      Vow |-> 1 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 9
+      Vow |-> 0 , 1 , 0 , 20 , 1000000000 , 0 , 1000000000 , "Alice" |-> 10
       "Bobby" |-> 10
       End |-> 0
-      Flap |-> 0
+      Flap |-> 1000000000
       Pot |-> 0
-      Vow |-> 1 , 0 , "Alice" |-> 0
+      Vow |-> 0 , 20 , "Alice" |-> 0
       "Bobby" |-> 0
       Flap |-> 20
       GemJoin "MKR" |-> 0
@@ -1118,40 +1152,40 @@
       ListItem ( Exception ( Flap . kick 1 20 ) )
       ListItem ( LogNote ( ADMIN , Vat . cage ) )
       ListItem ( LogNote ( ADMIN , Cat . cage ) )
-      ListItem ( LogNote ( Vow , Vat . move Flap Vow 0 ) )
-      ListItem ( LogNote ( End , Flap . cage 0 ) )
+      ListItem ( LogNote ( Vow , Vat . move Flap Vow 1000000000 ) )
+      ListItem ( LogNote ( End , Flap . cage 1000000000 ) )
       ListItem ( LogNote ( End , Flop . cage ) )
       ListItem ( LogNote ( End , Vat . heal 0 ) )
       ListItem ( LogNote ( ADMIN , Vow . cage ) )
       ListItem ( LogNote ( ADMIN , Pot . cage ) )
       ListItem ( LogNote ( ADMIN , End . cage ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 9
+      ListItem ( Measure ( 1000000020 , "Alice" |-> 10
       "Bobby" |-> 10
       End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 1 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 9
+      Vow |-> 1000000000 , 1 , 0 , 20 , 1000000000 , 0 , 1000000000 , "Alice" |-> 10
       "Bobby" |-> 10
       End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 1 , 0 , "Alice" |-> 0
+      Vow |-> 1000000000 , 20 , "Alice" |-> 0
       "Bobby" |-> 0
       Flap |-> 20
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
-      ListItem ( Exception ( Flap . yank 1 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 9
+      ListItem ( Exception ( Flap . yank 2 ) )
+      ListItem ( Measure ( 1000000020 , "Alice" |-> 10
       "Bobby" |-> 10
       End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 1 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 9
+      Vow |-> 1000000000 , 1 , 0 , 20 , 1000000000 , 0 , 1000000000 , "Alice" |-> 10
       "Bobby" |-> 10
       End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 1 , 0 , "Alice" |-> 0
+      Vow |-> 1000000000 , 20 , "Alice" |-> 0
       "Bobby" |-> 0
       Flap |-> 20
       GemJoin "MKR" |-> 0
@@ -1159,12 +1193,12 @@
     </processed-events>
     <properties>
       "Debt Constant After Thaw" |-> debtConstantAfterThaw
-      "Flap Dai Consistency" |-> flapDaiConsistency
+      "Flap Dai Consistency" |-> flapDaiConsistencyEnd
       "Flap MKR Consistency" |-> flapMkrConsistency
       "Pot Interest Accumulation After End" |-> potEndInterestEnd
       "PotChi PotPie VatPot" |-> potChiPieDai ( 0 , 0 )
       "Total Backed Debt Consistency" |-> totalBackedDebtConsistency
-      "Total Bound on Debt" |-> totalDebtBoundedEnd ( 20 )
+      "Total Bound on Debt" |-> totalDebtBoundedEnd ( 1000000020 )
       "Unauthorized Flap Kick" |-> unAuthFlapKick
       "Unauthorized Flip Kick" |-> unAuthFlipKick
       "Zero-Time Pot Interest Accumulation" |-> zeroTimePotInterest

--- a/tests/attacks/lucash-flap-end.random.mcd
+++ b/tests/attacks/lucash-flap-end.random.mcd
@@ -1,3 +1,4 @@
+STEPS ( DEPLOY-PRELUDE )
 STEPS ( ATTACK-PRELUDE )
 
 AddGenerator ( GenVatMove "Alice" Vow

--- a/tests/attacks/lucash-flap-end.random.mcd.expected
+++ b/tests/attacks/lucash-flap-end.random.mcd.expected
@@ -318,7 +318,7 @@
             End |-> .Set
             Flap |-> .Set
             Pot |-> .Set
-            Vow |-> .Set
+            Vow |-> SetItem ( Flap )
           </vat-can>
           <vat-ilks>
             "gold" |-> Ilk ( 20 , 1 , 3000000000 , 1000000000000 , 0 )
@@ -435,102 +435,6 @@
       Flap |-> 0
       Pot |-> 0
       Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Pot . file vow-file Vow ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Gem "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , GemJoin "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Vat . rely GemJoin "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" Flip "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Spot . init "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 1 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Flip "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Flip "gold" . rely End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , End . initGap "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . init ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
@@ -557,6 +461,136 @@
       Vow |-> 0 , 0 , GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Flap ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Pot . file vow-file Vow ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( Vow , Vat . hope Flap ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , GemJoin "gold" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . rely GemJoin "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" Flip "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Spot . init "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 1 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Flip "gold" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Flip "gold" . rely End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initGap "gold" ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0

--- a/tests/attacks/lucash-flap-end.random.mcd.expected
+++ b/tests/attacks/lucash-flap-end.random.mcd.expected
@@ -195,7 +195,7 @@
             <gem-balances>
               "Alice" |-> 0
               "Bobby" |-> 0
-              Flap |-> 20
+              Flap |-> 0
               GemJoin "MKR" |-> 0
               Vow |-> 0
             </gem-balances>
@@ -600,16 +600,6 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
-      ListItem ( LogNote ( ADMIN , Gem "MKR" . mint Flap 20 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . file Line 1000000000000 ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
@@ -617,7 +607,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initIlk "gold" ) )
@@ -627,7 +617,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . file spot "gold" 3000000000 ) )
@@ -637,7 +627,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
@@ -647,7 +637,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vow . file bump 1000000000 ) )
@@ -657,7 +647,17 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Vow . file hump 0 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Alice" ) )
@@ -667,7 +667,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Bobby" ) )
@@ -677,7 +677,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Alice" 20 ) )
@@ -687,7 +687,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Bobby" 20 ) )
@@ -697,7 +697,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Alice" ) )
@@ -708,7 +708,7 @@
       Flap |-> 0
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Bobby" ) )
@@ -720,7 +720,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Pot . initUser "Alice" ) )
@@ -732,7 +732,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Pot . initUser "Bobby" ) )
@@ -744,7 +744,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser "Alice" ) )
@@ -758,7 +758,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Alice" ) )
@@ -772,7 +772,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Alice" ) )
@@ -786,7 +786,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser "Bobby" ) )
@@ -802,7 +802,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Bobby" ) )
@@ -818,7 +818,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Bobby" ) )
@@ -834,7 +834,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Alice" , Vat . hope Pot ) )
@@ -850,7 +850,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Alice" , Vat . hope Flip "gold" ) )
@@ -866,7 +866,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Alice" , Vat . hope End ) )
@@ -882,7 +882,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope Pot ) )
@@ -898,7 +898,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope Flip "gold" ) )
@@ -914,7 +914,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope End ) )
@@ -930,7 +930,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Alice" , Vat . slip "gold" "Alice" 10 ) )
@@ -948,7 +948,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 10 ) )
@@ -966,7 +966,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Alice" , Vat . frob "gold" "Alice" "Alice" "Alice" 10 10 ) )
@@ -982,7 +982,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
@@ -998,7 +998,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
@@ -1014,7 +1014,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
@@ -1030,7 +1030,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
@@ -1046,7 +1046,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
@@ -1062,7 +1062,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( GenStep ( b"b0" , transact "Alice" Vat . move "Alice" Vow 15 /Rat 8 ) )
@@ -1079,7 +1079,7 @@
       Pot |-> 0
       Vow |-> 15 /Rat 8 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( GenStep ( b"b3" , transact "Bobby" GemJoin "gold" . join "Bobby" 255 /Rat 128 ) )
@@ -1098,7 +1098,7 @@
       Pot |-> 0
       Vow |-> 15 /Rat 8 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( GenStep ( b"b" , transact "Alice" Vat . hope Flap ) )
@@ -1115,11 +1115,11 @@
       Pot |-> 0
       Vow |-> 15 /Rat 8 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
-      ListItem ( GenStep ( b"b0Z" , transact "Alice" Flap . kick 195 /Rat 128 225 /Rat 32 ) )
-      ListItem ( Exception ( Flap . kick 195 /Rat 128 225 /Rat 32 ) )
+      ListItem ( GenStep ( b"b0Z" , transact "Alice" Flap . kick 195 /Rat 128 0 ) )
+      ListItem ( Exception ( Flap . kick 195 /Rat 128 0 ) )
       ListItem ( GenStep ( b"b" , transact ADMIN End . cage ) )
       ListItem ( LogNote ( ADMIN , Vat . cage ) )
       ListItem ( LogNote ( ADMIN , Cat . cage ) )
@@ -1142,7 +1142,7 @@
       Pot |-> 0
       Vow |-> 15 /Rat 8 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( GenStepFailed ( b"b" , GenFlapYank ) )
@@ -1158,13 +1158,13 @@
       Pot |-> 0
       Vow |-> 15 /Rat 8 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
     </processed-events>
     <properties>
       "Debt Constant After Thaw" |-> debtConstantAfterThaw
-      "Flap Dai Consistency" |-> flapDaiConsistency
+      "Flap Dai Consistency" |-> flapDaiConsistencyEnd
       "Flap MKR Consistency" |-> flapMkrConsistency
       "Pot Interest Accumulation After End" |-> potEndInterestEnd
       "PotChi PotPie VatPot" |-> potChiPieDai ( 0 , 0 )

--- a/tests/attacks/lucash-flip-end.mcd
+++ b/tests/attacks/lucash-flip-end.mcd
@@ -1,3 +1,4 @@
+STEPS ( DEPLOY-PRELUDE )
 STEPS ( ATTACK-PRELUDE )
 
 // Attack Sequence

--- a/tests/attacks/lucash-flip-end.mcd.expected
+++ b/tests/attacks/lucash-flip-end.mcd.expected
@@ -317,7 +317,7 @@
             End |-> .Set
             Flap |-> .Set
             Pot |-> .Set
-            Vow |-> .Set
+            Vow |-> SetItem ( Flap )
           </vat-can>
           <vat-ilks>
             "gold" |-> Ilk ( 20 , 1 , 3000000000 , 1000000000000 , 0 )
@@ -434,102 +434,6 @@
       Flap |-> 0
       Pot |-> 0
       Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Pot . file vow-file Vow ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Gem "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , GemJoin "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Vat . rely GemJoin "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" Flip "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Spot . init "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 1 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Flip "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Flip "gold" . rely End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , End . initGap "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . init ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
@@ -556,6 +460,136 @@
       Vow |-> 0 , 0 , GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Flap ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Pot . file vow-file Vow ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( Vow , Vat . hope Flap ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , GemJoin "gold" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . rely GemJoin "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" Flip "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Spot . init "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 1 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Flip "gold" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Flip "gold" . rely End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initGap "gold" ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0

--- a/tests/attacks/lucash-flip-end.mcd.expected
+++ b/tests/attacks/lucash-flip-end.mcd.expected
@@ -195,7 +195,7 @@
             <gem-balances>
               "Alice" |-> 0
               "Bobby" |-> 0
-              Flap |-> 20
+              Flap |-> 0
               GemJoin "MKR" |-> 0
               Vow |-> 0
             </gem-balances>
@@ -599,16 +599,6 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
-      ListItem ( LogNote ( ADMIN , Gem "MKR" . mint Flap 20 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . file Line 1000000000000 ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
@@ -616,7 +606,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initIlk "gold" ) )
@@ -626,7 +616,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . file spot "gold" 3000000000 ) )
@@ -636,7 +626,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
@@ -646,7 +636,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vow . file bump 1000000000 ) )
@@ -656,7 +646,17 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Vow . file hump 0 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Alice" ) )
@@ -666,7 +666,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Bobby" ) )
@@ -676,7 +676,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Alice" 20 ) )
@@ -686,7 +686,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Bobby" 20 ) )
@@ -696,7 +696,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Alice" ) )
@@ -707,7 +707,7 @@
       Flap |-> 0
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Bobby" ) )
@@ -719,7 +719,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Pot . initUser "Alice" ) )
@@ -731,7 +731,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Pot . initUser "Bobby" ) )
@@ -743,7 +743,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser "Alice" ) )
@@ -757,7 +757,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Alice" ) )
@@ -771,7 +771,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Alice" ) )
@@ -785,7 +785,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser "Bobby" ) )
@@ -801,7 +801,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Bobby" ) )
@@ -817,7 +817,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Bobby" ) )
@@ -833,7 +833,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Alice" , Vat . hope Pot ) )
@@ -849,7 +849,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Alice" , Vat . hope Flip "gold" ) )
@@ -865,7 +865,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Alice" , Vat . hope End ) )
@@ -881,7 +881,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope Pot ) )
@@ -897,7 +897,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope Flip "gold" ) )
@@ -913,7 +913,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope End ) )
@@ -929,7 +929,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Alice" , Vat . slip "gold" "Alice" 10 ) )
@@ -947,7 +947,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 10 ) )
@@ -965,7 +965,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Alice" , Vat . frob "gold" "Alice" "Alice" "Alice" 10 10 ) )
@@ -981,7 +981,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
@@ -997,7 +997,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
@@ -1013,7 +1013,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
@@ -1029,7 +1029,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
@@ -1045,7 +1045,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
@@ -1061,7 +1061,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 1 ) )
@@ -1079,7 +1079,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . cage ) )
@@ -1103,7 +1103,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , End . cage "gold" ) )
@@ -1119,7 +1119,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( TimeStep ( 3600 , 3600 ) )
@@ -1135,7 +1135,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , End . thaw ) )
@@ -1151,7 +1151,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , End . flow "gold" ) )
@@ -1167,7 +1167,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( Exception ( Flip "gold" . kick End "Bobby" 1001000000000 1 1000000000000 ) )
@@ -1184,13 +1184,13 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
     </processed-events>
     <properties>
       "Debt Constant After Thaw" |-> debtConstantAfterThaw
-      "Flap Dai Consistency" |-> flapDaiConsistency
+      "Flap Dai Consistency" |-> flapDaiConsistencyEnd
       "Flap MKR Consistency" |-> flapMkrConsistency
       "Pot Interest Accumulation After End" |-> potEndInterestEnd
       "PotChi PotPie VatPot" |-> potChiPieDai ( 0 , 0 )

--- a/tests/attacks/lucash-flip-end.random.mcd
+++ b/tests/attacks/lucash-flip-end.random.mcd
@@ -1,3 +1,4 @@
+STEPS ( DEPLOY-PRELUDE )
 STEPS ( ATTACK-PRELUDE )
 
 AddGenerator ( GenGemJoinJoin "gold" "Bobby"

--- a/tests/attacks/lucash-flip-end.random.mcd.expected
+++ b/tests/attacks/lucash-flip-end.random.mcd.expected
@@ -317,7 +317,7 @@
             End |-> .Set
             Flap |-> .Set
             Pot |-> .Set
-            Vow |-> .Set
+            Vow |-> SetItem ( Flap )
           </vat-can>
           <vat-ilks>
             "gold" |-> Ilk ( 20 , 1 , 3000000000 , 1000000000000 , 0 )
@@ -434,102 +434,6 @@
       Flap |-> 0
       Pot |-> 0
       Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Pot . file vow-file Vow ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Gem "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , GemJoin "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Vat . rely GemJoin "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" Flip "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Spot . init "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 1 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Flip "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Flip "gold" . rely End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , End . initGap "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . init ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
@@ -556,6 +460,136 @@
       Vow |-> 0 , 0 , GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Flap ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Pot . file vow-file Vow ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( Vow , Vat . hope Flap ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , GemJoin "gold" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . rely GemJoin "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" Flip "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Spot . init "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 1 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Flip "gold" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Flip "gold" . rely End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initGap "gold" ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0

--- a/tests/attacks/lucash-flip-end.random.mcd.expected
+++ b/tests/attacks/lucash-flip-end.random.mcd.expected
@@ -195,7 +195,7 @@
             <gem-balances>
               "Alice" |-> 0
               "Bobby" |-> 0
-              Flap |-> 20
+              Flap |-> 0
               GemJoin "MKR" |-> 0
               Vow |-> 0
             </gem-balances>
@@ -599,16 +599,6 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
-      ListItem ( LogNote ( ADMIN , Gem "MKR" . mint Flap 20 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . file Line 1000000000000 ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
@@ -616,7 +606,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initIlk "gold" ) )
@@ -626,7 +616,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . file spot "gold" 3000000000 ) )
@@ -636,7 +626,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
@@ -646,7 +636,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vow . file bump 1000000000 ) )
@@ -656,7 +646,17 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Vow . file hump 0 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Alice" ) )
@@ -666,7 +666,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Bobby" ) )
@@ -676,7 +676,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Alice" 20 ) )
@@ -686,7 +686,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Bobby" 20 ) )
@@ -696,7 +696,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Alice" ) )
@@ -707,7 +707,7 @@
       Flap |-> 0
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Bobby" ) )
@@ -719,7 +719,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Pot . initUser "Alice" ) )
@@ -731,7 +731,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Pot . initUser "Bobby" ) )
@@ -743,7 +743,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser "Alice" ) )
@@ -757,7 +757,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Alice" ) )
@@ -771,7 +771,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Alice" ) )
@@ -785,7 +785,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser "Bobby" ) )
@@ -801,7 +801,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Bobby" ) )
@@ -817,7 +817,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Bobby" ) )
@@ -833,7 +833,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Alice" , Vat . hope Pot ) )
@@ -849,7 +849,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Alice" , Vat . hope Flip "gold" ) )
@@ -865,7 +865,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Alice" , Vat . hope End ) )
@@ -881,7 +881,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope Pot ) )
@@ -897,7 +897,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope Flip "gold" ) )
@@ -913,7 +913,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope End ) )
@@ -929,7 +929,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Alice" , Vat . slip "gold" "Alice" 10 ) )
@@ -947,7 +947,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 10 ) )
@@ -965,7 +965,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Alice" , Vat . frob "gold" "Alice" "Alice" "Alice" 10 10 ) )
@@ -981,7 +981,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
@@ -997,7 +997,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
@@ -1013,7 +1013,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
@@ -1029,7 +1029,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
@@ -1045,7 +1045,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
@@ -1061,7 +1061,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( GenStep ( b"ca" , transact "Bobby" GemJoin "gold" . join "Bobby" 485 /Rat 128 ) )
@@ -1080,7 +1080,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( GenStep ( b"c" , transact ADMIN End . cage ) )
@@ -1105,7 +1105,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( GenStep ( b"ca" , transact ANYONE End . cage "gold" ) )
@@ -1122,7 +1122,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( GenStep ( b"ca" , TimeStep 2 ) )
@@ -1139,7 +1139,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( GenStep ( b"c" , transact ANYONE End . thaw ) )
@@ -1156,7 +1156,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( GenStep ( b"ca" , transact ANYONE End . flow "gold" ) )
@@ -1173,7 +1173,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( GenStep ( b"caa" , transact "Bobby" Flip "gold" . kick End Flap 1000 47045 /Rat 32768 12125 /Rat 32 ) )
@@ -1191,13 +1191,13 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
     </processed-events>
     <properties>
       "Debt Constant After Thaw" |-> debtConstantAfterThaw
-      "Flap Dai Consistency" |-> flapDaiConsistency
+      "Flap Dai Consistency" |-> flapDaiConsistencyEnd
       "Flap MKR Consistency" |-> flapMkrConsistency
       "Pot Interest Accumulation After End" |-> potEndInterestEnd
       "PotChi PotPie VatPot" |-> potChiPieDai ( 0 , 0 )

--- a/tests/attacks/lucash-pot-end.mcd
+++ b/tests/attacks/lucash-pot-end.mcd
@@ -1,3 +1,4 @@
+STEPS ( DEPLOY-PRELUDE )
 STEPS ( ATTACK-PRELUDE )
 
 // Attack Sequence

--- a/tests/attacks/lucash-pot-end.mcd.expected
+++ b/tests/attacks/lucash-pot-end.mcd.expected
@@ -317,7 +317,7 @@
             End |-> .Set
             Flap |-> .Set
             Pot |-> .Set
-            Vow |-> .Set
+            Vow |-> SetItem ( Flap )
           </vat-can>
           <vat-ilks>
             "gold" |-> Ilk ( 0 , 1 , 3000000000 , 1000000000000 , 0 )
@@ -434,102 +434,6 @@
       Flap |-> 0
       Pot |-> 0
       Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Pot . file vow-file Vow ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Gem "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , GemJoin "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Vat . rely GemJoin "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" Flip "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Spot . init "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 1 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Flip "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Flip "gold" . rely End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , End . initGap "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . init ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
@@ -556,6 +460,136 @@
       Vow |-> 0 , 0 , GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Flap ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Pot . file vow-file Vow ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( Vow , Vat . hope Flap ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , GemJoin "gold" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . rely GemJoin "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" Flip "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Spot . init "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 1 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Flip "gold" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Flip "gold" . rely End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initGap "gold" ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0

--- a/tests/attacks/lucash-pot-end.mcd.expected
+++ b/tests/attacks/lucash-pot-end.mcd.expected
@@ -195,7 +195,7 @@
             <gem-balances>
               "Alice" |-> 0
               "Bobby" |-> 0
-              Flap |-> 20
+              Flap |-> 0
               GemJoin "MKR" |-> 0
               Vow |-> 0
             </gem-balances>
@@ -599,16 +599,6 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
-      ListItem ( LogNote ( ADMIN , Gem "MKR" . mint Flap 20 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . file Line 1000000000000 ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
@@ -616,7 +606,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initIlk "gold" ) )
@@ -626,7 +616,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . file spot "gold" 3000000000 ) )
@@ -636,7 +626,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
@@ -646,7 +636,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vow . file bump 1000000000 ) )
@@ -656,7 +646,17 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Vow . file hump 0 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Alice" ) )
@@ -666,7 +666,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Bobby" ) )
@@ -676,7 +676,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Alice" 20 ) )
@@ -686,7 +686,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Bobby" 20 ) )
@@ -696,7 +696,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Alice" ) )
@@ -707,7 +707,7 @@
       Flap |-> 0
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Bobby" ) )
@@ -719,7 +719,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Pot . initUser "Alice" ) )
@@ -731,7 +731,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Pot . initUser "Bobby" ) )
@@ -743,7 +743,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser "Alice" ) )
@@ -757,7 +757,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Alice" ) )
@@ -771,7 +771,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Alice" ) )
@@ -785,7 +785,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser "Bobby" ) )
@@ -801,7 +801,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Bobby" ) )
@@ -817,7 +817,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Bobby" ) )
@@ -833,7 +833,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Alice" , Vat . hope Pot ) )
@@ -849,7 +849,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Alice" , Vat . hope Flip "gold" ) )
@@ -865,7 +865,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Alice" , Vat . hope End ) )
@@ -881,7 +881,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope Pot ) )
@@ -897,7 +897,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope Flip "gold" ) )
@@ -913,7 +913,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope End ) )
@@ -929,7 +929,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Alice" , Vat . slip "gold" "Alice" 10 ) )
@@ -947,7 +947,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 10 ) )
@@ -965,7 +965,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Alice" , Vat . frob "gold" "Alice" "Alice" "Alice" 10 10 ) )
@@ -981,7 +981,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
@@ -997,7 +997,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
@@ -1013,7 +1013,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
@@ -1029,7 +1029,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
@@ -1045,7 +1045,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
@@ -1061,7 +1061,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . cage ) )
@@ -1085,7 +1085,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , End . cage "gold" ) )
@@ -1101,7 +1101,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . grab "gold" "Alice" End Vow -10 -10 ) )
@@ -1118,7 +1118,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . grab "gold" "Bobby" End Vow -10 -10 ) )
@@ -1135,7 +1135,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , End . thaw ) )
@@ -1151,7 +1151,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , End . flow "gold" ) )
@@ -1167,7 +1167,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Alice" , Vat . move "Alice" Pot 10 ) )
@@ -1184,7 +1184,7 @@
       Pot |-> 10
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( Exception ( Pot . file dsr 2 ) )
@@ -1201,7 +1201,7 @@
       Pot |-> 10
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Alice" , Vat . suck Vow Pot 0 ) )
@@ -1218,7 +1218,7 @@
       Pot |-> 10
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Alice" , Vat . move Pot "Alice" 10 ) )
@@ -1235,7 +1235,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( Measure ( 20 , "Alice" |-> 10
@@ -1250,13 +1250,13 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
     </processed-events>
     <properties>
       "Debt Constant After Thaw" |-> debtConstantAfterThaw
-      "Flap Dai Consistency" |-> flapDaiConsistency
+      "Flap Dai Consistency" |-> flapDaiConsistencyEnd
       "Flap MKR Consistency" |-> flapMkrConsistency
       "Pot Interest Accumulation After End" |-> potEndInterestEnd
       "PotChi PotPie VatPot" |-> potChiPieDai ( 0 , 0 )

--- a/tests/attacks/lucash-pot-end.random.mcd
+++ b/tests/attacks/lucash-pot-end.random.mcd
@@ -1,3 +1,4 @@
+STEPS ( DEPLOY-PRELUDE )
 STEPS ( ATTACK-PRELUDE )
 
 AddGenerator ( GenEndCage

--- a/tests/attacks/lucash-pot-end.random.mcd.expected
+++ b/tests/attacks/lucash-pot-end.random.mcd.expected
@@ -317,7 +317,7 @@
             End |-> .Set
             Flap |-> .Set
             Pot |-> .Set
-            Vow |-> .Set
+            Vow |-> SetItem ( Flap )
           </vat-can>
           <vat-ilks>
             "gold" |-> Ilk ( 0 , 1 , 3000000000 , 1000000000000 , 0 )
@@ -434,102 +434,6 @@
       Flap |-> 0
       Pot |-> 0
       Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Pot . file vow-file Vow ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Gem "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , GemJoin "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Vat . rely GemJoin "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" Flip "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Spot . init "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 1 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Flip "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Flip "gold" . rely End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , End . initGap "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . init ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
@@ -556,6 +460,136 @@
       Vow |-> 0 , 0 , GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Flap ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Pot . file vow-file Vow ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( Vow , Vat . hope Flap ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , GemJoin "gold" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . rely GemJoin "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" Flip "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Spot . init "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 1 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Flip "gold" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Flip "gold" . rely End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initGap "gold" ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0

--- a/tests/attacks/lucash-pot-end.random.mcd.expected
+++ b/tests/attacks/lucash-pot-end.random.mcd.expected
@@ -195,7 +195,7 @@
             <gem-balances>
               "Alice" |-> 0
               "Bobby" |-> 0
-              Flap |-> 20
+              Flap |-> 0
               GemJoin "MKR" |-> 0
               Vow |-> 0
             </gem-balances>
@@ -599,16 +599,6 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
-      ListItem ( LogNote ( ADMIN , Gem "MKR" . mint Flap 20 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . file Line 1000000000000 ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
@@ -616,7 +606,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initIlk "gold" ) )
@@ -626,7 +616,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . file spot "gold" 3000000000 ) )
@@ -636,7 +626,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
@@ -646,7 +636,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vow . file bump 1000000000 ) )
@@ -656,7 +646,17 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Vow . file hump 0 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Alice" ) )
@@ -666,7 +666,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Bobby" ) )
@@ -676,7 +676,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Alice" 20 ) )
@@ -686,7 +686,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Bobby" 20 ) )
@@ -696,7 +696,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Alice" ) )
@@ -707,7 +707,7 @@
       Flap |-> 0
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Bobby" ) )
@@ -719,7 +719,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Pot . initUser "Alice" ) )
@@ -731,7 +731,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Pot . initUser "Bobby" ) )
@@ -743,7 +743,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser "Alice" ) )
@@ -757,7 +757,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Alice" ) )
@@ -771,7 +771,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Alice" ) )
@@ -785,7 +785,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser "Bobby" ) )
@@ -801,7 +801,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Bobby" ) )
@@ -817,7 +817,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Bobby" ) )
@@ -833,7 +833,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Alice" , Vat . hope Pot ) )
@@ -849,7 +849,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Alice" , Vat . hope Flip "gold" ) )
@@ -865,7 +865,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Alice" , Vat . hope End ) )
@@ -881,7 +881,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope Pot ) )
@@ -897,7 +897,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope Flip "gold" ) )
@@ -913,7 +913,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope End ) )
@@ -929,7 +929,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Alice" , Vat . slip "gold" "Alice" 10 ) )
@@ -947,7 +947,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 10 ) )
@@ -965,7 +965,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Alice" , Vat . frob "gold" "Alice" "Alice" "Alice" 10 10 ) )
@@ -981,7 +981,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
@@ -997,7 +997,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
@@ -1013,7 +1013,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
@@ -1029,7 +1029,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
@@ -1045,7 +1045,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
@@ -1061,7 +1061,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( GenStep ( b"d" , transact ADMIN End . cage ) )
@@ -1086,7 +1086,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( GenStep ( b"da" , transact ANYONE End . cage "gold" ) )
@@ -1103,7 +1103,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( GenStep ( b"d" , transact ANYONE End . skim "gold" "Alice" ) )
@@ -1121,7 +1121,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( GenStep ( b"d" , transact ANYONE End . skim "gold" "Bobby" ) )
@@ -1139,7 +1139,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( GenStep ( b"d" , transact ANYONE End . thaw ) )
@@ -1156,7 +1156,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( GenStep ( b"da" , transact ANYONE End . flow "gold" ) )
@@ -1173,7 +1173,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( GenStep ( b"da" , transact "Alice" Pot . join 485 /Rat 128 ) )
@@ -1191,7 +1191,7 @@
       Pot |-> 485 /Rat 128
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( GenStep ( b"da" , transact ADMIN Pot . file dsr 1377 /Rat 1280 ) )
@@ -1210,7 +1210,7 @@
       Pot |-> 485 /Rat 128
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( GenStep ( b"d" , transact ANYONE Pot . drip ) )
@@ -1228,7 +1228,7 @@
       Pot |-> 485 /Rat 128
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( GenStep ( b"d" , transact "Alice" Pot . exit 485 /Rat 128 ) )
@@ -1246,7 +1246,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( Measure ( 20 , "Alice" |-> 10
@@ -1261,13 +1261,13 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
     </processed-events>
     <properties>
       "Debt Constant After Thaw" |-> debtConstantAfterThaw
-      "Flap Dai Consistency" |-> flapDaiConsistency
+      "Flap Dai Consistency" |-> flapDaiConsistencyEnd
       "Flap MKR Consistency" |-> flapMkrConsistency
       "Pot Interest Accumulation After End" |-> potEndInterestEnd
       "PotChi PotPie VatPot" |-> potChiPieDai ( 0 , 0 )

--- a/tests/attacks/lucash-pot.mcd
+++ b/tests/attacks/lucash-pot.mcd
@@ -1,3 +1,4 @@
+STEPS ( DEPLOY-PRELUDE )
 STEPS ( ATTACK-PRELUDE )
 
 // Attack Sequence

--- a/tests/attacks/lucash-pot.mcd.expected
+++ b/tests/attacks/lucash-pot.mcd.expected
@@ -195,7 +195,7 @@
             <gem-balances>
               "Alice" |-> 0
               "Bobby" |-> 0
-              Flap |-> 20
+              Flap |-> 0
               GemJoin "MKR" |-> 0
               Vow |-> 0
             </gem-balances>
@@ -599,16 +599,6 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
-      ListItem ( LogNote ( ADMIN , Gem "MKR" . mint Flap 20 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . file Line 1000000000000 ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
@@ -616,7 +606,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initIlk "gold" ) )
@@ -626,7 +616,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . file spot "gold" 3000000000 ) )
@@ -636,7 +626,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
@@ -646,7 +636,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vow . file bump 1000000000 ) )
@@ -656,7 +646,17 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Vow . file hump 0 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Alice" ) )
@@ -666,7 +666,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Bobby" ) )
@@ -676,7 +676,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Alice" 20 ) )
@@ -686,7 +686,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Bobby" 20 ) )
@@ -696,7 +696,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Alice" ) )
@@ -707,7 +707,7 @@
       Flap |-> 0
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Bobby" ) )
@@ -719,7 +719,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Pot . initUser "Alice" ) )
@@ -731,7 +731,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Pot . initUser "Bobby" ) )
@@ -743,7 +743,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser "Alice" ) )
@@ -757,7 +757,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Alice" ) )
@@ -771,7 +771,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Alice" ) )
@@ -785,7 +785,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser "Bobby" ) )
@@ -801,7 +801,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Bobby" ) )
@@ -817,7 +817,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Bobby" ) )
@@ -833,7 +833,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Alice" , Vat . hope Pot ) )
@@ -849,7 +849,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Alice" , Vat . hope Flip "gold" ) )
@@ -865,7 +865,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Alice" , Vat . hope End ) )
@@ -881,7 +881,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope Pot ) )
@@ -897,7 +897,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope Flip "gold" ) )
@@ -913,7 +913,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope End ) )
@@ -929,7 +929,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Alice" , Vat . slip "gold" "Alice" 10 ) )
@@ -947,7 +947,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 10 ) )
@@ -965,7 +965,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Alice" , Vat . frob "gold" "Alice" "Alice" "Alice" 10 10 ) )
@@ -981,7 +981,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
@@ -997,7 +997,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
@@ -1013,7 +1013,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
@@ -1029,7 +1029,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
@@ -1045,7 +1045,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
@@ -1061,7 +1061,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Pot . file dsr 5 ) )
@@ -1077,7 +1077,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( TimeStep ( 1 , 1 ) )
@@ -1093,7 +1093,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( Exception ( Pot . join 10 ) )
@@ -1111,7 +1111,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( Exception ( Pot . exit 10 ) )
@@ -1127,7 +1127,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
     </processed-events>

--- a/tests/attacks/lucash-pot.mcd.expected
+++ b/tests/attacks/lucash-pot.mcd.expected
@@ -317,7 +317,7 @@
             End |-> .Set
             Flap |-> .Set
             Pot |-> .Set
-            Vow |-> .Set
+            Vow |-> SetItem ( Flap )
           </vat-can>
           <vat-ilks>
             "gold" |-> Ilk ( 20 , 1 , 3000000000 , 1000000000000 , 0 )
@@ -434,102 +434,6 @@
       Flap |-> 0
       Pot |-> 0
       Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Pot . file vow-file Vow ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Gem "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , GemJoin "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Vat . rely GemJoin "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" Flip "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Spot . init "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 1 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Flip "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Flip "gold" . rely End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , End . initGap "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . init ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
@@ -556,6 +460,136 @@
       Vow |-> 0 , 0 , GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Flap ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Pot . file vow-file Vow ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( Vow , Vat . hope Flap ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , GemJoin "gold" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . rely GemJoin "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" Flip "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Spot . init "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 1 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Flip "gold" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Flip "gold" . rely End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initGap "gold" ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0

--- a/tests/attacks/lucash-pot.random.mcd
+++ b/tests/attacks/lucash-pot.random.mcd
@@ -1,3 +1,4 @@
+STEPS ( DEPLOY-PRELUDE )
 STEPS ( ATTACK-PRELUDE )
 
 AddGenerator ( GenPotFileDSR

--- a/tests/attacks/lucash-pot.random.mcd.expected
+++ b/tests/attacks/lucash-pot.random.mcd.expected
@@ -195,7 +195,7 @@
             <gem-balances>
               "Alice" |-> 0
               "Bobby" |-> 0
-              Flap |-> 20
+              Flap |-> 0
               GemJoin "MKR" |-> 0
               Vow |-> 0
             </gem-balances>
@@ -599,16 +599,6 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
-      ListItem ( LogNote ( ADMIN , Gem "MKR" . mint Flap 20 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . file Line 1000000000000 ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
@@ -616,7 +606,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initIlk "gold" ) )
@@ -626,7 +616,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . file spot "gold" 3000000000 ) )
@@ -636,7 +626,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
@@ -646,7 +636,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vow . file bump 1000000000 ) )
@@ -656,7 +646,17 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Vow . file hump 0 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Alice" ) )
@@ -666,7 +666,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Bobby" ) )
@@ -676,7 +676,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Alice" 20 ) )
@@ -686,7 +686,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Bobby" 20 ) )
@@ -696,7 +696,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Alice" ) )
@@ -707,7 +707,7 @@
       Flap |-> 0
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Bobby" ) )
@@ -719,7 +719,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Pot . initUser "Alice" ) )
@@ -731,7 +731,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Pot . initUser "Bobby" ) )
@@ -743,7 +743,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser "Alice" ) )
@@ -757,7 +757,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Alice" ) )
@@ -771,7 +771,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Alice" ) )
@@ -785,7 +785,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser "Bobby" ) )
@@ -801,7 +801,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Bobby" ) )
@@ -817,7 +817,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Bobby" ) )
@@ -833,7 +833,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Alice" , Vat . hope Pot ) )
@@ -849,7 +849,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Alice" , Vat . hope Flip "gold" ) )
@@ -865,7 +865,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Alice" , Vat . hope End ) )
@@ -881,7 +881,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope Pot ) )
@@ -897,7 +897,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope Flip "gold" ) )
@@ -913,7 +913,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope End ) )
@@ -929,7 +929,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Alice" , Vat . slip "gold" "Alice" 10 ) )
@@ -947,7 +947,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 10 ) )
@@ -965,7 +965,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Alice" , Vat . frob "gold" "Alice" "Alice" "Alice" 10 10 ) )
@@ -981,7 +981,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
@@ -997,7 +997,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
@@ -1013,7 +1013,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
@@ -1029,7 +1029,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
@@ -1045,7 +1045,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
@@ -1061,7 +1061,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( GenStep ( b"aa" , transact ADMIN Pot . file dsr 1377 /Rat 1280 ) )
@@ -1078,7 +1078,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( GenStep ( b"aa" , TimeStep 2 ) )
@@ -1095,7 +1095,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( GenStep ( b"aa" , transact "Alice" Pot . join 485 /Rat 128 ) )
@@ -1115,7 +1115,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( GenStep ( b"a" , transact "Alice" Pot . exit 0 ) )
@@ -1133,7 +1133,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( Measure ( 20 , "Alice" |-> 10
@@ -1148,7 +1148,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
     </processed-events>

--- a/tests/attacks/lucash-pot.random.mcd.expected
+++ b/tests/attacks/lucash-pot.random.mcd.expected
@@ -317,7 +317,7 @@
             End |-> .Set
             Flap |-> .Set
             Pot |-> .Set
-            Vow |-> .Set
+            Vow |-> SetItem ( Flap )
           </vat-can>
           <vat-ilks>
             "gold" |-> Ilk ( 20 , 1 , 3000000000 , 1000000000000 , 0 )
@@ -434,102 +434,6 @@
       Flap |-> 0
       Pot |-> 0
       Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Pot . file vow-file Vow ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Gem "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , GemJoin "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Vat . rely GemJoin "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" Flip "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Spot . init "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 1 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Flip "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Flip "gold" . rely End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , End . initGap "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . init ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
@@ -556,6 +460,136 @@
       Vow |-> 0 , 0 , GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Flap ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Pot . file vow-file Vow ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( Vow , Vat . hope Flap ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , GemJoin "gold" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . rely GemJoin "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" Flip "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Spot . init "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 1 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Flip "gold" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Flip "gold" . rely End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initGap "gold" ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0

--- a/tests/fixes/debtBoundDSR.mcd
+++ b/tests/fixes/debtBoundDSR.mcd
@@ -1,3 +1,4 @@
+STEPS ( DEPLOY-PRELUDE )
 STEPS ( ATTACK-PRELUDE )
 
 transact "Bobby" Vat . move "Bobby" Pot 985 /Rat 128

--- a/tests/fixes/debtBoundDSR.mcd.expected
+++ b/tests/fixes/debtBoundDSR.mcd.expected
@@ -308,7 +308,7 @@
                 End |-> .Set
                 Flap |-> .Set
                 Pot |-> .Set
-                Vow |-> .Set
+                Vow |-> SetItem ( Flap )
               </vat-can>
               <vat-ilks>
                 "gold" |-> Ilk ( 20 , 1 , 3000000000 , 1000000000000 , 0 )
@@ -682,7 +682,7 @@
             End |-> .Set
             Flap |-> .Set
             Pot |-> .Set
-            Vow |-> .Set
+            Vow |-> SetItem ( Flap )
           </vat-can>
           <vat-ilks>
             "gold" |-> Ilk ( 20 , 1 , 3000000000 , 1000000000000 , 0 )
@@ -799,102 +799,6 @@
       Flap |-> 0
       Pot |-> 0
       Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Pot . file vow-file Vow ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Gem "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , GemJoin "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Vat . rely GemJoin "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" Flip "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Spot . init "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 1 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Flip "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Flip "gold" . rely End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , End . initGap "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . init ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
@@ -921,6 +825,136 @@
       Vow |-> 0 , 0 , GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Flap ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Pot . file vow-file Vow ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( Vow , Vat . hope Flap ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , GemJoin "gold" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . rely GemJoin "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" Flip "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Spot . init "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 1 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Flip "gold" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Flip "gold" . rely End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initGap "gold" ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0

--- a/tests/fixes/debtBoundDSR.mcd.expected
+++ b/tests/fixes/debtBoundDSR.mcd.expected
@@ -186,7 +186,7 @@
                 <gem-balances>
                   "Alice" |-> 0
                   "Bobby" |-> 0
-                  Flap |-> 20
+                  Flap |-> 0
                   GemJoin "MKR" |-> 0
                   Vow |-> 0
                 </gem-balances>
@@ -560,7 +560,7 @@
             <gem-balances>
               "Alice" |-> 0
               "Bobby" |-> 0
-              Flap |-> 20
+              Flap |-> 0
               GemJoin "MKR" |-> 0
               Vow |-> 0
             </gem-balances>
@@ -964,16 +964,6 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
-      ListItem ( LogNote ( ADMIN , Gem "MKR" . mint Flap 20 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . file Line 1000000000000 ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
@@ -981,7 +971,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initIlk "gold" ) )
@@ -991,7 +981,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . file spot "gold" 3000000000 ) )
@@ -1001,7 +991,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
@@ -1011,7 +1001,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vow . file bump 1000000000 ) )
@@ -1021,7 +1011,17 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Vow . file hump 0 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Alice" ) )
@@ -1031,7 +1031,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Bobby" ) )
@@ -1041,7 +1041,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Alice" 20 ) )
@@ -1051,7 +1051,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Bobby" 20 ) )
@@ -1061,7 +1061,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Alice" ) )
@@ -1072,7 +1072,7 @@
       Flap |-> 0
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Bobby" ) )
@@ -1084,7 +1084,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Pot . initUser "Alice" ) )
@@ -1096,7 +1096,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Pot . initUser "Bobby" ) )
@@ -1108,7 +1108,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser "Alice" ) )
@@ -1122,7 +1122,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Alice" ) )
@@ -1136,7 +1136,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Alice" ) )
@@ -1150,7 +1150,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser "Bobby" ) )
@@ -1166,7 +1166,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Bobby" ) )
@@ -1182,7 +1182,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Bobby" ) )
@@ -1198,7 +1198,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Alice" , Vat . hope Pot ) )
@@ -1214,7 +1214,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Alice" , Vat . hope Flip "gold" ) )
@@ -1230,7 +1230,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Alice" , Vat . hope End ) )
@@ -1246,7 +1246,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope Pot ) )
@@ -1262,7 +1262,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope Flip "gold" ) )
@@ -1278,7 +1278,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope End ) )
@@ -1294,7 +1294,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Alice" , Vat . slip "gold" "Alice" 10 ) )
@@ -1312,7 +1312,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 10 ) )
@@ -1330,7 +1330,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Alice" , Vat . frob "gold" "Alice" "Alice" "Alice" 10 10 ) )
@@ -1346,7 +1346,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
@@ -1362,7 +1362,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
@@ -1378,7 +1378,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
@@ -1394,7 +1394,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
@@ -1410,7 +1410,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
@@ -1426,7 +1426,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Bobby" , Vat . move "Bobby" Pot 985 /Rat 128 ) )
@@ -1442,7 +1442,7 @@
       Pot |-> 985 /Rat 128
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Pot . file dsr 9 /Rat 8 ) )
@@ -1458,7 +1458,7 @@
       Pot |-> 985 /Rat 128
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( TimeStep ( 1 , 1 ) )
@@ -1474,7 +1474,7 @@
       Pot |-> 985 /Rat 128
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . cage ) )
@@ -1498,13 +1498,13 @@
       Pot |-> 985 /Rat 128
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
     </processed-events>
     <properties>
       "Debt Constant After Thaw" |-> debtConstantAfterThaw
-      "Flap Dai Consistency" |-> flapDaiConsistency
+      "Flap Dai Consistency" |-> flapDaiConsistencyEnd
       "Flap MKR Consistency" |-> flapMkrConsistency
       "Pot Interest Accumulation After End" |-> potEndInterestEnd
       "PotChi PotPie VatPot" |-> potChiPieDai ( 985 /Rat 128 , 0 )

--- a/tests/fixes/potChiPieDai.mcd
+++ b/tests/fixes/potChiPieDai.mcd
@@ -1,3 +1,4 @@
+STEPS ( DEPLOY-PRELUDE )
 STEPS ( ATTACK-PRELUDE )
 
 transact ADMIN Pot . file dsr 23 /Rat 20

--- a/tests/fixes/potChiPieDai.mcd.expected
+++ b/tests/fixes/potChiPieDai.mcd.expected
@@ -195,7 +195,7 @@
             <gem-balances>
               "Alice" |-> 0
               "Bobby" |-> 0
-              Flap |-> 20
+              Flap |-> 0
               GemJoin "MKR" |-> 0
               Vow |-> 0
             </gem-balances>
@@ -599,16 +599,6 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
-      ListItem ( LogNote ( ADMIN , Gem "MKR" . mint Flap 20 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . file Line 1000000000000 ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
@@ -616,7 +606,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initIlk "gold" ) )
@@ -626,7 +616,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . file spot "gold" 3000000000 ) )
@@ -636,7 +626,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
@@ -646,7 +636,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vow . file bump 1000000000 ) )
@@ -656,7 +646,17 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Vow . file hump 0 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Alice" ) )
@@ -666,7 +666,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Bobby" ) )
@@ -676,7 +676,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Alice" 20 ) )
@@ -686,7 +686,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Bobby" 20 ) )
@@ -696,7 +696,7 @@
       Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 20
+      Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Alice" ) )
@@ -707,7 +707,7 @@
       Flap |-> 0
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Bobby" ) )
@@ -719,7 +719,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Pot . initUser "Alice" ) )
@@ -731,7 +731,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Pot . initUser "Bobby" ) )
@@ -743,7 +743,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser "Alice" ) )
@@ -757,7 +757,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Alice" ) )
@@ -771,7 +771,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Alice" ) )
@@ -785,7 +785,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser "Bobby" ) )
@@ -801,7 +801,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Bobby" ) )
@@ -817,7 +817,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Bobby" ) )
@@ -833,7 +833,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Alice" , Vat . hope Pot ) )
@@ -849,7 +849,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Alice" , Vat . hope Flip "gold" ) )
@@ -865,7 +865,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Alice" , Vat . hope End ) )
@@ -881,7 +881,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope Pot ) )
@@ -897,7 +897,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope Flip "gold" ) )
@@ -913,7 +913,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope End ) )
@@ -929,7 +929,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Alice" , Vat . slip "gold" "Alice" 10 ) )
@@ -947,7 +947,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 10 ) )
@@ -965,7 +965,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Alice" , Vat . frob "gold" "Alice" "Alice" "Alice" 10 10 ) )
@@ -981,7 +981,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
@@ -997,7 +997,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
@@ -1013,7 +1013,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
@@ -1029,7 +1029,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
@@ -1045,7 +1045,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
@@ -1061,7 +1061,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Pot . file dsr 23 /Rat 20 ) )
@@ -1077,7 +1077,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( TimeStep ( 1 , 1 ) )
@@ -1093,7 +1093,7 @@
       Pot |-> 0
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( "Bobby" , Vat . move "Bobby" Pot 495 /Rat 64 ) )
@@ -1109,7 +1109,7 @@
       Pot |-> 495 /Rat 64
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( Measure ( 20 , "Alice" |-> 10
@@ -1124,7 +1124,7 @@
       Pot |-> 495 /Rat 64
       Vow |-> 0 , 0 , "Alice" |-> 0
       "Bobby" |-> 0
-      Flap |-> 20
+      Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
     </processed-events>

--- a/tests/fixes/potChiPieDai.mcd.expected
+++ b/tests/fixes/potChiPieDai.mcd.expected
@@ -317,7 +317,7 @@
             End |-> .Set
             Flap |-> .Set
             Pot |-> .Set
-            Vow |-> .Set
+            Vow |-> SetItem ( Flap )
           </vat-can>
           <vat-ilks>
             "gold" |-> Ilk ( 20 , 1 , 3000000000 , 1000000000000 , 0 )
@@ -434,102 +434,6 @@
       Flap |-> 0
       Pot |-> 0
       Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Pot . file vow-file Vow ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Gem "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , GemJoin "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Vat . rely GemJoin "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" Flip "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Spot . init "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 1 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Flip "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , Flip "gold" . rely End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
-      ListItem ( LogNote ( ADMIN , End . initGap "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . init ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
@@ -556,6 +460,136 @@
       Vow |-> 0 , 0 , GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Flap ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Pot . file vow-file Vow ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( Vow , Vat . hope Flap ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , GemJoin "gold" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . rely GemJoin "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initGem "gold" Flip "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Spot . init "gold" ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 1 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Flip "gold" . init ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Flip "gold" . rely End ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , End . initGap "gold" ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0


### PR DESCRIPTION
Separates out "generic, immutable system configuration" in a `DEPLOY_PRELUDE` distinct from the `ATTACK_PRELUDE` rule.

Modifies the `lucash-flap-end` attack in such a way that it can be detected by the `flapMkrConsistency` property, with a couple small tweaks to harmonize the other properties with the new approach.