### PR TITLE
variablize solidty and assertions to avoid naming conflicts

### DIFF
--- a/mcd-pyk.py
+++ b/mcd-pyk.py
@@ -220,14 +220,31 @@ def detect_violations(config):
 # Solidity Generation
 # -------------------
 
+def variablize(input):
+    return input.replace('Alice', 'alice')          \
+                .replace('Bobby', 'bobby')          \
+                .replace('ADMIN', 'admin')          \
+                .replace('ANYONE', 'anyone')        \
+                .replace('Vat', 'vat')              \
+                .replace('Vow', 'vow')              \
+                .replace('Cat', 'cat')              \
+                .replace('Pot', 'pot')              \
+                .replace('Flap', 'flap')             \
+                .replace('Flop', 'flop')             \
+                .replace('End', 'end')              \
+                .replace('Spot', 'spotter')         \
+                .replace('Flip_gold', 'goldFlip')   \
+                .replace('GemJoin_gold', 'goldJoin')
+
 def solidify(input):
-    return input.replace(' ', '_').replace('"', '')
+    return variablize(input.replace(' ', '_').replace('"', ''))
+
 
 def argify(arg):
     newArg = solidify(arg)
-    if    newArg in ['Alice', 'Bobby', 'ADMIN', 'ANYONE']                                     \
-       or newArg in ['Cat', 'Dai', 'End', 'Flap', 'Flop', 'Jug', 'Pot', 'Spot', 'Vat', 'Vow'] \
-       or newArg.startswith('Flip_') or newArg.startswith('Gem_') or newArg.startswith('GemJoin_'):
+    if    newArg in ['alice', 'bobby', 'admin', 'anyone']                                      \
+       or newArg in ['cat', 'dai', 'end', 'flap', 'flop', 'jug', 'pot', 'spotter', 'vat', 'vow'] \
+       or newArg.endswith('Flip') or newArg.endswith('Join'):
         newArg = 'address(' + newArg + ')'
     if newArg in ['gold']:
         newArg = '"' + newArg + '"'
@@ -292,7 +309,7 @@ def buildAssert(contract, field, value):
         if value['token'] == 'true':
             comparator = '=/='
     expected = printMCD(value)
-    return 'assertTrue( ' + actual + ' ' + comparator + ' ' + expected + ' );'
+    return variablize('assertTrue( ' + actual + ' ' + comparator + ' ' + expected + ' );')
 
 def extractAsserts(config):
     (_, subst) = pyk.splitConfigFrom(config)

--- a/mcd-pyk.py
+++ b/mcd-pyk.py
@@ -229,8 +229,8 @@ def variablize(input):
                 .replace('Vow', 'vow')              \
                 .replace('Cat', 'cat')              \
                 .replace('Pot', 'pot')              \
-                .replace('Flap', 'flap')             \
-                .replace('Flop', 'flop')             \
+                .replace('Flap', 'flap')            \
+                .replace('Flop', 'flop')            \
                 .replace('End', 'end')              \
                 .replace('Spot', 'spotter')         \
                 .replace('Flip_gold', 'goldFlip')   \


### PR DESCRIPTION
Doing some brute find and replace to eliminate variable naming conflicts in the solidity tests.

Current example output:

```
### Solidity
#### ID:2
------------

    // Test Run
    admin.vat_rely(address(goldJoin));
    admin.spotter_setPrice("gold", 1);
    admin.goldFlip_rely(address(end));
    admin.vat_file("Line", 1000000000000);
    admin.vat_file("spot", "gold", 3000000000);
    admin.vat_file("line", "gold", 1000000000000);
    admin.vow_file("bump", 1000000000);
    admin.vow_file("hump", 0);
    admin.Gem_gold_mint(address(alice), 20);
    admin.Gem_gold_mint(address(bobby), 20);
    alice.vat_hope(address(pot));
    alice.vat_hope(address(goldFlip));
    alice.vat_hope(address(end));
    bobby.vat_hope(address(pot));
    bobby.vat_hope(address(goldFlip));
    bobby.vat_hope(address(end));
    alice.goldJoin_join(address(alice), 10);
    bobby.goldJoin_join(address(bobby), 10);
    alice.vat_frob("gold", address(alice), address(alice), address(alice), 10, 10);
    bobby.vat_frob("gold", address(bobby), address(bobby), address(bobby), 10, 10);
    alice.vat_move(address(alice), address(alice), 575_/Rat_64);
    admin.pot_file("dsr", 1489_/Rat_1280);
    hevm.warp(2);
    alice.vat_hope(address(alice));
    hevm.warp(1);
    hevm.warp(1);

    // Assertions
    assertTrue( pot.dsr() == 1489 /Rat 1280 );
    assertTrue( vat.can() == "bobby" |-> SetItem( Flip "gold" )
SetItem( pot )
SetItem( end )
"alice" |-> SetItem( Flip "gold" )
SetItem( "alice" )
SetItem( pot )
SetItem( end ) );

------------
### /Solidity
```

I didn't mess too much with the `assert` section since we still need a bigger PR to deal with the `SetItem` and other mapping state changes.