### PR TITLE
Handle more assertions, fixes to violation checking

### DIFF
--- a/mcd-pyk.py
+++ b/mcd-pyk.py
@@ -57,7 +57,7 @@ def flattenAssoc(input, col, elemConverter = lambda x: x):
     if not (pyk.isKApply(input) and input['label'] == '_' + col + '_'):
         return [elemConverter(input)]
     output = []
-    work = input['args']
+    work = [ arg for arg in input['args'] ]
     while len(work) > 0:
         first = work.pop(0)
         if pyk.isKApply(first) and first['label'] == '_' + col + '_':

--- a/mcd-pyk.py
+++ b/mcd-pyk.py
@@ -316,12 +316,18 @@ def noRewriteToDots(config):
 def buildAssert(contract, field, value):
     assertionTriples = []
     if pyk.isKToken(value) and value['sort'] == 'Bool':
-        expected = contract + '.' + field + '()'
-        value = intToken(0)
+        actual     = contract + '.' + field + '()'
         comparator = '=='
+        expected   = intToken(0)
         if value['token'] == 'true':
             comparator = '=/='
-        assertionTriples.append((actual, comparator, value))
+        assertionTriples.append((actual, comparator, expected))
+    elif pyk.isKApply(value) and value['label'] == '_Map_':
+        for (k, v) in flattenMap(value):
+            actual     = contract + '.' + field + '(' + argify(printMCD(k)) + ')'
+            comparator = '=='
+            expected   = 'UNIMPLEMENTED << ' + printMCD(v) + ' >>'
+            assertionTriples.append((actual, comparator, expected))
     else:
         actual = contract + '.' + field + '()'
         assertionTriples.append(('UNIMPLEMENTED << ' + actual + ' >>', '==', printMCD(value)))

--- a/mcd-pyk.py
+++ b/mcd-pyk.py
@@ -323,14 +323,14 @@ def buildAssert(contract, field, value):
         comparator = '=='
         expected   = printMCD(intToken(0))
         if value['token'] == 'true':
-            comparator = '=/='
+            comparator = '!='
         assertionData.append((actual, comparator, expected, True))
     elif pyk.isKApply(value) and value['label'] == '_Map_':
         for (k, v) in flattenMap(value):
             if pyk.isKApply(v) and v['label'] == '_Set_':
                 for si in flattenSet(v):
                     actual     = contract + '.' + field + '(' + argify(printMCD(k)) + ', ' + argify(printMCD(si)) + ')'
-                    comparator = '=/='
+                    comparator = '!='
                     expected   = printMCD(intToken(0))
                     assertionData.append((actual, comparator, expected, True))
             else:

--- a/mcd-pyk.py
+++ b/mcd-pyk.py
@@ -314,14 +314,20 @@ def noRewriteToDots(config):
     return pyk.substitute(cfg, subst)
 
 def buildAssert(contract, field, value):
-    actual     = contract + '.' + field + '()'
-    comparator = '=='
+    assertionTriples = []
     if pyk.isKToken(value) and value['sort'] == 'Bool':
+        expected = contract + '.' + field + '()'
         value = intToken(0)
+        comparator = '=='
         if value['token'] == 'true':
             comparator = '=/='
-    expected = printMCD(value)
-    return variablize('assertTrue( ' + actual + ' ' + comparator + ' ' + expected + ' );')
+        assertionTriples.append((actual, comparator, value))
+    else:
+        actual = contract + '.' + field + '()'
+        assertionTriples.append(('UNIMPLEMENTED << ' + actual + ' >>', '==', printMCD(value)))
+    assertions = [ 'assertTrue( ' + actual + ' ' + comparator + ' ' + expected + ' );' \
+                    for (actual, comparator, expected) in assertionTriples ]
+    return variablize('\n'.join(assertions))
 
 def extractAsserts(config):
     (_, subst) = pyk.splitConfigFrom(config)


### PR DESCRIPTION
This should wait for #168 and #167 before merge (to address merge conflicts), but morally should be reviewed separately.

-   Simplifies the logic of flattening collections in several places in `mcd-pyk.py`.
-   Fixes the violation checking in `mcd-pyk.py`.
-   Handles more assertion generation when there is a mapping update during execution.

An example of a mapping update looks like:

```
    assertTrue( vat.can(address(bobby), address(end)) != 0 );
    assertTrue( vat.can(address(bobby), address(alice)) != 0 );
    assertTrue( vat.can(address(bobby), address(goldFlip)) != 0 );
    assertTrue( vat.can(address(bobby), address(pot)) != 0 );
    assertTrue( vat.can(address(alice), address(end)) != 0 );
    assertTrue( vat.can(address(alice), address(goldFlip)) != 0 );
    assertTrue( vat.can(address(alice), address(pot)) != 0 );
```

I wasn't sure how to do the double-access of `address(alice)` followed by `address(pot)` in the `can` map, so for now I just put both arguments together. This can easily be changed.