### PR TITLE
Id solidity test output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /.build
 /tests/*/*.out
 /tests/*/*.python-out
+/kserver.log
+/random-test.out

--- a/mcd-pyk.py
+++ b/mcd-pyk.py
@@ -333,8 +333,11 @@ if __name__ == '__main__':
                 print(printMCD(violation['output']))
             if emitSol:
                 print('\n### Solidity')
+                print('#### ID:'+str(i))
                 print('------------')
                 print('    ' + '\n    '.join(extractTrace(output)))
+                print('\n------------')
+                print('### /Solidity')
             sys.stdout.flush()
     stopTime = time.time()
 


### PR DESCRIPTION
I found in the python where the header and other output where and updated them to better distinguish and id each test. 

After messing with the random seed bytearray for a bit, i decided that the `i` would be sufficient for identifying which `random-test.out` run was responsible for generating which solidity test.

let me know if either of you have a better idea how to structure this.