### PR TITLE
Init spot with mat

### DIFF
--- a/kmcd-prelude.md
+++ b/kmcd-prelude.md
@@ -19,9 +19,10 @@ module KMCD-PRELUDE
          // Contract Authorizations
          // -----------------------
 
-         // Auhthorize Pot/End for Vat
+         // Auhthorize Pot/End/Spot for Vat
          transact ADMIN Vat . rely Pot
          transact ADMIN Vat . rely End
+         transact ADMIN Vat . rely Spot
 
          // Authorize End for Pot
          transact ADMIN Pot . rely End
@@ -88,8 +89,9 @@ module KMCD-PRELUDE
 
          // Initialize Spot for gold
          transact ADMIN Spot . init     "gold"
-         transact ADMIN Spot . setPrice "gold" 1
-         transact ADMIN Spot . setMat   "gold" 1
+         transact ADMIN Spot . setPrice "gold" 3 ether
+         transact ADMIN Spot . file       mat "gold" 1
+         transact ADMIN Spot . file       par 1
 
          // Initialize Flipper for gold
          transact ADMIN Flip "gold" . init
@@ -104,8 +106,9 @@ module KMCD-PRELUDE
          // Setup Vat
          transact ADMIN Vat . file Line 1000 ether
          transact ADMIN Vat . initIlk "gold"
-         transact ADMIN Vat . file spot "gold" 3 ether
          transact ADMIN Vat . file line "gold" 1000 ether
+
+         transact ANYONE Spot . poke "gold"
 
          // Setup Vow
          transact ADMIN Vow . file bump 1 ether

--- a/kmcd-prelude.md
+++ b/kmcd-prelude.md
@@ -89,6 +89,7 @@ module KMCD-PRELUDE
          // Initialize Spot for gold
          transact ADMIN Spot . init     "gold"
          transact ADMIN Spot . setPrice "gold" 1
+         transact ADMIN Spot . setMat   "gold" 1
 
          // Initialize Flipper for gold
          transact ADMIN Flip "gold" . init

--- a/spot.md
+++ b/spot.md
@@ -112,13 +112,17 @@ Because data isn't explicitely initialized to 0 in KMCD, we need explicit initia
 ```k
     syntax SpotAuthStep ::= "init"     String
                           | "setPrice" String Wad
+                          | "setMat"   String Ray
  // ---------------------------------------------
     rule <k> Spot . init ILKID => . ... </k>
-         <spot-ilks> ILKS => ILKS [ ILKID <- SpotIlk( ... pip: .Wad , mat: 1 ) ] </spot-ilks>
+         <spot-ilks> ILKS => ILKS [ ILKID <- SpotIlk( ... pip: .Wad, mat: 1 ) ] </spot-ilks>
       requires notBool ILKID in_keys(ILKS)
 
     rule <k> Spot . setPrice ILKID PRICE => . ... </k>
          <spot-ilks> ... ILKID |-> SpotIlk( ... pip: (_ => PRICE) ) ... </spot-ilks>
+
+   rule <k> Spot . setMat ILKID MAT => . ... </k>
+         <spot-ilks> ... ILKID |-> SpotIlk( ... mat: (_ => MAT) ) ... </spot-ilks>
 ```
 
 Spot Semantics

--- a/spot.md
+++ b/spot.md
@@ -115,7 +115,7 @@ Because data isn't explicitely initialized to 0 in KMCD, we need explicit initia
                           | "setMat"   String Ray
  // ---------------------------------------------
     rule <k> Spot . init ILKID => . ... </k>
-         <spot-ilks> ILKS => ILKS [ ILKID <- SpotIlk( ... pip: .Wad, mat: 1 ) ] </spot-ilks>
+         <spot-ilks> ILKS => ILKS [ ILKID <- SpotIlk( ... pip: .Wad, mat: 0 ) ] </spot-ilks>
       requires notBool ILKID in_keys(ILKS)
 
     rule <k> Spot . setPrice ILKID PRICE => . ... </k>

--- a/spot.md
+++ b/spot.md
@@ -108,12 +108,10 @@ Because data isn't explicitely initialized to 0 in KMCD, we need explicit initia
 
 -   `init`: Initialize the spotter for a given ilk.
 -   `setPrice`: Manually inject a value for the price feed of a given ilk.
--   `setMat`: Manually inject a value for the collateralization ratio of a given ilk.
 
 ```k
     syntax SpotAuthStep ::= "init"     String
                           | "setPrice" String Wad
-                          | "setMat"   String Ray
  // ---------------------------------------------
     rule <k> Spot . init ILKID => . ... </k>
          <spot-ilks> ILKS => ILKS [ ILKID <- SpotIlk( ... pip: .Wad, mat: 0 ) ] </spot-ilks>
@@ -121,9 +119,6 @@ Because data isn't explicitely initialized to 0 in KMCD, we need explicit initia
 
     rule <k> Spot . setPrice ILKID PRICE => . ... </k>
          <spot-ilks> ... ILKID |-> SpotIlk( ... pip: (_ => PRICE) ) ... </spot-ilks>
-
-   rule <k> Spot . setMat ILKID MAT => . ... </k>
-         <spot-ilks> ... ILKID |-> SpotIlk( ... mat: (_ => MAT) ) ... </spot-ilks>
 ```
 
 Spot Semantics

--- a/spot.md
+++ b/spot.md
@@ -108,6 +108,7 @@ Because data isn't explicitely initialized to 0 in KMCD, we need explicit initia
 
 -   `init`: Initialize the spotter for a given ilk.
 -   `setPrice`: Manually inject a value for the price feed of a given ilk.
+-   `setMat`: Manually inject a value for the collateralization ratio of a given ilk.
 
 ```k
     syntax SpotAuthStep ::= "init"     String

--- a/tests/attacks/lucash-flap-end.mcd.expected
+++ b/tests/attacks/lucash-flap-end.mcd.expected
@@ -292,7 +292,7 @@
             .Set
           </spot-wards>
           <spot-ilks>
-            "gold" |-> SpotIlk ( 1 , 1 )
+            "gold" |-> SpotIlk ( 3000000000 , 1 )
           </spot-ilks>
           <spot-par>
             1
@@ -306,6 +306,7 @@
             SetItem ( End )
             SetItem ( GemJoin "gold" )
             SetItem ( Pot )
+            SetItem ( Spot )
           </vat-wards>
           <vat-can>
             "Alice" |-> SetItem ( End )
@@ -402,6 +403,8 @@
       ListItem ( LogNote ( ADMIN , Vat . rely Pot ) )
       ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map ) )
       ListItem ( LogNote ( ADMIN , Vat . rely End ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map ) )
+      ListItem ( LogNote ( ADMIN , Vat . rely Spot ) )
       ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map ) )
       ListItem ( LogNote ( ADMIN , Pot . rely End ) )
       ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map ) )
@@ -560,7 +563,7 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
-      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 1 ) )
+      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 3000000000 ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
@@ -570,7 +573,17 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
-      ListItem ( LogNote ( ADMIN , Spot . setMat "gold" 1 ) )
+      ListItem ( LogNote ( ADMIN , Spot . file mat "gold" 1 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Spot . file par 1 ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
@@ -630,7 +643,7 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
-      ListItem ( LogNote ( ADMIN , Vat . file spot "gold" 3000000000 ) )
+      ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
@@ -640,7 +653,8 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
-      ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
+      ListItem ( LogNote ( ANYONE , Vat . file spot "gold" 3000000000 ) )
+      ListItem ( Poke ( "gold" , 3000000000 , 3000000000 ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0

--- a/tests/attacks/lucash-flap-end.mcd.expected
+++ b/tests/attacks/lucash-flap-end.mcd.expected
@@ -570,6 +570,16 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Spot . setMat "gold" 1 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Flip "gold" . init ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0

--- a/tests/attacks/lucash-flap-end.random.mcd.expected
+++ b/tests/attacks/lucash-flap-end.random.mcd.expected
@@ -292,7 +292,7 @@
             .Set
           </spot-wards>
           <spot-ilks>
-            "gold" |-> SpotIlk ( 1 , 1 )
+            "gold" |-> SpotIlk ( 3000000000 , 1 )
           </spot-ilks>
           <spot-par>
             1
@@ -306,6 +306,7 @@
             SetItem ( End )
             SetItem ( GemJoin "gold" )
             SetItem ( Pot )
+            SetItem ( Spot )
           </vat-wards>
           <vat-can>
             "Alice" |-> SetItem ( End )
@@ -402,6 +403,8 @@
       ListItem ( LogNote ( ADMIN , Vat . rely Pot ) )
       ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map ) )
       ListItem ( LogNote ( ADMIN , Vat . rely End ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map ) )
+      ListItem ( LogNote ( ADMIN , Vat . rely Spot ) )
       ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map ) )
       ListItem ( LogNote ( ADMIN , Pot . rely End ) )
       ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map ) )
@@ -560,7 +563,7 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
-      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 1 ) )
+      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 3000000000 ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
@@ -570,7 +573,17 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
-      ListItem ( LogNote ( ADMIN , Spot . setMat "gold" 1 ) )
+      ListItem ( LogNote ( ADMIN , Spot . file mat "gold" 1 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Spot . file par 1 ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
@@ -630,7 +643,7 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
-      ListItem ( LogNote ( ADMIN , Vat . file spot "gold" 3000000000 ) )
+      ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
@@ -640,7 +653,8 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
-      ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
+      ListItem ( LogNote ( ANYONE , Vat . file spot "gold" 3000000000 ) )
+      ListItem ( Poke ( "gold" , 3000000000 , 3000000000 ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0

--- a/tests/attacks/lucash-flap-end.random.mcd.expected
+++ b/tests/attacks/lucash-flap-end.random.mcd.expected
@@ -570,6 +570,16 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Spot . setMat "gold" 1 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Flip "gold" . init ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0

--- a/tests/attacks/lucash-flip-end.mcd.expected
+++ b/tests/attacks/lucash-flip-end.mcd.expected
@@ -86,7 +86,7 @@
               20
             </end-debt>
             <end-tag>
-              "gold" |-> 1
+              "gold" |-> 1 /Rat 3000000000
             </end-tag>
             <end-gap>
               "gold" |-> 0
@@ -95,7 +95,7 @@
               "gold" |-> 20
             </end-art>
             <end-fix>
-              "gold" |-> 1
+              "gold" |-> 1 /Rat 3000000000
             </end-fix>
             <end-bag>
               "Alice" |-> 0
@@ -292,7 +292,7 @@
             .Set
           </spot-wards>
           <spot-ilks>
-            "gold" |-> SpotIlk ( 1 , 1 )
+            "gold" |-> SpotIlk ( 3000000000 , 1 )
           </spot-ilks>
           <spot-par>
             1
@@ -306,6 +306,7 @@
             SetItem ( End )
             SetItem ( GemJoin "gold" )
             SetItem ( Pot )
+            SetItem ( Spot )
           </vat-wards>
           <vat-can>
             "Alice" |-> SetItem ( End )
@@ -401,6 +402,8 @@
       ListItem ( LogNote ( ADMIN , Vat . rely Pot ) )
       ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map ) )
       ListItem ( LogNote ( ADMIN , Vat . rely End ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map ) )
+      ListItem ( LogNote ( ADMIN , Vat . rely Spot ) )
       ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map ) )
       ListItem ( LogNote ( ADMIN , Pot . rely End ) )
       ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map ) )
@@ -559,7 +562,7 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
-      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 1 ) )
+      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 3000000000 ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
@@ -569,7 +572,17 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
-      ListItem ( LogNote ( ADMIN , Spot . setMat "gold" 1 ) )
+      ListItem ( LogNote ( ADMIN , Spot . file mat "gold" 1 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Spot . file par 1 ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
@@ -629,7 +642,7 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
-      ListItem ( LogNote ( ADMIN , Vat . file spot "gold" 3000000000 ) )
+      ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
@@ -639,7 +652,8 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
-      ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
+      ListItem ( LogNote ( ANYONE , Vat . file spot "gold" 3000000000 ) )
+      ListItem ( Poke ( "gold" , 3000000000 , 3000000000 ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0

--- a/tests/attacks/lucash-flip-end.mcd.expected
+++ b/tests/attacks/lucash-flip-end.mcd.expected
@@ -569,6 +569,16 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Spot . setMat "gold" 1 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Flip "gold" . init ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0

--- a/tests/attacks/lucash-flip-end.random.mcd.expected
+++ b/tests/attacks/lucash-flip-end.random.mcd.expected
@@ -86,7 +86,7 @@
               20
             </end-debt>
             <end-tag>
-              "gold" |-> 1
+              "gold" |-> 1 /Rat 3000000000
             </end-tag>
             <end-gap>
               "gold" |-> 0
@@ -95,7 +95,7 @@
               "gold" |-> 20
             </end-art>
             <end-fix>
-              "gold" |-> 1
+              "gold" |-> 1 /Rat 3000000000
             </end-fix>
             <end-bag>
               "Alice" |-> 0
@@ -292,7 +292,7 @@
             .Set
           </spot-wards>
           <spot-ilks>
-            "gold" |-> SpotIlk ( 1 , 1 )
+            "gold" |-> SpotIlk ( 3000000000 , 1 )
           </spot-ilks>
           <spot-par>
             1
@@ -306,6 +306,7 @@
             SetItem ( End )
             SetItem ( GemJoin "gold" )
             SetItem ( Pot )
+            SetItem ( Spot )
           </vat-wards>
           <vat-can>
             "Alice" |-> SetItem ( End )
@@ -401,6 +402,8 @@
       ListItem ( LogNote ( ADMIN , Vat . rely Pot ) )
       ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map ) )
       ListItem ( LogNote ( ADMIN , Vat . rely End ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map ) )
+      ListItem ( LogNote ( ADMIN , Vat . rely Spot ) )
       ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map ) )
       ListItem ( LogNote ( ADMIN , Pot . rely End ) )
       ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map ) )
@@ -559,7 +562,7 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
-      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 1 ) )
+      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 3000000000 ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
@@ -569,7 +572,17 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
-      ListItem ( LogNote ( ADMIN , Spot . setMat "gold" 1 ) )
+      ListItem ( LogNote ( ADMIN , Spot . file mat "gold" 1 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Spot . file par 1 ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0

--- a/tests/attacks/lucash-flip-end.random.mcd.expected
+++ b/tests/attacks/lucash-flip-end.random.mcd.expected
@@ -642,7 +642,7 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
-      ListItem ( LogNote ( ADMIN , Vat . file spot "gold" 3000000000 ) )
+      ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
@@ -652,7 +652,8 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
-      ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
+      ListItem ( LogNote ( ANYONE , Vat . file spot "gold" 3000000000 ) )
+      ListItem ( Poke ( "gold" , 3000000000 , 3000000000 ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0

--- a/tests/attacks/lucash-flip-end.random.mcd.expected
+++ b/tests/attacks/lucash-flip-end.random.mcd.expected
@@ -569,6 +569,16 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Spot . setMat "gold" 1 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Flip "gold" . init ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0

--- a/tests/attacks/lucash-pot-end.mcd.expected
+++ b/tests/attacks/lucash-pot-end.mcd.expected
@@ -86,7 +86,7 @@
               20
             </end-debt>
             <end-tag>
-              "gold" |-> 1
+              "gold" |-> 1 /Rat 3000000000
             </end-tag>
             <end-gap>
               "gold" |-> 0
@@ -95,7 +95,7 @@
               "gold" |-> 20
             </end-art>
             <end-fix>
-              "gold" |-> 1
+              "gold" |-> 1 /Rat 3000000000
             </end-fix>
             <end-bag>
               "Alice" |-> 0
@@ -292,7 +292,7 @@
             .Set
           </spot-wards>
           <spot-ilks>
-            "gold" |-> SpotIlk ( 1 , 1 )
+            "gold" |-> SpotIlk ( 3000000000 , 1 )
           </spot-ilks>
           <spot-par>
             1
@@ -306,6 +306,7 @@
             SetItem ( End )
             SetItem ( GemJoin "gold" )
             SetItem ( Pot )
+            SetItem ( Spot )
           </vat-wards>
           <vat-can>
             "Alice" |-> SetItem ( End )
@@ -401,6 +402,8 @@
       ListItem ( LogNote ( ADMIN , Vat . rely Pot ) )
       ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map ) )
       ListItem ( LogNote ( ADMIN , Vat . rely End ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map ) )
+      ListItem ( LogNote ( ADMIN , Vat . rely Spot ) )
       ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map ) )
       ListItem ( LogNote ( ADMIN , Pot . rely End ) )
       ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map ) )
@@ -559,7 +562,7 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
-      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 1 ) )
+      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 3000000000 ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
@@ -569,7 +572,17 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
-      ListItem ( LogNote ( ADMIN , Spot . setMat "gold" 1 ) )
+      ListItem ( LogNote ( ADMIN , Spot . file mat "gold" 1 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Spot . file par 1 ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0

--- a/tests/attacks/lucash-pot-end.mcd.expected
+++ b/tests/attacks/lucash-pot-end.mcd.expected
@@ -324,14 +324,14 @@
             "gold" |-> Ilk ( 0 , 1 , 3000000000 , 1000000000000 , 0 )
           </vat-ilks>
           <vat-urns>
-            { "gold" , "Alice" } |-> Urn ( 0 , 0 )
-            { "gold" , "Bobby" } |-> Urn ( 0 , 0 )
+            { "gold" , "Alice" } |-> Urn ( 2999999999 /Rat 300000000 , 0 )
+            { "gold" , "Bobby" } |-> Urn ( 2999999999 /Rat 300000000 , 0 )
             { "gold" , End } |-> Urn ( 0 , 0 )
           </vat-urns>
           <vat-gem>
             { "gold" , "Alice" } |-> 0
             { "gold" , "Bobby" } |-> 0
-            { "gold" , End } |-> 20
+            { "gold" , End } |-> 1 /Rat 150000000
             { "gold" , Flip "gold" } |-> 0
           </vat-gem>
           <vat-dai>
@@ -642,7 +642,7 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
-      ListItem ( LogNote ( ADMIN , Vat . file spot "gold" 3000000000 ) )
+      ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
@@ -652,7 +652,8 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
-      ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
+      ListItem ( LogNote ( ANYONE , Vat . file spot "gold" 3000000000 ) )
+      ListItem ( Poke ( "gold" , 3000000000 , 3000000000 ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
@@ -1127,7 +1128,7 @@
       Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
-      ListItem ( LogNote ( ADMIN , Vat . grab "gold" "Alice" End Vow -10 -10 ) )
+      ListItem ( LogNote ( ADMIN , Vat . grab "gold" "Alice" End Vow -1 /Rat 300000000 -10 ) )
       ListItem ( LogNote ( ADMIN , End . skim "gold" "Alice" ) )
       ListItem ( Measure ( 20 , "Alice" |-> 10
       "Bobby" |-> 10
@@ -1144,7 +1145,7 @@
       Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
-      ListItem ( LogNote ( ADMIN , Vat . grab "gold" "Bobby" End Vow -10 -10 ) )
+      ListItem ( LogNote ( ADMIN , Vat . grab "gold" "Bobby" End Vow -1 /Rat 300000000 -10 ) )
       ListItem ( LogNote ( ADMIN , End . skim "gold" "Bobby" ) )
       ListItem ( Measure ( 20 , "Alice" |-> 10
       "Bobby" |-> 10

--- a/tests/attacks/lucash-pot-end.mcd.expected
+++ b/tests/attacks/lucash-pot-end.mcd.expected
@@ -569,6 +569,16 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Spot . setMat "gold" 1 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Flip "gold" . init ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0

--- a/tests/attacks/lucash-pot-end.random.mcd.expected
+++ b/tests/attacks/lucash-pot-end.random.mcd.expected
@@ -86,7 +86,7 @@
               20
             </end-debt>
             <end-tag>
-              "gold" |-> 1
+              "gold" |-> 1 /Rat 3000000000
             </end-tag>
             <end-gap>
               "gold" |-> 0
@@ -95,7 +95,7 @@
               "gold" |-> 20
             </end-art>
             <end-fix>
-              "gold" |-> 1
+              "gold" |-> 1 /Rat 3000000000
             </end-fix>
             <end-bag>
               "Alice" |-> 0
@@ -292,7 +292,7 @@
             .Set
           </spot-wards>
           <spot-ilks>
-            "gold" |-> SpotIlk ( 1 , 1 )
+            "gold" |-> SpotIlk ( 3000000000 , 1 )
           </spot-ilks>
           <spot-par>
             1
@@ -306,6 +306,7 @@
             SetItem ( End )
             SetItem ( GemJoin "gold" )
             SetItem ( Pot )
+            SetItem ( Spot )
           </vat-wards>
           <vat-can>
             "Alice" |-> SetItem ( End )
@@ -401,6 +402,8 @@
       ListItem ( LogNote ( ADMIN , Vat . rely Pot ) )
       ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map ) )
       ListItem ( LogNote ( ADMIN , Vat . rely End ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map ) )
+      ListItem ( LogNote ( ADMIN , Vat . rely Spot ) )
       ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map ) )
       ListItem ( LogNote ( ADMIN , Pot . rely End ) )
       ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map ) )
@@ -559,7 +562,7 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
-      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 1 ) )
+      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 3000000000 ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
@@ -569,7 +572,17 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
-      ListItem ( LogNote ( ADMIN , Spot . setMat "gold" 1 ) )
+      ListItem ( LogNote ( ADMIN , Spot . file mat "gold" 1 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Spot . file par 1 ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0

--- a/tests/attacks/lucash-pot-end.random.mcd.expected
+++ b/tests/attacks/lucash-pot-end.random.mcd.expected
@@ -324,14 +324,14 @@
             "gold" |-> Ilk ( 0 , 1 , 3000000000 , 1000000000000 , 0 )
           </vat-ilks>
           <vat-urns>
-            { "gold" , "Alice" } |-> Urn ( 0 , 0 )
-            { "gold" , "Bobby" } |-> Urn ( 0 , 0 )
+            { "gold" , "Alice" } |-> Urn ( 2999999999 /Rat 300000000 , 0 )
+            { "gold" , "Bobby" } |-> Urn ( 2999999999 /Rat 300000000 , 0 )
             { "gold" , End } |-> Urn ( 0 , 0 )
           </vat-urns>
           <vat-gem>
             { "gold" , "Alice" } |-> 0
             { "gold" , "Bobby" } |-> 0
-            { "gold" , End } |-> 20
+            { "gold" , End } |-> 1 /Rat 150000000
             { "gold" , Flip "gold" } |-> 0
           </vat-gem>
           <vat-dai>
@@ -642,7 +642,7 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
-      ListItem ( LogNote ( ADMIN , Vat . file spot "gold" 3000000000 ) )
+      ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
@@ -652,7 +652,8 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
-      ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
+      ListItem ( LogNote ( ANYONE , Vat . file spot "gold" 3000000000 ) )
+      ListItem ( Poke ( "gold" , 3000000000 , 3000000000 ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
@@ -1130,7 +1131,7 @@
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( GenStep ( b"d" , transact ANYONE End . skim "gold" "Alice" ) )
-      ListItem ( LogNote ( ANYONE , Vat . grab "gold" "Alice" End Vow -10 -10 ) )
+      ListItem ( LogNote ( ANYONE , Vat . grab "gold" "Alice" End Vow -1 /Rat 300000000 -10 ) )
       ListItem ( LogNote ( ANYONE , End . skim "gold" "Alice" ) )
       ListItem ( Measure ( 20 , "Alice" |-> 10
       "Bobby" |-> 10
@@ -1148,7 +1149,7 @@
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
       ListItem ( GenStep ( b"d" , transact ANYONE End . skim "gold" "Bobby" ) )
-      ListItem ( LogNote ( ANYONE , Vat . grab "gold" "Bobby" End Vow -10 -10 ) )
+      ListItem ( LogNote ( ANYONE , Vat . grab "gold" "Bobby" End Vow -1 /Rat 300000000 -10 ) )
       ListItem ( LogNote ( ANYONE , End . skim "gold" "Bobby" ) )
       ListItem ( Measure ( 20 , "Alice" |-> 10
       "Bobby" |-> 10

--- a/tests/attacks/lucash-pot-end.random.mcd.expected
+++ b/tests/attacks/lucash-pot-end.random.mcd.expected
@@ -569,6 +569,16 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Spot . setMat "gold" 1 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Flip "gold" . init ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0

--- a/tests/attacks/lucash-pot.mcd.expected
+++ b/tests/attacks/lucash-pot.mcd.expected
@@ -292,7 +292,7 @@
             .Set
           </spot-wards>
           <spot-ilks>
-            "gold" |-> SpotIlk ( 1 , 1 )
+            "gold" |-> SpotIlk ( 3000000000 , 1 )
           </spot-ilks>
           <spot-par>
             1
@@ -306,6 +306,7 @@
             SetItem ( End )
             SetItem ( GemJoin "gold" )
             SetItem ( Pot )
+            SetItem ( Spot )
           </vat-wards>
           <vat-can>
             "Alice" |-> SetItem ( End )
@@ -401,6 +402,8 @@
       ListItem ( LogNote ( ADMIN , Vat . rely Pot ) )
       ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map ) )
       ListItem ( LogNote ( ADMIN , Vat . rely End ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map ) )
+      ListItem ( LogNote ( ADMIN , Vat . rely Spot ) )
       ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map ) )
       ListItem ( LogNote ( ADMIN , Pot . rely End ) )
       ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map ) )
@@ -559,7 +562,7 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
-      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 1 ) )
+      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 3000000000 ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
@@ -569,7 +572,17 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
-      ListItem ( LogNote ( ADMIN , Spot . setMat "gold" 1 ) )
+      ListItem ( LogNote ( ADMIN , Spot . file mat "gold" 1 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Spot . file par 1 ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0

--- a/tests/attacks/lucash-pot.mcd.expected
+++ b/tests/attacks/lucash-pot.mcd.expected
@@ -642,7 +642,7 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
-      ListItem ( LogNote ( ADMIN , Vat . file spot "gold" 3000000000 ) )
+      ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
@@ -652,7 +652,8 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
-      ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
+      ListItem ( LogNote ( ANYONE , Vat . file spot "gold" 3000000000 ) )
+      ListItem ( Poke ( "gold" , 3000000000 , 3000000000 ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0

--- a/tests/attacks/lucash-pot.mcd.expected
+++ b/tests/attacks/lucash-pot.mcd.expected
@@ -569,6 +569,16 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Spot . setMat "gold" 1 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Flip "gold" . init ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0

--- a/tests/attacks/lucash-pot.random.mcd.expected
+++ b/tests/attacks/lucash-pot.random.mcd.expected
@@ -292,7 +292,7 @@
             .Set
           </spot-wards>
           <spot-ilks>
-            "gold" |-> SpotIlk ( 1 , 1 )
+            "gold" |-> SpotIlk ( 3000000000 , 1 )
           </spot-ilks>
           <spot-par>
             1
@@ -306,6 +306,7 @@
             SetItem ( End )
             SetItem ( GemJoin "gold" )
             SetItem ( Pot )
+            SetItem ( Spot )
           </vat-wards>
           <vat-can>
             "Alice" |-> SetItem ( End )
@@ -401,6 +402,8 @@
       ListItem ( LogNote ( ADMIN , Vat . rely Pot ) )
       ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map ) )
       ListItem ( LogNote ( ADMIN , Vat . rely End ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map ) )
+      ListItem ( LogNote ( ADMIN , Vat . rely Spot ) )
       ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map ) )
       ListItem ( LogNote ( ADMIN , Pot . rely End ) )
       ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map ) )
@@ -559,7 +562,7 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
-      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 1 ) )
+      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 3000000000 ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
@@ -569,7 +572,17 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
-      ListItem ( LogNote ( ADMIN , Spot . setMat "gold" 1 ) )
+      ListItem ( LogNote ( ADMIN , Spot . file mat "gold" 1 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Spot . file par 1 ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0

--- a/tests/attacks/lucash-pot.random.mcd.expected
+++ b/tests/attacks/lucash-pot.random.mcd.expected
@@ -642,7 +642,7 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
-      ListItem ( LogNote ( ADMIN , Vat . file spot "gold" 3000000000 ) )
+      ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
@@ -652,7 +652,8 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
-      ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
+      ListItem ( LogNote ( ANYONE , Vat . file spot "gold" 3000000000 ) )
+      ListItem ( Poke ( "gold" , 3000000000 , 3000000000 ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0

--- a/tests/attacks/lucash-pot.random.mcd.expected
+++ b/tests/attacks/lucash-pot.random.mcd.expected
@@ -569,6 +569,16 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Spot . setMat "gold" 1 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Flip "gold" . init ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0

--- a/tests/fixes/debtBoundDSR.mcd.expected
+++ b/tests/fixes/debtBoundDSR.mcd.expected
@@ -934,6 +934,16 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Spot . setMat "gold" 1 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Flip "gold" . init ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0

--- a/tests/fixes/debtBoundDSR.mcd.expected
+++ b/tests/fixes/debtBoundDSR.mcd.expected
@@ -297,6 +297,7 @@
                 SetItem ( End )
                 SetItem ( GemJoin "gold" )
                 SetItem ( Pot )
+                SetItem ( Spot )
               </vat-wards>
               <vat-can>
                 "Alice" |-> SetItem ( End )
@@ -657,7 +658,7 @@
             .Set
           </spot-wards>
           <spot-ilks>
-            "gold" |-> SpotIlk ( 1 , 1 )
+            "gold" |-> SpotIlk ( 3000000000 , 1 )
           </spot-ilks>
           <spot-par>
             1
@@ -1007,7 +1008,7 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
-      ListItem ( LogNote ( ADMIN , Vat . file spot "gold" 3000000000 ) )
+      ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
@@ -1017,7 +1018,8 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
-      ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
+      ListItem ( LogNote ( ANYONE , Vat . file spot "gold" 3000000000 ) )
+      ListItem ( Poke ( "gold" , 3000000000 , 3000000000 ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0

--- a/tests/fixes/debtBoundDSR.mcd.expected
+++ b/tests/fixes/debtBoundDSR.mcd.expected
@@ -283,7 +283,7 @@
                 .Set
               </spot-wards>
               <spot-ilks>
-                "gold" |-> SpotIlk ( 1 , 1 )
+                "gold" |-> SpotIlk ( 3000000000 , 1 )
               </spot-ilks>
               <spot-par>
                 1
@@ -671,6 +671,7 @@
             SetItem ( End )
             SetItem ( GemJoin "gold" )
             SetItem ( Pot )
+            SetItem ( Spot )
           </vat-wards>
           <vat-can>
             "Alice" |-> SetItem ( End )
@@ -766,6 +767,8 @@
       ListItem ( LogNote ( ADMIN , Vat . rely Pot ) )
       ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map ) )
       ListItem ( LogNote ( ADMIN , Vat . rely End ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map ) )
+      ListItem ( LogNote ( ADMIN , Vat . rely Spot ) )
       ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map ) )
       ListItem ( LogNote ( ADMIN , Pot . rely End ) )
       ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map ) )
@@ -924,7 +927,7 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
-      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 1 ) )
+      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 3000000000 ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
@@ -934,7 +937,17 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
-      ListItem ( LogNote ( ADMIN , Spot . setMat "gold" 1 ) )
+      ListItem ( LogNote ( ADMIN , Spot . file mat "gold" 1 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Spot . file par 1 ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0

--- a/tests/fixes/potChiPieDai.mcd.expected
+++ b/tests/fixes/potChiPieDai.mcd.expected
@@ -292,7 +292,7 @@
             .Set
           </spot-wards>
           <spot-ilks>
-            "gold" |-> SpotIlk ( 1 , 1 )
+            "gold" |-> SpotIlk ( 3000000000 , 1 )
           </spot-ilks>
           <spot-par>
             1
@@ -306,6 +306,7 @@
             SetItem ( End )
             SetItem ( GemJoin "gold" )
             SetItem ( Pot )
+            SetItem ( Spot )
           </vat-wards>
           <vat-can>
             "Alice" |-> SetItem ( End )
@@ -401,6 +402,8 @@
       ListItem ( LogNote ( ADMIN , Vat . rely Pot ) )
       ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map ) )
       ListItem ( LogNote ( ADMIN , Vat . rely End ) )
+      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map ) )
+      ListItem ( LogNote ( ADMIN , Vat . rely Spot ) )
       ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map ) )
       ListItem ( LogNote ( ADMIN , Pot . rely End ) )
       ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map ) )
@@ -559,7 +562,7 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
-      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 1 ) )
+      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 3000000000 ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
@@ -569,7 +572,17 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
-      ListItem ( LogNote ( ADMIN , Spot . setMat "gold" 1 ) )
+      ListItem ( LogNote ( ADMIN , Spot . file mat "gold" 1 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Spot . file par 1 ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0

--- a/tests/fixes/potChiPieDai.mcd.expected
+++ b/tests/fixes/potChiPieDai.mcd.expected
@@ -642,7 +642,7 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
-      ListItem ( LogNote ( ADMIN , Vat . file spot "gold" 3000000000 ) )
+      ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0
@@ -652,7 +652,8 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
-      ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
+      ListItem ( LogNote ( ANYONE , Vat . file spot "gold" 3000000000 ) )
+      ListItem ( Poke ( "gold" , 3000000000 , 3000000000 ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0
       Pot |-> 0

--- a/tests/fixes/potChiPieDai.mcd.expected
+++ b/tests/fixes/potChiPieDai.mcd.expected
@@ -569,6 +569,16 @@
       Vow |-> 0 , 0 , Flap |-> 0
       GemJoin "MKR" |-> 0
       Vow |-> 0 ) )
+      ListItem ( LogNote ( ADMIN , Spot . setMat "gold" 1 ) )
+      ListItem ( Measure ( 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
+      Flap |-> 0
+      Pot |-> 0
+      Vow |-> 0 , 0 , Flap |-> 0
+      GemJoin "MKR" |-> 0
+      Vow |-> 0 ) )
       ListItem ( LogNote ( ADMIN , Flip "gold" . init ) )
       ListItem ( Measure ( 0 , End |-> 0
       Flap |-> 0


### PR DESCRIPTION
This adds a `Spot.setMat` function to the spec so that we can call it when initializing the collateral.  

Previously the `mat` was set to 1 with the `Spot.init` function which was then excluded from the Solidity output causing either a divide by 0 error or needing to hard code the mat into the solidity test harness.

I did not find an obvious way to remove the `mat` from the init function so I opted to set it to 0, but open to a better way of doing this.