### PR TITLE
Separate out representation of Wad/Rad/Ray

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ MAIN_DEFN_FILE := kmcd-prelude
 KOMPILE_OPTS      :=
 LLVM_KOMPILE_OPTS := $(KOMPILE_OPTS) -ccopt -O2
 
-k_files := $(MAIN_DEFN_FILE).k kmcd-prelude.k kmcd-props.k kmcd.k kmcd-driver.k cat.k dai.k end.k flap.k flip.k flop.k gem.k join.k jug.k pot.k spot.k vat.k vow.k
+k_files := $(MAIN_DEFN_FILE).k kmcd-prelude.k kmcd-props.k kmcd.k kmcd-data.k kmcd-driver.k cat.k dai.k end.k flap.k flip.k flop.k gem.k join.k jug.k pot.k spot.k vat.k vow.k
 
 llvm_dir    := $(DEFN_DIR)/llvm
 haskell_dir := $(DEFN_DIR)/haskell

--- a/cat.md
+++ b/cat.md
@@ -126,7 +126,7 @@ Cat Semantics
           ~> call Vow . fess TAB
           ~> call Flip ILK . kick URN VOWADDR (TAB *Rad Ray2Rad(CHOP)) LOT 0Rad
           ~> emitBite ILK URN LOT ART TAB)
-          (ART *Rate RATE))
+          (ART *RateWad RATE))
           (minWad(URNART, (LOT *Wad URNART) /Wad INK)))
           (minWad(INK, LUMP))
          ...
@@ -137,7 +137,7 @@ Cat Semantics
          <vat-ilks> ... ILK |-> Ilk(... rate: RATE, spot: SPOT) ... </vat-ilks>
          <vat-urns> ... { ILK, URN } |-> Urn(... ink: INK, art: URNART ) ... </vat-urns>
          <cat-vow> VOWADDR </cat-vow>
-      requires (INK *Rate SPOT) <Rad (URNART *Rate RATE)
+      requires (INK *RateWad SPOT) <Rad (URNART *RateWad RATE)
 
     syntax CatAuthStep ::= "cage" [klabel(#CatCage), symbol]
  // --------------------------------------------------------

--- a/cat.md
+++ b/cat.md
@@ -101,11 +101,11 @@ The parameters controlled by governance are:
 
     rule <k> Cat . file chop ILKID CHOP => . ... </k>
          <cat-ilks> ... ILKID |-> Ilk ( ... chop: (_ => CHOP) ) ... </cat-ilks>
-      requires CHOP >=Rat 0
+      requires CHOP >=Ray 0Ray
 
     rule <k> Cat . file lump ILKID LUMP => . ... </k>
          <cat-ilks> ... ILKID |-> Ilk ( ... lump: (_ => LUMP) ) ... </cat-ilks>
-      requires LUMP >=Rat 0
+      requires LUMP >=Wad 0Wad
 ```
 
 **NOTE**: `flip` is not fileable since we are assuming a unique liquidator for each ilk.
@@ -122,22 +122,22 @@ Cat Semantics
           => #fun(LOT
           => #fun(ART
           => #fun(TAB
-          => call Vat . grab ILK URN THIS VOWADDR (-1 *Rat LOT) (-1 *Rat ART)
+          => call Vat . grab ILK URN THIS VOWADDR (0Wad -Wad LOT) (0Wad -Wad ART)
           ~> call Vow . fess TAB
-          ~> call Flip ILK . kick URN VOWADDR (TAB *Rat CHOP) LOT 0
+          ~> call Flip ILK . kick URN VOWADDR (TAB *Rad Ray2Rad(CHOP)) LOT 0Rad
           ~> emitBite ILK URN LOT ART TAB)
-          (ART *Rat RATE))
-          (minRat(URNART, LOT *Rat URNART /Rat INK)))
-          (minRat(INK, LUMP))
+          (ART *Rate RATE))
+          (minWad(URNART, (LOT *Wad URNART) /Wad INK)))
+          (minWad(INK, LUMP))
          ...
          </k>
          <this> THIS </this>
          <cat-live> true </cat-live>
          <cat-ilks> ... ILK |-> Ilk(... chop: CHOP, lump: LUMP) ... </cat-ilks>
          <vat-ilks> ... ILK |-> Ilk(... rate: RATE, spot: SPOT) ... </vat-ilks>
-         <vat-urns> ... { ILK, URN } |-> Urn( INK, URNART ) ... </vat-urns>
+         <vat-urns> ... { ILK, URN } |-> Urn(... ink: INK, art: URNART ) ... </vat-urns>
          <cat-vow> VOWADDR </cat-vow>
-      requires (INK *Rat SPOT) <Rat (URNART *Rat RATE)
+      requires (INK *Rate SPOT) <Rad (URNART *Rate RATE)
 
     syntax CatAuthStep ::= "cage" [klabel(#CatCage), symbol]
  // --------------------------------------------------------

--- a/cat.md
+++ b/cat.md
@@ -69,10 +69,10 @@ Cat Events
 ----------
 
 ```k
-    syntax Event ::= Bite(ilk: String, urn: Address, ink: Wad, art: Wad, tab: Wad, flip: Address, id: Int) [klabel(Bite), symbol]
+    syntax Event ::= Bite(ilk: String, urn: Address, ink: Wad, art: Wad, tab: Rad, flip: Address, id: Int) [klabel(Bite), symbol]
  // -----------------------------------------------------------------------------------------------------------------------------
 
-    syntax CatStep ::= "emitBite" String Address Wad Wad Wad
+    syntax CatStep ::= "emitBite" String Address Wad Wad Rad
  // --------------------------------------------------------
     rule <k> emitBite ILK URN INK ART TAB => ID ... </k>
          <return-value> ID:Int </return-value>

--- a/cat.md
+++ b/cat.md
@@ -126,7 +126,7 @@ Cat Semantics
           ~> call Vow . fess TAB
           ~> call Flip ILK . kick URN VOWADDR rmulRad(TAB, CHOP) LOT 0Rad
           ~> emitBite ILK URN LOT ART TAB)
-          (ART *RateWad RATE))
+          (ART *Rate RATE))
           (minWad(URNART, (LOT *Wad URNART) /Wad INK)))
           (minWad(INK, LUMP))
          ...
@@ -137,7 +137,7 @@ Cat Semantics
          <vat-ilks> ... ILK |-> Ilk(... rate: RATE, spot: SPOT) ... </vat-ilks>
          <vat-urns> ... { ILK, URN } |-> Urn(... ink: INK, art: URNART ) ... </vat-urns>
          <cat-vow> VOWADDR </cat-vow>
-      requires (INK *RateWad SPOT) <Rad (URNART *RateWad RATE)
+      requires (INK *Rate SPOT) <Rad (URNART *Rate RATE)
 
     syntax CatAuthStep ::= "cage" [klabel(#CatCage), symbol]
  // --------------------------------------------------------

--- a/cat.md
+++ b/cat.md
@@ -124,7 +124,7 @@ Cat Semantics
           => #fun(TAB
           => call Vat . grab ILK URN THIS VOWADDR (0Wad -Wad LOT) (0Wad -Wad ART)
           ~> call Vow . fess TAB
-          ~> call Flip ILK . kick URN VOWADDR (TAB *Rad Ray2Rad(CHOP)) LOT 0Rad
+          ~> call Flip ILK . kick URN VOWADDR rmulRad(TAB, CHOP) LOT 0Rad
           ~> emitBite ILK URN LOT ART TAB)
           (ART *RateWad RATE))
           (minWad(URNART, (LOT *Wad URNART) /Wad INK)))

--- a/dai.md
+++ b/dai.md
@@ -13,12 +13,12 @@ module DAI
 
     configuration
       <dai>
-        <dai-wards>       .Set  </dai-wards>
-        <dai-totalSupply> 0:Wad </dai-totalSupply>
-        <dai-account-id>  0     </dai-account-id>
-        <dai-balance>     .Map  </dai-balance>     // mapping (address => uint)                      Address |-> Wad
-        <dai-allowance>   .Map  </dai-allowance>   // mapping (address => mapping (address => uint))
-        <dai-nonce>       .Map  </dai-nonce>       // mapping (address => uint)                      Address |-> Wad
+        <dai-wards>       .Set </dai-wards>
+        <dai-totalSupply> 0Wad </dai-totalSupply>
+        <dai-account-id>  0    </dai-account-id>
+        <dai-balance>     .Map </dai-balance>     // mapping (address => uint)                      Address |-> Wad
+        <dai-allowance>   .Map </dai-allowance>   // mapping (address => mapping (address => uint))
+        <dai-nonce>       .Map </dai-nonce>       // mapping (address => uint)                      Address |-> Wad
       </dai>
 ```
 
@@ -79,72 +79,72 @@ The Dai token is a mintable/burnable ERC20 token.
          <msg-sender> ACCOUNT_SRC </msg-sender>
          <dai-balance> ... ACCOUNT_SRC |-> BALANCE_SRC ... </dai-balance>
          <frame-events> ... (.List => ListItem(Transfer(ACCOUNT_SRC, ACCOUNT_SRC, AMOUNT))) </frame-events>
-      requires AMOUNT >=Rat 0
-       andBool BALANCE_SRC >=Rat AMOUNT
+      requires AMOUNT >=Wad 0Wad
+       andBool BALANCE_SRC >=Wad AMOUNT
 
     rule <k> Dai . transfer ACCOUNT_DST AMOUNT => . ... </k>
          <msg-sender> ACCOUNT_SRC </msg-sender>
          <dai-balance>
            ...
-           ACCOUNT_SRC |-> (BALANCE_SRC => BALANCE_SRC -Rat AMOUNT)
-           ACCOUNT_DST |-> (BALANCE_DST => BALANCE_DST +Rat AMOUNT)
+           ACCOUNT_SRC |-> (BALANCE_SRC => BALANCE_SRC -Wad AMOUNT)
+           ACCOUNT_DST |-> (BALANCE_DST => BALANCE_DST +Wad AMOUNT)
            ...
          </dai-balance>
          <frame-events> ... (.List => ListItem(Transfer(ACCOUNT_SRC, ACCOUNT_DST, AMOUNT))) </frame-events>
-      requires AMOUNT >=Rat 0
+      requires AMOUNT >=Wad 0Wad
        andBool ACCOUNT_SRC =/=K ACCOUNT_DST
-       andBool BALANCE_SRC >=Rat AMOUNT
+       andBool BALANCE_SRC >=Wad AMOUNT
 
     syntax DaiStep ::= "transferFrom" Address Address Wad
  // -----------------------------------------------------
     rule <k> Dai . transferFrom ACCOUNT_SRC ACCOUNT_SRC AMOUNT => . ... </k>
          <dai-balance> ... ACCOUNT_SRC |-> BALANCE_SRC ... </dai-balance>
          <frame-events> ... (.List => ListItem(Transfer(ACCOUNT_SRC, ACCOUNT_SRC, AMOUNT))) </frame-events>
-      requires AMOUNT >=Rat 0
-       andBool BALANCE_SRC >=Rat AMOUNT
+      requires AMOUNT >=Wad 0Wad
+       andBool BALANCE_SRC >=Wad AMOUNT
 
     rule <k> Dai . transferFrom ACCOUNT_SRC ACCOUNT_DST AMOUNT => . ... </k>
-         <dai-allowance> ... { ACCOUNT_SRC -> ACCOUNT_DST } |-> (ALLOWANCE_SRC_DST => ALLOWANCE_SRC_DST -Rat AMOUNT) ... </dai-allowance>
+         <dai-allowance> ... { ACCOUNT_SRC -> ACCOUNT_DST } |-> (ALLOWANCE_SRC_DST => ALLOWANCE_SRC_DST -Wad AMOUNT) ... </dai-allowance>
          <dai-balance>
            ...
-           ACCOUNT_SRC |-> (BALANCE_SRC => BALANCE_SRC -Rat AMOUNT)
-           ACCOUNT_DST |-> (BALANCE_DST => BALANCE_DST +Rat AMOUNT)
+           ACCOUNT_SRC |-> (BALANCE_SRC => BALANCE_SRC -Wad AMOUNT)
+           ACCOUNT_DST |-> (BALANCE_DST => BALANCE_DST +Wad AMOUNT)
            ...
          </dai-balance>
          <frame-events> ... (.List => ListItem(Transfer(ACCOUNT_SRC, ACCOUNT_DST, AMOUNT))) </frame-events>
-      requires AMOUNT >=Rat 0
+      requires AMOUNT >=Wad 0Wad
        andBool ACCOUNT_SRC =/=K ACCOUNT_DST
-       andBool BALANCE_SRC >=Rat AMOUNT
-       andBool ALLOWANCE_SRC_DST >=Rat AMOUNT
+       andBool BALANCE_SRC >=Wad AMOUNT
+       andBool ALLOWANCE_SRC_DST >=Wad AMOUNT
 
     rule <k> Dai . transferFrom ACCOUNT_SRC ACCOUNT_DST AMOUNT => . ... </k>
          <dai-allowance> ... { ACCOUNT_SRC -> ACCOUNT_DST } |-> -1 ... </dai-allowance>
          <dai-balance>
            ...
-           ACCOUNT_SRC |-> (BALANCE_SRC => BALANCE_SRC -Rat AMOUNT)
-           ACCOUNT_DST |-> (BALANCE_DST => BALANCE_DST +Rat AMOUNT)
+           ACCOUNT_SRC |-> (BALANCE_SRC => BALANCE_SRC -Wad AMOUNT)
+           ACCOUNT_DST |-> (BALANCE_DST => BALANCE_DST +Wad AMOUNT)
            ...
          </dai-balance>
          <frame-events> ... (.List => ListItem(Transfer(ACCOUNT_SRC, ACCOUNT_DST, AMOUNT))) </frame-events>
-      requires AMOUNT >=Rat 0
+      requires AMOUNT >=Wad 0Wad
        andBool ACCOUNT_SRC =/=K ACCOUNT_DST
-       andBool BALANCE_SRC >=Rat AMOUNT
+       andBool BALANCE_SRC >=Wad AMOUNT
 
     syntax DaiAuthStep ::= "mint" Address Wad
  // -----------------------------------------
     rule <k> Dai . mint ACCOUNT_DST AMOUNT => . ... </k>
-         <dai-totalSupply> DAI_SUPPLY => DAI_SUPPLY +Rat AMOUNT </dai-totalSupply>
-         <dai-balance> ... ACCOUNT_DST |-> (BALANCE_DST => BALANCE_DST +Rat AMOUNT) ... </dai-balance>
+         <dai-totalSupply> DAI_SUPPLY => DAI_SUPPLY +Wad AMOUNT </dai-totalSupply>
+         <dai-balance> ... ACCOUNT_DST |-> (BALANCE_DST => BALANCE_DST +Wad AMOUNT) ... </dai-balance>
          <frame-events> ... (.List => ListItem(Transfer(0, ACCOUNT_DST, AMOUNT))) </frame-events>
-      requires AMOUNT >=Rat 0
+      requires AMOUNT >=Wad 0Wad
 
     syntax DaiStep ::= "burn" Address Wad
  // -------------------------------------
     rule <k> Dai . burn ACCOUNT_SRC AMOUNT => . ... </k>
-         <dai-totalSupply> DAI_SUPPLY => DAI_SUPPLY -Rat AMOUNT </dai-totalSupply>
-         <dai-balance> ... ACCOUNT_SRC |-> (AMOUNT_SRC => AMOUNT_SRC -Rat AMOUNT) ... </dai-balance>
+         <dai-totalSupply> DAI_SUPPLY => DAI_SUPPLY -Wad AMOUNT </dai-totalSupply>
+         <dai-balance> ... ACCOUNT_SRC |-> (AMOUNT_SRC => AMOUNT_SRC -Wad AMOUNT) ... </dai-balance>
          <frame-events> ... (.List => ListItem(Transfer(ACCOUNT_SRC, 0, AMOUNT))) </frame-events>
-      requires AMOUNT >=Rat 0
+      requires AMOUNT >=Wad 0Wad
 
     syntax DaiStep ::= "approve" Address Wad
  // ----------------------------------------
@@ -152,24 +152,24 @@ The Dai token is a mintable/burnable ERC20 token.
          <msg-sender> ACCOUNT_SRC </msg-sender>
          <dai-allowance> ... { ACCOUNT_SRC -> ACCOUNT_DST } |-> (_ => AMOUNT) ... </dai-allowance>
          <frame-events> ... (.List => ListItem(Approval(ACCOUNT_SRC, ACCOUNT_DST, AMOUNT))) </frame-events>
-      requires AMOUNT >=Rat 0
+      requires AMOUNT >=Wad 0Wad
 
     syntax DaiStep ::= "push" Address Wad
  // -------------------------------------
     rule <k> Dai . push ACCOUNT_DST AMOUNT => Dai . transferFrom ACCOUNT_SRC ACCOUNT_DST AMOUNT ... </k>
          <msg-sender> ACCOUNT_SRC </msg-sender>
-      requires AMOUNT >=Rat 0
+      requires AMOUNT >=Wad 0Wad
 
     syntax DaiStep ::= "pull" Address Wad
  // -------------------------------------
     rule <k> Dai . pull ACCOUNT_SRC AMOUNT => Dai . transferFrom ACCOUNT_SRC ACCOUNT_DST AMOUNT ... </k>
          <msg-sender> ACCOUNT_DST </msg-sender>
-      requires AMOUNT >=Rat 0
+      requires AMOUNT >=Wad 0Wad
 
     syntax DaiStep ::= "move" Address Address Wad
  // ---------------------------------------------
     rule <k> Dai . move ACCOUNT_SRC ACCOUNT_DST AMOUNT => Dai . transferFrom ACCOUNT_SRC ACCOUNT_DST AMOUNT ... </k>
-      requires AMOUNT >=Rat 0
+      requires AMOUNT >=Wad 0Wad
 ```
 
 **TODO**: `permit` logic, seems to be a time-locked allowance.

--- a/end.md
+++ b/end.md
@@ -167,12 +167,12 @@ End Semantics
     syntax EndStep ::= "skim" String Address
  // ----------------------------------------
     rule <k> End . skim ILK ADDR
-          => call Vat . grab ILK ADDR THIS Vow (0Wad -Wad minWad(INK, rmul(rmul(ART, RATE), TAG))) (0Wad -Wad ART)
+          => call Vat . grab ILK ADDR THIS Vow (0Wad -Wad minWad(INK, rmulWad(rmulWad(ART, RATE), TAG))) (0Wad -Wad ART)
          ...
          </k>
          <this> THIS </this>
          <end-tag> ... ILK |-> TAG ... </end-tag>
-         <end-gap> ... ILK |-> (GAP => GAP +Wad (rmul(rmul(ART, RATE), TAG) -Wad minWad(INK, rmul(rmul(ART, RATE), TAG)))) ... </end-gap>
+         <end-gap> ... ILK |-> (GAP => GAP +Wad (rmulWad(rmulWad(ART, RATE), TAG) -Wad minWad(INK, rmulWad(rmulWad(ART, RATE), TAG)))) ... </end-gap>
          <vat-ilks> ... ILK |-> Ilk(... rate: RATE)::VatIlk ... </vat-ilks>
          <vat-urns> ... {ILK, ADDR} |-> Urn(... ink: INK, art: ART) ... </vat-urns>
       requires TAG =/=Ray 0Ray
@@ -204,13 +204,13 @@ End Semantics
  // --------------------------------
     rule <k> End . flow ILK => . ... </k>
          <end-debt> DEBT </end-debt>
-         <end-fix> FIX => FIX [ ILK <- rdiv(Wad2Ray(rmul(rmul(ART, RATE), TAG) -Wad GAP), DEBT) ] </end-fix>
+         <end-fix> FIX => FIX [ ILK <- rdiv(Wad2Ray(rmulWad(rmulWad(ART, RATE), TAG) -Wad GAP), DEBT) ] </end-fix>
          <end-tag> ... ILK |-> TAG ... </end-tag>
          <end-gap> ... ILK |-> GAP ... </end-gap>
          <end-art> ... ILK |-> ART ... </end-art>
          <vat-ilks> ... ILK |-> Ilk(... rate: RATE)::VatIlk ... </vat-ilks>
       requires DEBT =/=Rad 0Rad
-       andBool rmul(rmul(ART, RATE), TAG) >=Wad GAP
+       andBool rmulWad(rmulWad(ART, RATE), TAG) >=Wad GAP
        andBool notBool ILK in_keys(FIX)
 
     syntax EndStep ::= "pack" Wad
@@ -228,7 +228,7 @@ End Semantics
     syntax EndStep ::= "cash" String Wad
  // ------------------------------------
     rule <k> End . cash ILK AMOUNT
-          => call Vat . flux ILK THIS MSGSENDER rmul(AMOUNT, FIX)
+          => call Vat . flux ILK THIS MSGSENDER rmulWad(AMOUNT, FIX)
          ...
          </k>
          <msg-sender> MSGSENDER </msg-sender>

--- a/end.md
+++ b/end.md
@@ -161,7 +161,7 @@ End Semantics
            ...
          </flip>
       requires TAG =/=Ray 0Ray
-       andBool LOT >=Rad 0Rad
+       andBool LOT >=Wad 0Wad
        andBool TAB /Rate RATE >=Wad 0Wad
 
     syntax EndStep ::= "skim" String Address
@@ -216,7 +216,7 @@ End Semantics
     syntax EndStep ::= "pack" Wad
  // -----------------------------
     rule <k> End . pack AMOUNT
-          => call Vat . move MSGSENDER Vow AMOUNT
+          => call Vat . move MSGSENDER Vow Wad2Rad(AMOUNT)
          ...
          </k>
          <msg-sender> MSGSENDER </msg-sender>

--- a/end.md
+++ b/end.md
@@ -25,17 +25,17 @@ End Configuration
       <end-state>
         <endPhase> false </endPhase>
         <end>
-          <end-wards> .Set  </end-wards>
-          <end-live>  true  </end-live>
-          <end-when>  0     </end-when>
-          <end-wait>  0     </end-wait>
-          <end-debt>  0:Rad </end-debt>
-          <end-tag>   .Map  </end-tag>  // mapping (bytes32 => uint256)                      String  |-> Ray
-          <end-gap>   .Map  </end-gap>  // mapping (bytes32 => uint256)                      String  |-> Wad
-          <end-art>   .Map  </end-art>  // mapping (bytes32 => uint256)                      String  |-> Wad
-          <end-fix>   .Map  </end-fix>  // mapping (bytes32 => uint256)                      String  |-> Ray
-          <end-bag>   .Map  </end-bag>  // mapping (address => uint256)                      Address |-> Wad
-          <end-out>   .Map  </end-out>  // mapping (bytes32 => mapping (address => uint256)) CDPID   |-> Wad
+          <end-wards> .Set </end-wards>
+          <end-live>  true </end-live>
+          <end-when>  0    </end-when>
+          <end-wait>  0    </end-wait>
+          <end-debt>  0Rad </end-debt>
+          <end-tag>   .Map </end-tag>  // mapping (bytes32 => uint256)                      String  |-> Ray
+          <end-gap>   .Map </end-gap>  // mapping (bytes32 => uint256)                      String  |-> Wad
+          <end-art>   .Map </end-art>  // mapping (bytes32 => uint256)                      String  |-> Wad
+          <end-fix>   .Map </end-fix>  // mapping (bytes32 => uint256)                      String  |-> Ray
+          <end-bag>   .Map </end-bag>  // mapping (address => uint256)                      Address |-> Wad
+          <end-out>   .Map </end-out>  // mapping (bytes32 => mapping (address => uint256)) CDPID   |-> Wad
         </end>
       </end-state>
 ```
@@ -101,15 +101,15 @@ Because data isn't explicitely initialized to 0 in KMCD, we need explicit initia
                          | "initOut" String Address
  // -----------------------------------------------
     rule <k> End . initGap ILKID => . ... </k>
-         <end-gap> GAPS => GAPS [ ILKID <- 0 ] </end-gap>
+         <end-gap> GAPS => GAPS [ ILKID <- 0Wad ] </end-gap>
       requires notBool ILKID in_keys(GAPS)
 
     rule <k> End . initBag ADDR => . ... </k>
-         <end-bag> BAGS => BAGS [ ADDR <- 0 ] </end-bag>
+         <end-bag> BAGS => BAGS [ ADDR <- 0Wad ] </end-bag>
       requires notBool ADDR in_keys(BAGS)
 
     rule <k> End . initOut ILKID ADDR => . ... </k>
-         <end-out> OUTS => OUTS [ { ILKID , ADDR } <- 0 ] </end-out>
+         <end-out> OUTS => OUTS [ { ILKID , ADDR } <- 0Wad ] </end-out>
       requires notBool { ILKID , ADDR } in_keys(OUTS)
 ```
 
@@ -134,7 +134,7 @@ End Semantics
  // --------------------------------
     rule <k> End . cage ILK:String => . ... </k>
          <end-live> false </end-live>
-         <end-tag> TAGS => TAGS [ ILK <- PAR /Rat PIP ] </end-tag>
+         <end-tag> TAGS => TAGS [ ILK <- wdiv(PAR, PIP) ] </end-tag>
          <end-art> ARTS => ARTS [ ILK <- ART ] </end-art>
          <spot-par> PAR </spot-par>
          <spot-ilks> ... ILK |-> SpotIlk(... pip: PIP) ... </spot-ilks>
@@ -148,55 +148,55 @@ End Semantics
           ~> call Vat . suck Vow THIS BID
           ~> call Vat . hope Flip ILK
           ~> call Flip ILK . yank ID
-          ~> call Vat . grab ILK USR THIS Vow LOT (TAB /Rat RATE)
+          ~> call Vat . grab ILK USR THIS Vow LOT (TAB /Rate RATE)
          ...
          </k>
          <this> THIS </this>
          <end-tag> ... ILK |-> TAG ... </end-tag>
-         <end-art> ... ILK |-> (ART => ART +Rat (TAB /Rat RATE)) ... </end-art>
+         <end-art> ... ILK |-> (ART => ART +Wad (TAB /Rate RATE)) ... </end-art>
          <vat-ilks> ... ILK |-> Ilk(... rate: RATE)::VatIlk ... </vat-ilks>
          <flip>
            <flip-ilk> ILK </flip-ilk>
            <flip-bids> ... ID |-> FlipBid(... bid: BID, lot: LOT, usr: USR, tab: TAB) ... </flip-bids>
            ...
          </flip>
-      requires TAG =/=Rat 0
-       andBool LOT >=Rat 0
-       andBool TAB /Rat RATE >=Rat 0
+      requires TAG =/=Ray 0Ray
+       andBool LOT >=Rad 0Rad
+       andBool TAB /Rate RATE >=Wad 0Wad
 
     syntax EndStep ::= "skim" String Address
  // ----------------------------------------
     rule <k> End . skim ILK ADDR
-          => call Vat . grab ILK ADDR THIS Vow (0 -Rat minRat(INK, ART *Rat RATE *Rat TAG)) (0 -Rat ART)
+          => call Vat . grab ILK ADDR THIS Vow (0Wad -Wad minWad(INK, rmul(rmul(ART, RATE), TAG))) (0Wad -Wad ART)
          ...
          </k>
          <this> THIS </this>
          <end-tag> ... ILK |-> TAG ... </end-tag>
-         <end-gap> ... ILK |-> (GAP => GAP +Rat ((ART *Rat RATE *Rat TAG) -Rat minRat(INK, (ART *Rat RATE *Rat TAG)))) ... </end-gap>
+         <end-gap> ... ILK |-> (GAP => GAP +Wad (rmul(rmul(ART, RATE), TAG) -Wad minWad(INK, rmul(rmul(ART, RATE), TAG)))) ... </end-gap>
          <vat-ilks> ... ILK |-> Ilk(... rate: RATE)::VatIlk ... </vat-ilks>
          <vat-urns> ... {ILK, ADDR} |-> Urn(... ink: INK, art: ART) ... </vat-urns>
-      requires TAG =/=Rat 0
+      requires TAG =/=Ray 0Ray
 
     syntax EndStep ::= "free" String
  // --------------------------------
     rule <k> End . free ILK
-          => call Vat . grab ILK MSGSENDER MSGSENDER Vow (0 -Rat INK) 0
+          => call Vat . grab ILK MSGSENDER MSGSENDER Vow (0Wad -Wad INK) 0Wad
          ...
          </k>
          <msg-sender> MSGSENDER </msg-sender>
          <end-live> false </end-live>
          <vat-urns> ... {ILK, MSGSENDER} |-> Urn(... ink: INK, art: ART) ... </vat-urns>
-      requires ART ==Int 0
+      requires ART ==Wad 0Wad
 
     syntax EndStep ::= "thaw"
  // -------------------------
     rule <k> End . thaw => . ... </k>
          <current-time> NOW </current-time>
          <end-live> false </end-live>
-         <end-debt> 0 => DEBT </end-debt>
+         <end-debt> 0Rad => DEBT </end-debt>
          <end-when> WHEN </end-when>
          <end-wait> WAIT </end-wait>
-         <vat-dai> ... Vow |-> 0 ... </vat-dai>
+         <vat-dai> ... Vow |-> 0Rad ... </vat-dai>
          <vat-debt> DEBT </vat-debt>
       requires NOW >=Int WHEN +Int WAIT
 
@@ -204,13 +204,13 @@ End Semantics
  // --------------------------------
     rule <k> End . flow ILK => . ... </k>
          <end-debt> DEBT </end-debt>
-         <end-fix> FIX => FIX [ ILK <- (ART *Rat RATE *Rat TAG -Rat GAP) /Rat DEBT ] </end-fix>
+         <end-fix> FIX => FIX [ ILK <- rdiv(rmul(rmul(ART, RATE), TAG) -Wad GAP, DEBT) ] </end-fix>
          <end-tag> ... ILK |-> TAG ... </end-tag>
          <end-gap> ... ILK |-> GAP ... </end-gap>
          <end-art> ... ILK |-> ART ... </end-art>
          <vat-ilks> ... ILK |-> Ilk(... rate: RATE)::VatIlk ... </vat-ilks>
-      requires DEBT =/=Rat 0
-       andBool ART *Rat RATE *Rat TAG >=Rat GAP
+      requires DEBT =/=Rad 0Rad
+       andBool rmul(rmul(ART, RATE), TAG) >=Wad GAP
        andBool notBool ILK in_keys(FIX)
 
     syntax EndStep ::= "pack" Wad
@@ -221,24 +221,24 @@ End Semantics
          </k>
          <msg-sender> MSGSENDER </msg-sender>
          <end-debt> DEBT </end-debt>
-         <end-bag> ... MSGSENDER |-> (BAG => BAG +Rat AMOUNT) ... </end-bag>
-      requires AMOUNT >=Rat 0
-       andBool DEBT =/=Rat 0
+         <end-bag> ... MSGSENDER |-> (BAG => BAG +Wad AMOUNT) ... </end-bag>
+      requires AMOUNT >=Wad 0Wad
+       andBool DEBT =/=Rad 0Rad
 
     syntax EndStep ::= "cash" String Wad
  // ------------------------------------
     rule <k> End . cash ILK AMOUNT
-          => call Vat . flux ILK THIS MSGSENDER (AMOUNT *Rat FIX)
+          => call Vat . flux ILK THIS MSGSENDER rmul(AMOUNT, FIX)
          ...
          </k>
          <msg-sender> MSGSENDER </msg-sender>
          <this> THIS </this>
          <end-fix> ... ILK |-> FIX ... </end-fix>
-         <end-out> ... {ILK, MSGSENDER} |-> (OUT => OUT +Rat AMOUNT) ... </end-out>
+         <end-out> ... {ILK, MSGSENDER} |-> (OUT => OUT +Wad AMOUNT) ... </end-out>
          <end-bag> ... MSGSENDER |-> BAG ... </end-bag>
-      requires AMOUNT >=Rat 0
-       andBool FIX =/=Rat 0
-       andBool OUT +Rat AMOUNT <=Rat BAG
+      requires AMOUNT >=Wad 0Wad
+       andBool FIX =/=Ray 0Ray
+       andBool OUT +Wad AMOUNT <=Wad BAG
 ```
 
 ```k

--- a/end.md
+++ b/end.md
@@ -204,7 +204,7 @@ End Semantics
  // --------------------------------
     rule <k> End . flow ILK => . ... </k>
          <end-debt> DEBT </end-debt>
-         <end-fix> FIX => FIX [ ILK <- rdiv(rmul(rmul(ART, RATE), TAG) -Wad GAP, DEBT) ] </end-fix>
+         <end-fix> FIX => FIX [ ILK <- rdiv(Wad2Ray(rmul(rmul(ART, RATE), TAG) -Wad GAP), DEBT) ] </end-fix>
          <end-tag> ... ILK |-> TAG ... </end-tag>
          <end-gap> ... ILK |-> GAP ... </end-gap>
          <end-art> ... ILK |-> ART ... </end-art>

--- a/flap.md
+++ b/flap.md
@@ -83,13 +83,13 @@ The parameters controlled by governance are:
     syntax FlapAuthStep ::= "file" FlapFile
  // ---------------------------------------
 
-    syntax FlapFile ::= "beg" Ray
+    syntax FlapFile ::= "beg" Wad
                       | "ttl" Int
                       | "tau" Int
  // -----------------------------
     rule <k> Flap . file beg BEG => . ... </k>
          <flap-beg> _ => BEG </flap-beg>
-      requires BEG >=Ray 0Ray
+      requires BEG >=Wad 0Wad
 
     rule <k> Flap . file ttl TTL => . ... </k>
          <flap-ttl> _ => TTL </flap-ttl>

--- a/flap.md
+++ b/flap.md
@@ -19,7 +19,7 @@ Flap Configuration
         <flap-bids>  .Map         </flap-bids>  // mapping (uint => Bid) Int |-> FlapBid
         <flap-kicks> 0            </flap-kicks>
         <flap-live>  true         </flap-live>
-        <flap-beg>   105 /Rat 100 </flap-beg>
+        <flap-beg>   105 /Wad 100 </flap-beg>
         <flap-ttl>   3 hours      </flap-ttl>
         <flap-tau>   2 days       </flap-tau>
       </flap-state>
@@ -89,7 +89,7 @@ The parameters controlled by governance are:
  // -----------------------------
     rule <k> Flap . file beg BEG => . ... </k>
          <flap-beg> _ => BEG </flap-beg>
-      requires BEG >=Rat 0
+      requires BEG >=Ray 0Ray
 
     rule <k> Flap . file ttl TTL => . ... </k>
          <flap-ttl> _ => TTL </flap-ttl>
@@ -130,8 +130,8 @@ Flap Semantics
          <flap-live> true </flap-live>
          <flap-tau> TAU </flap-tau>
          <frame-events> ... (.List => ListItem(FlapKick(MSGSENDER, KICKS +Int 1, LOT, BID))) </frame-events>
-      requires LOT >=Rat 0
-       andBool BID >=Rat 0
+      requires LOT >=Rad 0Rad
+       andBool BID >=Wad 0Wad
 ```
 
 - tick(uint id)
@@ -155,7 +155,7 @@ Flap Semantics
  // --------------------------------------
     rule <k> Flap . tend ID LOT BID
           => call Gem "MKR" . move MSGSENDER GUY BID'
-          ~> call Gem "MKR" . move MSGSENDER THIS (BID -Rat BID')
+          ~> call Gem "MKR" . move MSGSENDER THIS (BID -Wad BID')
          ...
          </k>
          <msg-sender> MSGSENDER </msg-sender>
@@ -165,13 +165,13 @@ Flap Semantics
          <flap-live> true </flap-live>
          <flap-ttl> TTL </flap-ttl>
          <flap-beg> BEG </flap-beg>
-      requires LOT >=Rat 0
-       andBool BID >=Rat 0
+      requires LOT >=Rad 0Rad
+       andBool BID >=Wad 0Wad
        andBool (TIC >Int NOW orBool TIC ==Int 0)
        andBool END  >Int NOW
-       andBool LOT ==Rat LOT'
-       andBool BID  >Rat BID'
-       andBool BID >=Rat BID' *Rat BEG
+       andBool LOT ==Rad LOT'
+       andBool BID  >Wad BID'
+       andBool BID >=Wad BID' *Wad BEG
 ```
 
 - deal(uint id)
@@ -203,7 +203,7 @@ Flap Semantics
          <msg-sender> MSGSENDER </msg-sender>
          <this> THIS </this>
          <flap-live> _ => false </flap-live>
-      requires RAD >=Rat 0
+      requires RAD >=Rad 0Rad
 ```
 
 - yank(uint id)

--- a/flip.md
+++ b/flip.md
@@ -17,7 +17,7 @@ Flip Configuration
           <flip-ilk>   ""           </flip-ilk>
           <flip-wards> .Set         </flip-wards>
           <flip-bids>  .Map         </flip-bids> // mapping (uint => Bid) Int |-> FlipBid
-          <flip-beg>   105 /Rat 100 </flip-beg>  // Minimum Bid Increase
+          <flip-beg>   105 /Wad 100 </flip-beg>  // Minimum Bid Increase
           <flip-ttl>   3 hours      </flip-ttl>  // Single Bid Lifetime
           <flip-tau>   2 days       </flip-tau>  // Total Auction Length
           <flip-kicks> 0            </flip-kicks>
@@ -91,7 +91,7 @@ The parameters controlled by governance are:
     syntax FlipAuthStep ::= "file" FlipFile
  // ---------------------------------------
 
-    syntax FlipFile ::= "beg" Ray
+    syntax FlipFile ::= "beg" Wad
                       | "ttl" Int
                       | "tau" Int
  // -----------------------------
@@ -101,7 +101,7 @@ The parameters controlled by governance are:
            <flip-beg> _ => BEG </flip-beg>
            ...
          </flip>
-      requires BEG >=Rat 0
+      requires BEG >=Wad 0Wad
 
     rule <k> Flip ILKID . file ttl TTL => . ... </k>
          <flip>
@@ -162,9 +162,9 @@ Flip Semantics
            ...
          </flip>
          <frame-events> ... (.List => ListItem(FlipKick(MSGSENDER, ILK, KICKS +Int 1, LOT, BID, TAB, USR, GAL))) </frame-events>
-      requires TAB >=Rat 0
-       andBool LOT >=Rat 0
-       andBool BID >=Rat 0
+      requires TAB >=Rad 0Rad
+       andBool LOT >=Wad 0Wad
+       andBool BID >=Rad 0Rad
 
     syntax FlipStep ::= "tick" Int
  // ------------------------------
@@ -183,7 +183,7 @@ Flip Semantics
  // --------------------------------------
     rule <k> Flip ILK . tend ID LOT BID
           => call Vat . move MSGSENDER GUY BID'
-          ~> call Vat . move MSGSENDER GAL (BID -Rat BID')
+          ~> call Vat . move MSGSENDER GAL (BID -Rad BID')
          ...
          </k>
          <msg-sender> MSGSENDER </msg-sender>
@@ -195,21 +195,21 @@ Flip Semantics
            <flip-bids> ... ID |-> FlipBid(... bid: BID' => BID, lot: LOT', guy: GUY => MSGSENDER, tic: TIC => NOW +Int TTL, end: END, gal: GAL, tab: TAB) ... </flip-bids>
            ...
          </flip>
-      requires LOT >=Rat 0
-       andBool BID >=Rat 0
+      requires LOT >=Wad 0Wad
+       andBool BID >=Rad 0Rad
        andBool GUY =/=K 0
        andBool (TIC >Int NOW orBool TIC ==Int 0)
        andBool END >Int NOW
-       andBool LOT ==Rat LOT'
-       andBool BID <=Rat TAB
-       andBool BID >Rat BID'
-       andBool (BID >=Rat BEG *Rat BID' orBool BID ==Rat TAB)
+       andBool LOT ==Wad LOT'
+       andBool BID <=Rad TAB
+       andBool BID >Rad BID'
+       andBool (BID >=Rad Wad2Rad(BEG) *Rad BID' orBool BID ==Rad TAB)
 
     syntax FlipStep ::= "dent" Int Wad Rad
  // --------------------------------------
     rule <k> Flip ILK . dent ID LOT BID
           => call Vat.move MSGSENDER GUY BID
-          ~> call Vat.flux ILK THIS USR (LOT' -Rat LOT)
+          ~> call Vat.flux ILK THIS USR (LOT' -Wad LOT)
          ...
          </k>
          <msg-sender> MSGSENDER </msg-sender>
@@ -222,15 +222,15 @@ Flip Semantics
            <flip-bids> ... ID |-> FlipBid(... bid: BID', lot: LOT' => LOT, guy: GUY => MSGSENDER, tic: TIC => NOW +Int TTL, end: END, usr: USR, tab: TAB) ... </flip-bids>
            ...
          </flip>
-      requires LOT >=Rat 0
-       andBool BID >=Rat 0
+      requires LOT >=Wad 0Wad
+       andBool BID >=Rad 0Rad
        andBool GUY =/=K 0
        andBool (TIC >Int NOW orBool TIC ==Int 0)
        andBool END >Int NOW
-       andBool BID ==Rat BID'
-       andBool BID ==Rat TAB
-       andBool LOT <Rat LOT'
-       andBool BEG *Rat LOT <Rat LOT'
+       andBool BID ==Rad BID'
+       andBool BID ==Rad TAB
+       andBool LOT <Wad LOT'
+       andBool BEG *Wad LOT <Wad LOT'
 
     syntax FlipStep ::= "deal" Int
  // ------------------------------
@@ -259,7 +259,7 @@ Flip Semantics
            <flip-bids> ... ID |-> FlipBid(... bid: BID, lot: LOT, guy: GUY, tab: TAB) => .Map ... </flip-bids>
            ...
          </flip>
-      requires GUY =/=K 0 andBool BID <Rat TAB
+      requires GUY =/=K 0 andBool BID <Rad TAB
 ```
 
 ```k

--- a/flop.md
+++ b/flop.md
@@ -19,8 +19,8 @@ Flop Configuration
         <flop-bids>  .Map          </flop-bids>  // mapping (uint => Bid) Int |-> FlopBid
         <flop-kicks>  0            </flop-kicks>
         <flop-live>   true         </flop-live>
-        <flop-beg>    105 /Rat 100 </flop-beg>
-        <flop-pad>    150 /Rat 100 </flop-pad>
+        <flop-beg>    105 /Wad 100 </flop-beg>
+        <flop-pad>    150 /Wad 100 </flop-pad>
         <flop-ttl>    3 hours      </flop-ttl>
         <flop-tau>    2 days       </flop-tau>
         <flop-vow>    0:Address    </flop-vow>
@@ -91,7 +91,7 @@ The parameters controlled by governance are:
  // --------------------------------------
     rule <k> Flop . file beg BEG => . ... </k>
          <flop-beg> _ => BEG </flop-beg>
-      requires BEG >=Rat 0
+      requires BEG >=Ray 0Ray
 
     rule <k> Flop . file ttl TTL => . ... </k>
          <flop-ttl> _ => TTL </flop-ttl>
@@ -103,7 +103,7 @@ The parameters controlled by governance are:
 
     rule <k> Flop . file pad PAD => . ... </k>
          <flop-pad> _ => PAD </flop-pad>
-      requires PAD >=Rat 0
+      requires PAD >=Ray 0Ray
 
     rule <k> Flop . file vow-file ADDR => . ... </k>
          <flop-vow> _ => ADDR </flop-vow>
@@ -138,8 +138,8 @@ Flop Semantics
          <flop-kicks> KICKS => KICKS +Int 1 </flop-kicks>
          <flop-tau> TAU </flop-tau>
          <frame-events> ... (.List => ListItem(FlopKick(KICKS +Int 1, LOT, BID, GAL))) </frame-events>
-      requires LOT >=Rat 0
-       andBool BID >=Rat 0
+      requires LOT >=Wad 0Wad
+       andBool BID >=Rad 0Rad
 ```
 
 - tick(uint id)
@@ -150,7 +150,7 @@ Flop Semantics
  // ------------------------------
     rule <k> Flop . tick ID => . ... </k>
          <current-time> NOW </current-time>
-         <flop-bids> ... ID |-> FlopBid(... lot: LOT => LOT *Rat PAD, tic: 0, end: END => NOW +Int TAU ) ... </flop-bids>
+         <flop-bids> ... ID |-> FlopBid(... lot: LOT => LOT *Wad PAD, tic: 0, end: END => NOW +Int TAU ) ... </flop-bids>
          <flop-pad> PAD </flop-pad>
          <flop-tau> TAU </flop-tau>
       requires END <Int NOW
@@ -172,13 +172,13 @@ Flop Semantics
          <flop-live> true </flop-live>
          <flop-beg> BEG </flop-beg>
          <flop-ttl> TTL </flop-ttl>
-      requires LOT >=Rat 0
-       andBool BID >=Rat 0
+      requires LOT >=Wad 0Wad
+       andBool BID >=Rad 0Rad
        andBool (TIC >Int NOW orBool TIC ==Int 0)
        andBool END >Int NOW
-       andBool BID ==Rat BID'
-       andBool LOT <Rat LOT'
-       andBool LOT *Rat BEG <=Rat LOT'
+       andBool BID ==Rad BID'
+       andBool LOT <Wad LOT'
+       andBool LOT *Wad BEG <=Wad LOT'
 ```
 
 - deal(uint id)

--- a/flop.md
+++ b/flop.md
@@ -83,15 +83,15 @@ The parameters controlled by governance are:
     syntax FlopAuthStep ::= "file" FlopFile
  // ---------------------------------------
 
-    syntax FlopFile ::= "beg" Ray
+    syntax FlopFile ::= "beg" Wad
                       | "ttl" Int
                       | "tau" Int
-                      | "pad" Ray
+                      | "pad" Wad
                       | "vow-file" Address
  // --------------------------------------
     rule <k> Flop . file beg BEG => . ... </k>
          <flop-beg> _ => BEG </flop-beg>
-      requires BEG >=Ray 0Ray
+      requires BEG >=Wad 0Wad
 
     rule <k> Flop . file ttl TTL => . ... </k>
          <flop-ttl> _ => TTL </flop-ttl>
@@ -103,7 +103,7 @@ The parameters controlled by governance are:
 
     rule <k> Flop . file pad PAD => . ... </k>
          <flop-pad> _ => PAD </flop-pad>
-      requires PAD >=Ray 0Ray
+      requires PAD >=Wad 0Wad
 
     rule <k> Flop . file vow-file ADDR => . ... </k>
          <flop-vow> _ => ADDR </flop-vow>

--- a/gem.md
+++ b/gem.md
@@ -46,7 +46,7 @@ Because data isn't explicitely initialized to 0 in KMCD, we need explicit initia
     rule <k> Gem GEMID . initUser ADDR => . ... </k>
          <gem>
             <gem-id> GEMID </gem-id>
-            <gem-balances> BALS => BALS [ ADDR <- 0 ] </gem-balances>
+            <gem-balances> BALS => BALS [ ADDR <- 0Wad ] </gem-balances>
             ...
          </gem>
       requires notBool ADDR in_keys(BALS)
@@ -63,16 +63,16 @@ Gem Semantics
            <gem-id> GEMID </gem-id>
            <gem-balances>
              ...
-             ACCTSRC |-> ( BALANCE_SRC => BALANCE_SRC -Rat VALUE )
-             ACCTDST |-> ( BALANCE_DST => BALANCE_DST +Rat VALUE )
+             ACCTSRC |-> ( BALANCE_SRC => BALANCE_SRC -Wad VALUE )
+             ACCTDST |-> ( BALANCE_DST => BALANCE_DST +Wad VALUE )
              ...
            </gem-balances>
            ...
          </gem>
-      requires VALUE >=Rat 0
+      requires VALUE >=Wad 0Wad
        andBool ACCTSRC =/=K ACCTDST
-       andBool VALUE >=Rat 0
-       andBool BALANCE_SRC >=Rat VALUE
+       andBool VALUE >=Wad 0Wad
+       andBool BALANCE_SRC >=Wad VALUE
 
     rule <k> Gem GEMID . transferFrom ACCTSRC ACCTSRC VALUE => . ... </k>
          <gem>
@@ -80,52 +80,52 @@ Gem Semantics
            <gem-balances> ... ACCTSRC |-> BALANCE_SRC ... </gem-balances>
            ...
          </gem>
-      requires VALUE >=Rat 0
-       andBool BALANCE_SRC >=Rat VALUE
+      requires VALUE >=Wad 0Wad
+       andBool BALANCE_SRC >=Wad VALUE
 
     syntax GemStep ::= "move" Address Address Wad
  // ---------------------------------------------
     rule <k> Gem _ . (move ACCTSRC ACCTDST VALUE => transferFrom ACCTSRC ACCTDST VALUE) ... </k>
-      requires VALUE >=Rat 0
+      requires VALUE >=Wad 0Wad
 
     syntax GemStep ::= "push" Address Wad
  // -------------------------------------
     rule <k> Gem _ . (push ACCTDST VALUE => transferFrom MSGSENDER ACCTDST VALUE) ... </k>
          <msg-sender> MSGSENDER </msg-sender>
-      requires VALUE >=Rat 0
+      requires VALUE >=Wad 0Wad
 
     syntax GemStep ::= "pull" Address Wad
  // -------------------------------------
     rule <k> Gem _ . (pull ACCTSRC VALUE => transferFrom ACCTSRC MSGSENDER VALUE) ... </k>
          <msg-sender> MSGSENDER </msg-sender>
-      requires VALUE >=Rat 0
+      requires VALUE >=Wad 0Wad
 
     syntax GemStep ::= "transfer" Address Wad
  // -----------------------------------------
     rule <k> Gem _ . (transfer ACCTDST VALUE => transferFrom MSGSENDER ACCTDST VALUE) ... </k>
          <msg-sender> MSGSENDER </msg-sender>
-      requires VALUE >=Rat 0
+      requires VALUE >=Wad 0Wad
 
     syntax GemStep ::= "mint" Address Wad
  // -------------------------------------
     rule <k> Gem GEMID . mint ACCTDST VALUE => . ... </k>
          <gem>
            <gem-id> GEMID </gem-id>
-           <gem-balances> ... ACCTDST |-> ( BALANCE_DST => BALANCE_DST +Rat VALUE ) ... </gem-balances>
+           <gem-balances> ... ACCTDST |-> ( BALANCE_DST => BALANCE_DST +Wad VALUE ) ... </gem-balances>
            ...
          </gem>
-      requires VALUE >=Rat 0
+      requires VALUE >=Wad 0Wad
 
     syntax GemStep ::= "burn" Address Wad
  // -------------------------------------
     rule <k> Gem GEMID . burn ACCTSRC VALUE => . ... </k>
          <gem>
            <gem-id> GEMID </gem-id>
-           <gem-balances> ... ACCTSRC |-> ( BALANCE_SRC => BALANCE_SRC -Rat VALUE ) ... </gem-balances>
+           <gem-balances> ... ACCTSRC |-> ( BALANCE_SRC => BALANCE_SRC -Wad VALUE ) ... </gem-balances>
            ...
          </gem>
-      requires VALUE >=Rat 0
-       andBool BALANCE_SRC >=Rat VALUE
+      requires VALUE >=Wad 0Wad
+       andBool BALANCE_SRC >=Wad VALUE
 ```
 
 ```k

--- a/join.md
+++ b/join.md
@@ -121,7 +121,7 @@ Join Semantics
     syntax GemJoinStep ::= "exit" Address Wad
  // -----------------------------------------
     rule <k> GemJoin GEMID . exit USR AMOUNT
-          => call Vat . slip GEMID MSGSENDER (0 -Wad AMOUNT)
+          => call Vat . slip GEMID MSGSENDER (0Wad -Wad AMOUNT)
           ~> call Gem GEMID . transfer USR AMOUNT
          ...
          </k>
@@ -131,7 +131,7 @@ Join Semantics
     syntax DaiJoinStep ::= "join" Address Wad
  // -----------------------------------------
     rule <k> DaiJoin . join USR AMOUNT
-          => call Vat . move THIS USR AMOUNT
+          => call Vat . move THIS USR Wad2Rad(AMOUNT)
           ~> call Dai . burn MSGSENDER AMOUNT
          ...
          </k>
@@ -143,7 +143,7 @@ Join Semantics
     syntax DaiJoinStep ::= "exit" Address Wad
  // -----------------------------------------
     rule <k> DaiJoin . exit USR AMOUNT
-          => call Vat . move MSGSENDER THIS AMOUNT
+          => call Vat . move MSGSENDER THIS Wad2Rad(AMOUNT)
           ~> call Dai . mint USR AMOUNT
          ...
          </k>

--- a/join.md
+++ b/join.md
@@ -116,17 +116,17 @@ Join Semantics
            <gem-join-live> true </gem-join-live>
            ...
          </gem-join>
-      requires AMOUNT >=Rat 0
+      requires AMOUNT >=Wad 0Wad
 
     syntax GemJoinStep ::= "exit" Address Wad
  // -----------------------------------------
     rule <k> GemJoin GEMID . exit USR AMOUNT
-          => call Vat . slip GEMID MSGSENDER (0 -Rat AMOUNT)
+          => call Vat . slip GEMID MSGSENDER (0 -Wad AMOUNT)
           ~> call Gem GEMID . transfer USR AMOUNT
          ...
          </k>
          <msg-sender> MSGSENDER </msg-sender>
-      requires AMOUNT >=Rat 0
+      requires AMOUNT >=Wad 0Wad
 
     syntax DaiJoinStep ::= "join" Address Wad
  // -----------------------------------------
@@ -138,7 +138,7 @@ Join Semantics
          <msg-sender> MSGSENDER </msg-sender>
          <this> THIS </this>
          <dai-join-live> true </dai-join-live>
-      requires AMOUNT >=Rat 0
+      requires AMOUNT >=Wad 0Wad
 
     syntax DaiJoinStep ::= "exit" Address Wad
  // -----------------------------------------
@@ -149,7 +149,7 @@ Join Semantics
          </k>
          <msg-sender> MSGSENDER </msg-sender>
          <this> THIS </this>
-      requires AMOUNT >=Rat 0
+      requires AMOUNT >=Wad 0Wad
 ```
 
 Join Deactivation

--- a/jug.md
+++ b/jug.md
@@ -16,7 +16,7 @@ Jug Configuration
         <jug-wards> .Set      </jug-wards>
         <jug-ilks>  .Map      </jug-ilks> // mapping (bytes32 => JugIlk) String  |-> JugIlk
         <jug-vow>   0:Address </jug-vow>  //                             Address
-        <jug-base>  0:Ray     </jug-base> //                             Ray
+        <jug-base>  0Ray      </jug-base> //                             Ray
       </jug>
 ```
 
@@ -80,11 +80,11 @@ These parameters are controlled by governance:
          <jug-ilks> ... ILK |-> Ilk ( ... duty: (_ => DUTY) , rho: RHO ) ... </jug-ilks>
          <current-time> NOW </current-time>
       requires NOW ==Int RHO
-       andBool DUTY >=Rat 0
+       andBool DUTY >=Ray 0Ray
 
     rule <k> Jug . file base BASE => . ... </k>
          <jug-base> _ => BASE </jug-base>
-      requires BASE >=Rat 0
+      requires BASE >=Ray 0Ray
 
     rule <k> Jug . file vow-file ADDR => . ... </k>
          <jug-vow> _ => ADDR </jug-vow>
@@ -100,13 +100,13 @@ Jug Semantics
  // ------------------------------------
     rule <k> Jug . init ILK => . ... </k>
          <current-time> NOW </current-time>
-         <jug-ilks> ... ILK |-> Ilk ( ... duty: 0 => 1, rho: _ => NOW ) ... </jug-ilks>
+         <jug-ilks> ... ILK |-> Ilk ( ... duty: 0Ray => 1Ray, rho: _ => NOW ) ... </jug-ilks>
 ```
 
 ```k
     syntax JugStep ::= "drip" String
  // --------------------------------
-    rule <k> Jug . drip ILK => call Vat . fold ILK ADDRESS ( ( (BASE +Rat ILKDUTY) ^Rat (TIME -Int ILKRHO) ) *Rat ILKRATE ) -Rat ILKRATE ... </k>
+    rule <k> Jug . drip ILK => call Vat . fold ILK ADDRESS ( ( (BASE +Ray ILKDUTY) ^Ray (TIME -Int ILKRHO) ) *Ray ILKRATE ) -Ray ILKRATE ... </k>
          <current-time> TIME </current-time>
          <vat-ilks> ... ILK |-> Ilk ( ... rate: ILKRATE ) ... </vat-ilks>
          <jug-ilks> ... ILK |-> Ilk ( ... duty: ILKDUTY, rho: ILKRHO => TIME ) ... </jug-ilks>

--- a/kmcd-data.md
+++ b/kmcd-data.md
@@ -54,13 +54,21 @@ We model everything with arbitrary precision rationals, but use sort information
 ```
 
 ```k
-    syntax Ray ::= Wad2Ray ( Wad ) [function]
+    syntax Wad ::= Int2Wad ( Int ) [function]
  // -----------------------------------------
+    rule Int2Wad(I) => I
+
+    syntax Ray ::= Int2Ray ( Int ) [function]
+                 | Wad2Ray ( Wad ) [function]
+ // -----------------------------------------
+    rule Int2Ray(I) => I
     rule Wad2Ray(W) => W
 
-    syntax Rad ::= Wad2Rad ( Wad ) [function]
+    syntax Rad ::= Int2Rad ( Int ) [function]
+                 | Wad2Rad ( Wad ) [function]
                  | Ray2Rad ( Ray ) [function]
  // -----------------------------------------
+    rule Int2Rad(I) => I
     rule Wad2Rad(W) => W
     rule Ray2Rad(R) => R
 ```

--- a/kmcd-data.md
+++ b/kmcd-data.md
@@ -177,10 +177,8 @@ We model everything with arbitrary precision rationals, but use sort information
 
 ```k
     syntax Rad ::= Wad "*RateWad" Ray [function]
-                 | Rad "*RateRad" Ray [function]
  // --------------------------------------------
     rule R1 *RateWad R2 => R1 *Rat R2
-    rule R1 *RateRad R2 => R1 *Rat R2
 
     syntax Wad ::= Rad "/Rate" Ray [function]
  // -----------------------------------------

--- a/kmcd-data.md
+++ b/kmcd-data.md
@@ -267,6 +267,18 @@ module KMCD-RANDOM-CHOICES
     rule chooseString (I, ITEMS) => { ITEMS [ I modInt size(ITEMS) ] }:>String
     rule chooseAddress(I, ITEMS) => { ITEMS [ I modInt size(ITEMS) ] }:>Address
     rule chooseCDPID  (I, ITEMS) => { ITEMS [ I modInt size(ITEMS) ] }:>CDPID
+
+    syntax Wad ::= randWadBounded ( Int , Wad ) [function]
+ // ------------------------------------------------------
+    rule randWadBounded(I, W) => randRatBounded(I, W)
+
+    syntax Ray ::= randRayBounded ( Int , Ray ) [function]
+ // ------------------------------------------------------
+    rule randRayBounded(I, R) => randRatBounded(I, R)
+
+    syntax Rad ::= randRadBounded ( Int , Rad ) [function]
+ // ------------------------------------------------------
+    rule randRadBounded(I, R) => randRatBounded(I, R)
 ```
 
 ```k

--- a/kmcd-data.md
+++ b/kmcd-data.md
@@ -36,6 +36,88 @@ We model everything with arbitrary precision rationals, but use sort information
  // --------------------------------
 ```
 
+```k
+    syntax Wad ::= Wad "*Wad" Wad [function]
+                 | Wad "/Wad" Wad [function]
+                 > Wad "+Wad" Wad [function]
+                 | Wad "-Wad" Wad [function]
+ // ----------------------------------------
+    rule R1 *Wad R2 => R1 *Rat R2
+    rule R1 /Wad R2 => R1 /Rat R2
+    rule R1 +Wad R2 => R1 +Rat R2
+    rule R1 -Wad R2 => R1 -Rat R2
+
+    syntax Ray ::= Ray "*Ray" Ray [function]
+                 | Ray "/Ray" Ray [function]
+                 > Ray "+Ray" Ray [function]
+                 | Ray "-Ray" Ray [function]
+ // ----------------------------------------
+    rule R1 *Ray R2 => R1 *Rat R2
+    rule R1 /Ray R2 => R1 /Rat R2
+    rule R1 +Ray R2 => R1 +Rat R2
+    rule R1 -Ray R2 => R1 -Rat R2
+
+    syntax Rad ::= Rad "*Rad" Rad [function]
+                 | Rad "/Rad" Rad [function]
+                 > Rad "+Rad" Rad [function]
+                 | Rad "-Rad" Rad [function]
+ // ----------------------------------------
+    rule R1 *Rad R2 => R1 *Rat R2
+    rule R1 /Rad R2 => R1 /Rat R2
+    rule R1 +Rad R2 => R1 +Rat R2
+    rule R1 -Rad R2 => R1 -Rat R2
+```
+
+```k
+    syntax Bool ::= Wad  "<=Wad" Wad [function]
+                  | Wad   "<Wad" Wad [function]
+                  | Wad  ">=Wad" Wad [function]
+                  | Wad   ">Wad" Wad [function]
+                  | Wad  "==Wad" Wad [function]
+                  | Wad "=/=Wad" Wad [function]
+ // -------------------------------------------
+    rule W1  <=Wad W2 => W1  <=Rat W2
+    rule W1   <Wad W2 => W1   <Rat W2
+    rule W1  >=Wad W2 => W1  >=Rat W2
+    rule W1   >Wad W2 => W1   >Rat W2
+    rule W1  ==Wad W2 => W1  ==Rat W2
+    rule W1 =/=Wad W2 => W1 =/=Rat W2
+
+    syntax Bool ::= Ray  "<=Ray" Ray [function]
+                  | Ray   "<Ray" Ray [function]
+                  | Ray  ">=Ray" Ray [function]
+                  | Ray   ">Ray" Ray [function]
+                  | Ray  "==Ray" Ray [function]
+                  | Ray "=/=Ray" Ray [function]
+ // -------------------------------------------
+    rule W1  <=Ray W2 => W1  <=Rat W2
+    rule W1   <Ray W2 => W1   <Rat W2
+    rule W1  >=Ray W2 => W1  >=Rat W2
+    rule W1   >Ray W2 => W1   >Rat W2
+    rule W1  ==Ray W2 => W1  ==Rat W2
+    rule W1 =/=Ray W2 => W1 =/=Rat W2
+
+    syntax Bool ::= Rad  "<=Rad" Rad [function]
+                  | Rad   "<Rad" Rad [function]
+                  | Rad  ">=Rad" Rad [function]
+                  | Rad   ">Rad" Rad [function]
+                  | Rad  "==Rad" Rad [function]
+                  | Rad "=/=Rad" Rad [function]
+ // -------------------------------------------
+    rule W1  <=Rad W2 => W1  <=Rat W2
+    rule W1   <Rad W2 => W1   <Rat W2
+    rule W1  >=Rad W2 => W1  >=Rat W2
+    rule W1   >Rad W2 => W1   >Rat W2
+    rule W1  ==Rad W2 => W1  ==Rat W2
+    rule W1 =/=Rad W2 => W1 =/=Rat W2
+```
+
+```k
+    syntax Rad ::= Wad "*Rate" Ray [function]
+ // -----------------------------------------
+    rule R1 *Rate R2 => R1 *Rat R2
+```
+
 Time Increments
 ---------------
 

--- a/kmcd-data.md
+++ b/kmcd-data.md
@@ -121,7 +121,6 @@ We model everything with arbitrary precision rationals, but use sort information
  // ----------------------------------------------
     rule minRad(W1, W2) => minRat(W1, W2)
     rule maxRad(W1, W2) => maxRat(W1, W2)
-
 ```
 
 ```k
@@ -234,4 +233,3 @@ Collateral Increments
 ```k
 endmodule
 ```
-

--- a/kmcd-data.md
+++ b/kmcd-data.md
@@ -176,9 +176,9 @@ We model everything with arbitrary precision rationals, but use sort information
 ```
 
 ```k
-    syntax Rad ::= Wad "*RateWad" Ray [function]
- // --------------------------------------------
-    rule R1 *RateWad R2 => R1 *Rat R2
+    syntax Rad ::= Wad "*Rate" Ray [function]
+ // -----------------------------------------
+    rule R1 *Rate R2 => R1 *Rat R2
 
     syntax Wad ::= Rad "/Rate" Ray [function]
  // -----------------------------------------

--- a/kmcd-data.md
+++ b/kmcd-data.md
@@ -172,6 +172,22 @@ We model everything with arbitrary precision rationals, but use sort information
     syntax Rad ::= Wad "*Rate" Ray [function]
  // -----------------------------------------
     rule R1 *Rate R2 => R1 *Rat R2
+
+    syntax Wad ::= Rad "/Rate" Ray [function]
+ // -----------------------------------------
+    rule R1 /Rate R2 => R1 /Rat R2
+
+    syntax Wad ::= rmul ( Wad , Ray ) [function]
+ // --------------------------------------------
+    rule rmul(R1, R2) => R1 *Rat R2
+
+    syntax Ray ::= rdiv ( Ray , Rad ) [function]
+ // --------------------------------------------
+    rule rdiv(R1, R2) => R1 /Rat R2
+
+    syntax Ray ::= wdiv ( Ray , Wad ) [function]
+ // --------------------------------------------
+    rule wdiv(R1, R2) => R1 /Rat R2
 ```
 
 Time Increments

--- a/kmcd-data.md
+++ b/kmcd-data.md
@@ -54,6 +54,18 @@ We model everything with arbitrary precision rationals, but use sort information
 ```
 
 ```k
+    syntax Ray ::= Wad2Ray ( Wad ) [function]
+ // -----------------------------------------
+    rule Wad2Ray(W) => W
+
+    syntax Rad ::= Wad2Rad ( Wad ) [function]
+                 | Ray2Rad ( Ray ) [function]
+ // -----------------------------------------
+    rule Wad2Rad(W) => W
+    rule Ray2Rad(R) => R
+```
+
+```k
     syntax Wad ::= Wad "*Wad" Wad [function]
                  | Wad "/Wad" Wad [function]
                  | Wad "^Wad" Int [function]

--- a/kmcd-data.md
+++ b/kmcd-data.md
@@ -186,9 +186,13 @@ We model everything with arbitrary precision rationals, but use sort information
  // -----------------------------------------
     rule R1 /Rate R2 => R1 /Rat R2
 
-    syntax Wad ::= rmul ( Wad , Ray ) [function]
- // --------------------------------------------
-    rule rmul(R1, R2) => R1 *Rat R2
+    syntax Wad ::= rmulWad ( Wad , Ray ) [function]
+ // -----------------------------------------------
+    rule rmulWad(R1, R2) => R1 *Rat R2
+
+    syntax Rad ::= rmulRad ( Rad , Ray ) [function]
+ // -----------------------------------------------
+    rule rmulRad(R1, R2) => R1 *Rat R2
 
     syntax Ray ::= rdiv ( Ray , Rad ) [function]
  // --------------------------------------------

--- a/kmcd-data.md
+++ b/kmcd-data.md
@@ -1,0 +1,83 @@
+KMCD Data
+=========
+
+This module defines base data-types needed for the KMCD system.
+
+```k
+requires "rat.k"
+
+module KMCD-DATA
+    imports BOOL
+    imports INT
+    imports RAT
+    imports MAP
+```
+
+Precision Quantities
+--------------------
+
+We model everything with arbitrary precision rationals, but use sort information to indicate the EVM code precision.
+
+-   `Wad`: basic quantities (e.g. balances). Represented in implementation as 1e18 fixed point.
+-   `Ray`: precise quantities (e.g. ratios). Represented in implementation as 1e27 fixed point.
+-   `Rad`: result of multiplying `Wad` and `Ray` (highest precision). Represented in implementation as 1e45 fixed point.
+
+```k
+    syntax Wad = Rat
+ // ----------------
+
+    syntax Ray = Rat
+ // ----------------
+
+    syntax Rad = Rat
+ // ----------------
+
+    syntax MaybeWad ::= Wad | ".Wad"
+ // --------------------------------
+```
+
+Time Increments
+---------------
+
+Some methods rely on a timestamp.
+We simulate that here.
+
+```k
+    syntax priorities timeUnit > _+Int_ _-Int_ _*Int_ _/Int_
+ // --------------------------------------------------------
+
+    syntax Int ::= Int "second"  [timeUnit]
+                 | Int "seconds" [timeUnit]
+                 | Int "minute"  [timeUnit]
+                 | Int "minutes" [timeUnit]
+                 | Int "hour"    [timeUnit]
+                 | Int "hours"   [timeUnit]
+                 | Int "day"     [timeUnit]
+                 | Int "days"    [timeUnit]
+ // ---------------------------------------
+    rule 1 second  => 1                    [macro]
+    rule N seconds => N                    [macro]
+    rule 1 minute  =>        60    seconds [macro]
+    rule N minutes => N *Int 60    seconds [macro]
+    rule 1 hour    =>        3600  seconds [macro]
+    rule N hours   => N *Int 3600  seconds [macro]
+    rule 1 day     =>        86400 seconds [macro]
+    rule N days    => N *Int 86400 seconds [macro]
+```
+
+Collateral Increments
+---------------------
+
+```k
+    syntax priorities collateralUnit > _+Int_ _-Int_ _*Int_ _/Int_
+ // --------------------------------------------------------------
+
+    syntax Int ::= Int "ether" [collateralUnit]
+ // -------------------------------------------
+    rule N ether => N *Int 1000000000 [macro]
+```
+
+```k
+endmodule
+```
+

--- a/kmcd-data.md
+++ b/kmcd-data.md
@@ -24,13 +24,19 @@ We model everything with arbitrary precision rationals, but use sort information
 
 ```k
     syntax Wad = Rat
- // ----------------
+    syntax Wad ::= wad ( Rat )
+ // --------------------------
+    rule wad(R) => R [macro]
 
     syntax Ray = Rat
- // ----------------
+    syntax Ray ::= ray ( Rat )
+ // --------------------------
+    rule ray(R) => R [macro]
 
     syntax Rad = Rat
- // ----------------
+    syntax Rad ::= rad ( Rat )
+ // --------------------------
+    rule rad(R) => R [macro]
 
     syntax MaybeWad ::= Wad | ".Wad"
  // --------------------------------
@@ -54,21 +60,13 @@ We model everything with arbitrary precision rationals, but use sort information
 ```
 
 ```k
-    syntax Wad ::= Int2Wad ( Int ) [function]
+    syntax Ray ::= Wad2Ray ( Wad ) [function]
  // -----------------------------------------
-    rule Int2Wad(I) => I
-
-    syntax Ray ::= Int2Ray ( Int ) [function]
-                 | Wad2Ray ( Wad ) [function]
- // -----------------------------------------
-    rule Int2Ray(I) => I
     rule Wad2Ray(W) => W
 
-    syntax Rad ::= Int2Rad ( Int ) [function]
-                 | Wad2Rad ( Wad ) [function]
+    syntax Rad ::= Wad2Rad ( Wad ) [function]
                  | Ray2Rad ( Ray ) [function]
  // -----------------------------------------
-    rule Int2Rad(I) => I
     rule Wad2Rad(W) => W
     rule Ray2Rad(R) => R
 ```

--- a/kmcd-data.md
+++ b/kmcd-data.md
@@ -168,9 +168,11 @@ We model everything with arbitrary precision rationals, but use sort information
 ```
 
 ```k
-    syntax Rad ::= Wad "*Rate" Ray [function]
- // -----------------------------------------
-    rule R1 *Rate R2 => R1 *Rat R2
+    syntax Rad ::= Wad "*RateWad" Ray [function]
+                 | Rad "*RateRad" Ray [function]
+ // --------------------------------------------
+    rule R1 *RateWad R2 => R1 *Rat R2
+    rule R1 *RateRad R2 => R1 *Rat R2
 
     syntax Wad ::= Rad "/Rate" Ray [function]
  // -----------------------------------------

--- a/kmcd-data.md
+++ b/kmcd-data.md
@@ -235,3 +235,40 @@ Collateral Increments
 ```k
 endmodule
 ```
+
+Random Choices
+--------------
+
+```k
+module KMCD-RANDOM-CHOICES
+    imports KMCD-DATA
+```
+
+```k
+    syntax Int ::= randIntBounded ( Int , Int ) [function]
+ // ------------------------------------------------------
+    rule randIntBounded(RAND, BOUND) => 0                          requires         BOUND <Int 0
+    rule randIntBounded(RAND, BOUND) => RAND modInt (BOUND +Int 1) requires notBool BOUND <Int 0
+
+    syntax Rat ::= randRat ( Int ) [function]
+ // -----------------------------------------
+    rule randRat(I) => I /Rat 256
+
+    syntax Rat ::= randRatBounded ( Int , Rat ) [function]
+ // ------------------------------------------------------
+    rule randRatBounded(I, BOUND) => BOUND *Rat randRat(I)
+
+    syntax Int     ::= chooseInt     ( Int , List ) [function]
+    syntax String  ::= chooseString  ( Int , List ) [function]
+    syntax Address ::= chooseAddress ( Int , List ) [function]
+    syntax CDPID   ::= chooseCDPID   ( Int , List ) [function]
+ // ----------------------------------------------------------
+    rule chooseInt    (I, ITEMS) => { ITEMS [ I modInt size(ITEMS) ] }:>Int
+    rule chooseString (I, ITEMS) => { ITEMS [ I modInt size(ITEMS) ] }:>String
+    rule chooseAddress(I, ITEMS) => { ITEMS [ I modInt size(ITEMS) ] }:>Address
+    rule chooseCDPID  (I, ITEMS) => { ITEMS [ I modInt size(ITEMS) ] }:>CDPID
+```
+
+```k
+endmodule
+```

--- a/kmcd-data.md
+++ b/kmcd-data.md
@@ -37,6 +37,23 @@ We model everything with arbitrary precision rationals, but use sort information
 ```
 
 ```k
+    syntax Wad ::= "0Wad" | "1Wad"
+ // ------------------------------
+    rule 0Wad => 0 [macro]
+    rule 1Wad => 1 [macro]
+
+    syntax Ray ::= "0Ray" | "1Ray"
+ // ------------------------------
+    rule 0Ray => 0 [macro]
+    rule 1Ray => 1 [macro]
+
+    syntax Rad ::= "0Rad" | "1Rad"
+ // ------------------------------
+    rule 0Rad => 0 [macro]
+    rule 1Rad => 1 [macro]
+```
+
+```k
     syntax Wad ::= Wad "*Wad" Wad [function]
                  | Wad "/Wad" Wad [function]
                  | Wad "^Wad" Int [function]

--- a/kmcd-data.md
+++ b/kmcd-data.md
@@ -104,6 +104,27 @@ We model everything with arbitrary precision rationals, but use sort information
 ```
 
 ```k
+    syntax Wad ::= minWad ( Wad , Wad ) [function]
+                 | maxWad ( Wad , Wad ) [function]
+ // ----------------------------------------------
+    rule minWad(W1, W2) => minRat(W1, W2)
+    rule maxWad(W1, W2) => maxRat(W1, W2)
+
+    syntax Ray ::= minRay ( Ray , Ray ) [function]
+                 | maxRay ( Ray , Ray ) [function]
+ // ----------------------------------------------
+    rule minRay(W1, W2) => minRat(W1, W2)
+    rule maxRay(W1, W2) => maxRat(W1, W2)
+
+    syntax Rad ::= minRad ( Rad , Rad ) [function]
+                 | maxRad ( Rad , Rad ) [function]
+ // ----------------------------------------------
+    rule minRad(W1, W2) => minRat(W1, W2)
+    rule maxRad(W1, W2) => maxRat(W1, W2)
+
+```
+
+```k
     syntax Bool ::= Wad  "<=Wad" Wad [function]
                   | Wad   "<Wad" Wad [function]
                   | Wad  ">=Wad" Wad [function]

--- a/kmcd-data.md
+++ b/kmcd-data.md
@@ -39,31 +39,37 @@ We model everything with arbitrary precision rationals, but use sort information
 ```k
     syntax Wad ::= Wad "*Wad" Wad [function]
                  | Wad "/Wad" Wad [function]
+                 | Wad "^Wad" Int [function]
                  > Wad "+Wad" Wad [function]
                  | Wad "-Wad" Wad [function]
  // ----------------------------------------
     rule R1 *Wad R2 => R1 *Rat R2
     rule R1 /Wad R2 => R1 /Rat R2
+    rule R1 ^Wad R2 => R1 ^Rat R2
     rule R1 +Wad R2 => R1 +Rat R2
     rule R1 -Wad R2 => R1 -Rat R2
 
     syntax Ray ::= Ray "*Ray" Ray [function]
                  | Ray "/Ray" Ray [function]
+                 | Ray "^Ray" Int [function]
                  > Ray "+Ray" Ray [function]
                  | Ray "-Ray" Ray [function]
  // ----------------------------------------
     rule R1 *Ray R2 => R1 *Rat R2
     rule R1 /Ray R2 => R1 /Rat R2
+    rule R1 ^Ray R2 => R1 ^Rat R2
     rule R1 +Ray R2 => R1 +Rat R2
     rule R1 -Ray R2 => R1 -Rat R2
 
     syntax Rad ::= Rad "*Rad" Rad [function]
                  | Rad "/Rad" Rad [function]
+                 | Rad "^Rad" Int [function]
                  > Rad "+Rad" Rad [function]
                  | Rad "-Rad" Rad [function]
  // ----------------------------------------
     rule R1 *Rad R2 => R1 *Rat R2
     rule R1 /Rad R2 => R1 /Rat R2
+    rule R1 ^Rad R2 => R1 ^Rat R2
     rule R1 +Rad R2 => R1 +Rat R2
     rule R1 -Rad R2 => R1 -Rat R2
 ```

--- a/kmcd-driver.md
+++ b/kmcd-driver.md
@@ -4,14 +4,12 @@ KMCD Driver
 This module defines common state and control flow between all the other KMCD modules.
 
 ```k
-requires "rat.k"
+requires "kmcd-data.k"
 
 module KMCD-DRIVER
-    imports BOOL
-    imports INT
+    imports KMCD-DATA
     imports MAP
     imports STRING
-    imports RAT
 
     configuration
         <kmcd-driver>
@@ -165,32 +163,8 @@ Most operations add to the log, which stores the address which made the call and
  // --------------------------------------------------------------------
 ```
 
-Base Data
----------
-
-### Precision Quantities
-
-We model everything with arbitrary precision rationals, but use sort information to indicate the EVM code precision.
-
--   `Wad`: basic quantities (e.g. balances). Represented in implementation as 1e18 fixed point.
--   `Ray`: precise quantities (e.g. ratios). Represented in implementation as 1e27 fixed point.
--   `Rad`: result of multiplying `Wad` and `Ray` (highest precision). Represented in implementation as 1e45 fixed point.
-
-```k
-    syntax Wad = Rat
- // ----------------
-
-    syntax Ray = Rat
- // ----------------
-
-    syntax Rad = Rat
- // ----------------
-
-    syntax MaybeWad ::= Wad | ".Wad"
- // --------------------------------
-```
-
-### Time Increments
+Time Steps
+----------
 
 Some methods rely on a timestamp.
 We simulate that here.
@@ -208,38 +182,6 @@ We simulate that here.
          <current-time> TIME => TIME +Int N </current-time>
          <events> ... (.List => ListItem(TimeStep(N, TIME +Int N))) </events>
       requires N >Int 0
-
-    syntax priorities timeUnit > _+Int_ _-Int_ _*Int_ _/Int_
- // --------------------------------------------------------
-
-    syntax Int ::= Int "second"  [timeUnit]
-                 | Int "seconds" [timeUnit]
-                 | Int "minute"  [timeUnit]
-                 | Int "minutes" [timeUnit]
-                 | Int "hour"    [timeUnit]
-                 | Int "hours"   [timeUnit]
-                 | Int "day"     [timeUnit]
-                 | Int "days"    [timeUnit]
- // ---------------------------------------
-    rule 1 second  => 1                    [macro]
-    rule N seconds => N                    [macro]
-    rule 1 minute  =>        60    seconds [macro]
-    rule N minutes => N *Int 60    seconds [macro]
-    rule 1 hour    =>        3600  seconds [macro]
-    rule N hours   => N *Int 3600  seconds [macro]
-    rule 1 day     =>        86400 seconds [macro]
-    rule N days    => N *Int 86400 seconds [macro]
-```
-
-### Collateral Increments
-
-```k
-    syntax priorities collateralUnit > _+Int_ _-Int_ _*Int_ _/Int_
- // --------------------------------------------------------------
-
-    syntax Int ::= Int "ether" [collateralUnit]
- // -------------------------------------------
-    rule N ether => N *Int 1000000000 [macro]
 ```
 
 ```k

--- a/kmcd-driver.md
+++ b/kmcd-driver.md
@@ -190,17 +190,6 @@ We model everything with arbitrary precision rationals, but use sort information
  // --------------------------------
 ```
 
-### Lookup Defaulting to 0
-
-Sometimes you need a lookup to default to zero, and want to cast the result as a `Rat`.
-
-```k
-    syntax Rat ::= #lookup ( Map , Address ) [function]
- // ---------------------------------------------------
-    rule #lookup(M, A) => { M[A] }:>Rat requires A in_keys(M)
-    rule #lookup(M, A) => 0             [owise]
-```
-
 ### Time Increments
 
 Some methods rely on a timestamp.

--- a/kmcd-prelude.md
+++ b/kmcd-prelude.md
@@ -73,14 +73,14 @@ module KMCD-PRELUDE
          // -------------------------------------------------------------
 
          // Vat parameters
-         transact ADMIN Vat . file Line Int2Rad(1000 ether)
+         transact ADMIN Vat . file Line rad(1000 ether)
 
          // Vow parameters
-         transact ADMIN Vow . file bump Int2Rad(1 ether) // flap fixed lot size
-         transact ADMIN Vow . file hump Int2Rad(0)       // surplus buffer
-         transact ADMIN Vow . file sump Int2Rad(50)      // flop fixed bid size
-         transact ADMIN Vow . file dump Int2Wad(30)      // flop initial lot size
-         transact ADMIN Flop . file tau 3600             // flop auction liftime (s)
+         transact ADMIN Vow . file bump rad(1 ether) // flap fixed lot size
+         transact ADMIN Vow . file hump rad(0)       // surplus buffer
+         transact ADMIN Vow . file sump rad(50)      // flop fixed bid size
+         transact ADMIN Vow . file dump wad(30)      // flop initial lot size
+         transact ADMIN Flop . file tau 3600         // flop auction liftime (s)
 
          .MCDSteps
       [macro]
@@ -102,7 +102,7 @@ module KMCD-PRELUDE
 
          // Initialize Spot for gold
          transact ADMIN Spot . init     "gold"
-         transact ADMIN Spot . setPrice "gold" Int2Wad(3 ether)
+         transact ADMIN Spot . setPrice "gold" wad(3 ether)
          transact ADMIN Spot . file       mat "gold" 1Ray
          transact ADMIN Spot . file       par 1Ray
 
@@ -115,7 +115,7 @@ module KMCD-PRELUDE
 
          // Initialize "gold for Vat
          transact ADMIN Vat . initIlk "gold"
-         transact ADMIN Vat . file line "gold" Int2Rad(1000 ether)
+         transact ADMIN Vat . file line "gold" rad(1000 ether)
          transact ANYONE Spot . poke "gold"
 
          // User Setup
@@ -124,8 +124,8 @@ module KMCD-PRELUDE
          // Initialize gold Gem and GemJoin
          transact ADMIN Gem "gold" . initUser "Alice"
          transact ADMIN Gem "gold" . initUser "Bobby"
-         transact ADMIN Gem "gold" . mint "Alice" Int2Wad(20)
-         transact ADMIN Gem "gold" . mint "Bobby" Int2Wad(20)
+         transact ADMIN Gem "gold" . mint "Alice" wad(20)
+         transact ADMIN Gem "gold" . mint "Bobby" wad(20)
 
          transact ADMIN Gem "MKR" . initUser "Alice"
          transact ADMIN Gem "MKR" . initUser "Bobby"
@@ -154,10 +154,10 @@ module KMCD-PRELUDE
          transact "Bobby" Vat . hope Flop
 
          // Setup CDPs
-         transact "Alice" GemJoin "gold" . join "Alice" Int2Wad(10)
-         transact "Bobby" GemJoin "gold" . join "Bobby" Int2Wad(10)
-         transact "Alice" Vat . frob "gold" "Alice" "Alice" "Alice" Int2Wad(10) Int2Wad(10)
-         transact "Bobby" Vat . frob "gold" "Bobby" "Bobby" "Bobby" Int2Wad(10) Int2Wad(10)
+         transact "Alice" GemJoin "gold" . join "Alice" wad(10)
+         transact "Bobby" GemJoin "gold" . join "Bobby" wad(10)
+         transact "Alice" Vat . frob "gold" "Alice" "Alice" "Alice" wad(10) wad(10)
+         transact "Bobby" Vat . frob "gold" "Bobby" "Bobby" "Bobby" wad(10) wad(10)
 
          // Initialize End for Users
          transact ADMIN End . initBag "Alice"
@@ -212,7 +212,7 @@ module KMCD-GEN
 
     syntax Ray ::= #dsrSpread() [function]
  // --------------------------------------
-    rule #dsrSpread() => Int2Ray(20)
+    rule #dsrSpread() => ray(20)
 
     syntax Int   ::= head        ( Bytes ) [function]
     syntax Bytes ::= tail        ( Bytes ) [function]
@@ -348,7 +348,7 @@ module KMCD-GEN
       requires lengthBytes(BS) >Int 0
        andBool size(VAT_URNS) >Int 0
 
-    rule <k> GenVatFrob CDPID => GenVatFrob CDPID ((Int2Wad(2) *Wad randWadBounded(head(BS), VAT_GEM)) -Wad VAT_GEM) ... </k>
+    rule <k> GenVatFrob CDPID => GenVatFrob CDPID ((wad(2) *Wad randWadBounded(head(BS), VAT_GEM)) -Wad VAT_GEM) ... </k>
          <random> BS => tail(BS) </random>
          <used-random> BS' => BS' +Bytes headAsBytes(BS) </used-random>
          <vat-gem> ... CDPID |-> VAT_GEM ... </vat-gem>
@@ -356,7 +356,7 @@ module KMCD-GEN
 
     rule <k> GenVatFrob { ILKID , ADDRESS } DINK
           => #fun( DARTBOUND
-                => LogGen ( transact ADDRESS Vat . frob ILKID ADDRESS ADDRESS ADDRESS DINK ((Int2Wad(2) *Wad randWadBounded(head(BS), DARTBOUND)) -Wad DARTBOUND) )
+                => LogGen ( transact ADDRESS Vat . frob ILKID ADDRESS ADDRESS ADDRESS DINK ((wad(2) *Wad randWadBounded(head(BS), DARTBOUND)) -Wad DARTBOUND) )
                  ) ((((URNINK +Wad DINK) *Rate SPOT) /Rate RATE) -Wad URNART)
          ...
          </k>
@@ -522,12 +522,12 @@ module KMCD-GEN
          <vat-gem> ... CDPID |-> VAT_GEM ... </vat-gem>
       requires lengthBytes(BS) >Int 0
 
-    rule <k> GenFlipKick CDPID STORAGE BENEFICIARY LOT => GenFlipKick CDPID STORAGE BENEFICIARY LOT randRadBounded(head(BS), Int2Rad(1000)) ... </k>
+    rule <k> GenFlipKick CDPID STORAGE BENEFICIARY LOT => GenFlipKick CDPID STORAGE BENEFICIARY LOT randRadBounded(head(BS), rad(1000)) ... </k>
          <random> BS => tail(BS) </random>
          <used-random> BS' => BS' +Bytes headAsBytes(BS) </used-random>
       requires lengthBytes(BS) >Int 0
 
-    rule <k> GenFlipKick { ILKID , ADDRESS } STORAGE BENEFICIARY LOT BID => LogGen ( transact ADDRESS Flip ILKID . kick STORAGE BENEFICIARY Int2Rad(1000) LOT BID ) ... </k>
+    rule <k> GenFlipKick { ILKID , ADDRESS } STORAGE BENEFICIARY LOT BID => LogGen ( transact ADDRESS Flip ILKID . kick STORAGE BENEFICIARY rad(1000) LOT BID ) ... </k>
 
     syntax GenStep ::= GenPotStep
     syntax GenPotStep ::= "GenPotJoin"
@@ -555,7 +555,7 @@ module KMCD-GEN
          <pot-chi> POT_CHI </pot-chi>
       requires lengthBytes(BS) >Int 0
 
-    rule <k> GenPotFileDSR => LogGen ( transact ADMIN Pot . file dsr (randRayBounded(head(BS), #dsrSpread() /Ray Int2Ray(100)) +Ray 1Ray) ) ... </k>
+    rule <k> GenPotFileDSR => LogGen ( transact ADMIN Pot . file dsr (randRayBounded(head(BS), #dsrSpread() /Ray ray(100)) +Ray 1Ray) ) ... </k>
          <random> BS => tail(BS) </random>
          <used-random> BS' => BS' +Bytes headAsBytes(BS) </used-random>
       requires lengthBytes(BS) >Int 0

--- a/kmcd-prelude.md
+++ b/kmcd-prelude.md
@@ -357,7 +357,7 @@ module KMCD-GEN
     rule <k> GenVatFrob { ILKID , ADDRESS } DINK
           => #fun( DARTBOUND
                 => LogGen ( transact ADDRESS Vat . frob ILKID ADDRESS ADDRESS ADDRESS DINK ((Int2Wad(2) *Wad randWadBounded(head(BS), DARTBOUND)) -Wad DARTBOUND) )
-                 ) ((((URNINK +Wad DINK) *RateWad SPOT) /Rate RATE) -Wad URNART)
+                 ) ((((URNINK +Wad DINK) *Rate SPOT) /Rate RATE) -Wad URNART)
          ...
          </k>
          <random> BS => tail(BS) </random>

--- a/kmcd-prelude.md
+++ b/kmcd-prelude.md
@@ -169,49 +169,13 @@ module KMCD-PRELUDE
 endmodule
 ```
 
-Random Choices
---------------
-
-```k
-module KMCD-RANDOM-CHOICES
-    imports KMCD-PRELUDE
-```
-
-```k
-    syntax Int ::= randIntBounded ( Int , Int ) [function]
- // ------------------------------------------------------
-    rule randIntBounded(RAND, BOUND) => 0                          requires         BOUND <Int 0
-    rule randIntBounded(RAND, BOUND) => RAND modInt (BOUND +Int 1) requires notBool BOUND <Int 0
-
-    syntax Rat ::= randRat ( Int ) [function]
- // -----------------------------------------
-    rule randRat(I) => I /Rat 256
-
-    syntax Rat ::= randRatBounded ( Int , Rat ) [function]
- // ------------------------------------------------------
-    rule randRatBounded(I, BOUND) => BOUND *Rat randRat(I)
-
-    syntax Int     ::= chooseInt     ( Int , List ) [function]
-    syntax String  ::= chooseString  ( Int , List ) [function]
-    syntax Address ::= chooseAddress ( Int , List ) [function]
-    syntax CDPID   ::= chooseCDPID   ( Int , List ) [function]
- // ----------------------------------------------------------
-    rule chooseInt    (I, ITEMS) => { ITEMS [ I modInt size(ITEMS) ] }:>Int
-    rule chooseString (I, ITEMS) => { ITEMS [ I modInt size(ITEMS) ] }:>String
-    rule chooseAddress(I, ITEMS) => { ITEMS [ I modInt size(ITEMS) ] }:>Address
-    rule chooseCDPID  (I, ITEMS) => { ITEMS [ I modInt size(ITEMS) ] }:>CDPID
-```
-
-```k
-endmodule
-```
-
 Random Sequence Generation
 --------------------------
 
 ```k
 module KMCD-GEN
     imports KMCD-RANDOM-CHOICES
+    imports KMCD-PRELUDE
     imports BYTES
 
     configuration

--- a/kmcd-prelude.md
+++ b/kmcd-prelude.md
@@ -73,14 +73,14 @@ module KMCD-PRELUDE
          // -------------------------------------------------------------
 
          // Vat parameters
-         transact ADMIN Vat . file Line 1000 ether
+         transact ADMIN Vat . file Line Int2Rad(1000 ether)
 
          // Vow parameters
-         transact ADMIN Vow . file bump 1 ether // flap fixed lot size
-         transact ADMIN Vow . file hump 0       // surplus buffer
-         transact ADMIN Vow . file sump 50      // flop fixed bid size
-         transact ADMIN Vow . file dump 30      // flop initial lot size
-         transact ADMIN Flop . file tau 3600    // flop auction liftime (s)
+         transact ADMIN Vow . file bump Int2Rad(1 ether) // flap fixed lot size
+         transact ADMIN Vow . file hump Int2Rad(0)       // surplus buffer
+         transact ADMIN Vow . file sump Int2Rad(50)      // flop fixed bid size
+         transact ADMIN Vow . file dump Int2Wad(30)      // flop initial lot size
+         transact ADMIN Flop . file tau 3600             // flop auction liftime (s)
 
          .MCDSteps
       [macro]
@@ -102,9 +102,9 @@ module KMCD-PRELUDE
 
          // Initialize Spot for gold
          transact ADMIN Spot . init     "gold"
-         transact ADMIN Spot . setPrice "gold" 3 ether
-         transact ADMIN Spot . file       mat "gold" 1
-         transact ADMIN Spot . file       par 1
+         transact ADMIN Spot . setPrice "gold" Int2Wad(3 ether)
+         transact ADMIN Spot . file       mat "gold" 1Ray
+         transact ADMIN Spot . file       par 1Ray
 
          // Initialize Flipper for gold
          transact ADMIN Flip "gold" . init
@@ -115,7 +115,7 @@ module KMCD-PRELUDE
 
          // Initialize "gold for Vat
          transact ADMIN Vat . initIlk "gold"
-         transact ADMIN Vat . file line "gold" 1000 ether
+         transact ADMIN Vat . file line "gold" Int2Rad(1000 ether)
          transact ANYONE Spot . poke "gold"
 
          // User Setup
@@ -124,8 +124,8 @@ module KMCD-PRELUDE
          // Initialize gold Gem and GemJoin
          transact ADMIN Gem "gold" . initUser "Alice"
          transact ADMIN Gem "gold" . initUser "Bobby"
-         transact ADMIN Gem "gold" . mint "Alice" 20
-         transact ADMIN Gem "gold" . mint "Bobby" 20
+         transact ADMIN Gem "gold" . mint "Alice" Int2Wad(20)
+         transact ADMIN Gem "gold" . mint "Bobby" Int2Wad(20)
 
          transact ADMIN Gem "MKR" . initUser "Alice"
          transact ADMIN Gem "MKR" . initUser "Bobby"
@@ -154,10 +154,10 @@ module KMCD-PRELUDE
          transact "Bobby" Vat . hope Flop
 
          // Setup CDPs
-         transact "Alice" GemJoin "gold" . join "Alice" 10
-         transact "Bobby" GemJoin "gold" . join "Bobby" 10
-         transact "Alice" Vat . frob "gold" "Alice" "Alice" "Alice" 10 10
-         transact "Bobby" Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10
+         transact "Alice" GemJoin "gold" . join "Alice" Int2Wad(10)
+         transact "Bobby" GemJoin "gold" . join "Bobby" Int2Wad(10)
+         transact "Alice" Vat . frob "gold" "Alice" "Alice" "Alice" Int2Wad(10) Int2Wad(10)
+         transact "Bobby" Vat . frob "gold" "Bobby" "Bobby" "Bobby" Int2Wad(10) Int2Wad(10)
 
          // Initialize End for Users
          transact ADMIN End . initBag "Alice"
@@ -207,10 +207,12 @@ module KMCD-GEN
          <kmcd-snapshots> ListItem(_) </kmcd-snapshots>
 
     syntax Int ::= #timeStepMax() [function]
-                 | #dsrSpread()   [function]
  // ----------------------------------------
-    rule #timeStepMax() => 2  [macro]
-    rule #dsrSpread()   => 20 [macro]
+    rule #timeStepMax() => 2 [macro]
+
+    syntax Ray ::= #dsrSpread() [function]
+ // --------------------------------------
+    rule #dsrSpread() => Int2Ray(20)
 
     syntax Int   ::= head        ( Bytes ) [function]
     syntax Bytes ::= tail        ( Bytes ) [function]
@@ -346,7 +348,7 @@ module KMCD-GEN
       requires lengthBytes(BS) >Int 0
        andBool size(VAT_URNS) >Int 0
 
-    rule <k> GenVatFrob CDPID => GenVatFrob CDPID ((2 *Rat randRatBounded(head(BS), VAT_GEM)) -Rat VAT_GEM) ... </k>
+    rule <k> GenVatFrob CDPID => GenVatFrob CDPID ((Int2Wad(2) *Wad randWadBounded(head(BS), VAT_GEM)) -Wad VAT_GEM) ... </k>
          <random> BS => tail(BS) </random>
          <used-random> BS' => BS' +Bytes headAsBytes(BS) </used-random>
          <vat-gem> ... CDPID |-> VAT_GEM ... </vat-gem>
@@ -354,8 +356,8 @@ module KMCD-GEN
 
     rule <k> GenVatFrob { ILKID , ADDRESS } DINK
           => #fun( DARTBOUND
-                => LogGen ( transact ADDRESS Vat . frob ILKID ADDRESS ADDRESS ADDRESS DINK ((2 *Rat randRatBounded(head(BS), DARTBOUND)) -Rat DARTBOUND) )
-                 ) (((SPOT *Rat (URNINK +Rat DINK)) /Rat RATE) -Rat URNART)
+                => LogGen ( transact ADDRESS Vat . frob ILKID ADDRESS ADDRESS ADDRESS DINK ((Int2Wad(2) *Wad randWadBounded(head(BS), DARTBOUND)) -Wad DARTBOUND) )
+                 ) ((((URNINK +Wad DINK) *RateWad SPOT) /Rate RATE) -Wad URNART)
          ...
          </k>
          <random> BS => tail(BS) </random>
@@ -386,7 +388,7 @@ module KMCD-GEN
       requires lengthBytes(BS) >Int 0
        andBool size(VAT_DAIS) >Int 0
 
-    rule <k> GenVatMove ADDRSRC ADDRDST => LogGen ( transact ADDRSRC Vat . move ADDRSRC ADDRDST randRatBounded(head(BS), VAT_DAI) ) ... </k>
+    rule <k> GenVatMove ADDRSRC ADDRDST => LogGen ( transact ADDRSRC Vat . move ADDRSRC ADDRDST randRadBounded(head(BS), VAT_DAI) ) ... </k>
          <random> BS => tail(BS) </random>
          <used-random> BS' => BS' +Bytes headAsBytes(BS) </used-random>
          <vat-dai>
@@ -436,7 +438,7 @@ module KMCD-GEN
       requires lengthBytes(BS) >Int 0
        andBool size(GEM_BALANCES) >Int 0
 
-    rule <k> GenGemJoinJoin GEM_JOIN_ID ADDRESS => LogGen ( transact ADDRESS GemJoin GEM_JOIN_ID . join ADDRESS randRatBounded(head(BS), GEM_BALANCE) ) ... </k>
+    rule <k> GenGemJoinJoin GEM_JOIN_ID ADDRESS => LogGen ( transact ADDRESS GemJoin GEM_JOIN_ID . join ADDRESS randWadBounded(head(BS), GEM_BALANCE) ) ... </k>
          <random> BS => tail(BS) </random>
          <used-random> BS' => BS' +Bytes headAsBytes(BS) </used-random>
          <gem>
@@ -460,13 +462,13 @@ module KMCD-GEN
       requires lengthBytes(BS) >Int 0
        andBool size(VAT_DAIS) >Int 0
 
-    rule <k> GenFlapKick ADDRESS => GenFlapKick ADDRESS randRatBounded(head(BS), VOW_DAI) ... </k>
+    rule <k> GenFlapKick ADDRESS => GenFlapKick ADDRESS randRadBounded(head(BS), VOW_DAI) ... </k>
          <random> BS => tail(BS) </random>
          <used-random> BS' => BS' +Bytes headAsBytes(BS) </used-random>
          <vat-dai> ... ADDRESS |-> VOW_DAI ... </vat-dai>
       requires lengthBytes(BS) >Int 0
 
-    rule <k> GenFlapKick ADDRESS LOT => GenFlapKick ADDRESS LOT randRatBounded(head(BS), FLAP_MKR) ... </k>
+    rule <k> GenFlapKick ADDRESS LOT => GenFlapKick ADDRESS LOT randWadBounded(head(BS), FLAP_MKR) ... </k>
          <random> BS => tail(BS) </random>
          <used-random> BS' => BS' +Bytes headAsBytes(BS) </used-random>
          <gem>
@@ -490,8 +492,8 @@ module KMCD-GEN
                          | "GenFlipKick" CDPID
                          | "GenFlipKick" CDPID Address
                          | "GenFlipKick" CDPID Address Address
-                         | "GenFlipKick" CDPID Address Address Rad
-                         | "GenFlipKick" CDPID Address Address Rad Wad
+                         | "GenFlipKick" CDPID Address Address Wad
+                         | "GenFlipKick" CDPID Address Address Wad Rad
  // ------------------------------------------------------------------
     rule <k> GenFlipKick => GenFlipKick chooseCDPID(head(BS), keys_list(VAT_GEMS)) ... </k>
          <random> BS => tail(BS) </random>
@@ -514,18 +516,18 @@ module KMCD-GEN
       requires lengthBytes(BS) >Int 0
        andBool size(VAT_DAIS) >Int 0
 
-    rule <k> GenFlipKick CDPID STORAGE BENEFICIARY => GenFlipKick CDPID STORAGE BENEFICIARY randRatBounded(head(BS), VAT_GEM) ... </k>
+    rule <k> GenFlipKick CDPID STORAGE BENEFICIARY => GenFlipKick CDPID STORAGE BENEFICIARY randWadBounded(head(BS), VAT_GEM) ... </k>
          <random> BS => tail(BS) </random>
          <used-random> BS' => BS' +Bytes headAsBytes(BS) </used-random>
          <vat-gem> ... CDPID |-> VAT_GEM ... </vat-gem>
       requires lengthBytes(BS) >Int 0
 
-    rule <k> GenFlipKick CDPID STORAGE BENEFICIARY LOT => GenFlipKick CDPID STORAGE BENEFICIARY LOT randRatBounded(head(BS), 1000) ... </k>
+    rule <k> GenFlipKick CDPID STORAGE BENEFICIARY LOT => GenFlipKick CDPID STORAGE BENEFICIARY LOT randRadBounded(head(BS), Int2Rad(1000)) ... </k>
          <random> BS => tail(BS) </random>
          <used-random> BS' => BS' +Bytes headAsBytes(BS) </used-random>
       requires lengthBytes(BS) >Int 0
 
-    rule <k> GenFlipKick { ILKID , ADDRESS } STORAGE BENEFICIARY LOT BID => LogGen ( transact ADDRESS Flip ILKID . kick STORAGE BENEFICIARY 1000 LOT BID ) ... </k>
+    rule <k> GenFlipKick { ILKID , ADDRESS } STORAGE BENEFICIARY LOT BID => LogGen ( transact ADDRESS Flip ILKID . kick STORAGE BENEFICIARY Int2Rad(1000) LOT BID ) ... </k>
 
     syntax GenStep ::= GenPotStep
     syntax GenPotStep ::= "GenPotJoin"
@@ -546,14 +548,14 @@ module KMCD-GEN
       requires lengthBytes(BS) >Int 0
        andBool size(POT_PIES) >Int 0
 
-    rule <k> GenPotJoin ADDRESS => LogGen ( transact ADDRESS Pot . join randRatBounded(head(BS), VAT_DAI /Rat POT_CHI) ) ... </k>
+    rule <k> GenPotJoin ADDRESS => LogGen ( transact ADDRESS Pot . join randWadBounded(head(BS), VAT_DAI /Rate POT_CHI) ) ... </k>
          <random> BS => tail(BS) </random>
          <used-random> BS' => BS' +Bytes headAsBytes(BS) </used-random>
          <vat-dai> ... ADDRESS |-> VAT_DAI ... </vat-dai>
          <pot-chi> POT_CHI </pot-chi>
       requires lengthBytes(BS) >Int 0
 
-    rule <k> GenPotFileDSR => LogGen ( transact ADMIN Pot . file dsr (randRatBounded(head(BS), #dsrSpread() /Rat 100) +Rat 1) ) ... </k>
+    rule <k> GenPotFileDSR => LogGen ( transact ADMIN Pot . file dsr (randRayBounded(head(BS), #dsrSpread() /Ray Int2Ray(100)) +Ray 1Ray) ) ... </k>
          <random> BS => tail(BS) </random>
          <used-random> BS' => BS' +Bytes headAsBytes(BS) </used-random>
       requires lengthBytes(BS) >Int 0
@@ -565,7 +567,7 @@ module KMCD-GEN
       requires lengthBytes(BS) >Int 0
        andBool size(POT_PIES) >Int 0
 
-    rule <k> GenPotExit ADDRESS => LogGen ( transact ADDRESS Pot . exit (VAT_DAI /Rat CHI) ) ... </k>
+    rule <k> GenPotExit ADDRESS => LogGen ( transact ADDRESS Pot . exit (VAT_DAI /Rate CHI) ) ... </k>
          <vat-dai> ... Pot |-> VAT_DAI ... </vat-dai>
          <pot-chi> CHI </pot-chi>
 
@@ -649,7 +651,7 @@ module KMCD-GEN
       requires lengthBytes(BS) >Int 0
        andBool size(END_OUTS) >Int 0
 
-    rule <k> GenEndCash { ILKID , ADDRESS } => LogGen ( transact ADDRESS End . cash ILKID randRatBounded(head(BS), BAG -Rat OUT) ) ... </k>
+    rule <k> GenEndCash { ILKID , ADDRESS } => LogGen ( transact ADDRESS End . cash ILKID randWadBounded(head(BS), BAG -Wad OUT) ) ... </k>
          <random> BS => tail(BS) </random>
          <used-random> BS' => BS' +Bytes headAsBytes(BS) </used-random>
          <end-out> ... { ILKID , ADDRESS } |-> OUT ... </end-out>

--- a/kmcd-props.md
+++ b/kmcd-props.md
@@ -285,7 +285,7 @@ The Debt growth should be bounded in principle by the interest rates available i
     rule derive(totalDebtBounded(... dsr: DSR), Measure(... debt: DEBT)) => totalDebtBoundedRun(... debt: DEBT, dsr: DSR)
 
     rule derive( totalDebtBoundedRun(... debt: DEBT, dsr: _  ) #as PREV , Measure(... debt: DEBT')            ) => Violated(PREV) requires DEBT' >Rad DEBT
-    rule derive( totalDebtBoundedRun(... debt: DEBT, dsr: DSR)          , TimeStep(TIME, _)                   ) => totalDebtBoundedRun(... debt: DEBT +Rad (vatDaiForUser(Pot) *RateRad ((DSR ^Ray TIME) -Ray 1Ray)), dsr: DSR)
+    rule derive( totalDebtBoundedRun(... debt: DEBT, dsr: DSR)          , TimeStep(TIME, _)                   ) => totalDebtBoundedRun(... debt: DEBT +Rad rmulRad(vatDaiForUser(Pot), (DSR ^Ray TIME) -Ray 1Ray), dsr: DSR)
     rule derive( totalDebtBoundedRun(... debt: DEBT, dsr: DSR)          , LogNote(_ , Vat . frob _ _ _ _ _ _) ) => totalDebtBounded(... dsr: DSR)
     rule derive( totalDebtBoundedRun(... debt: DEBT, dsr: DSR)          , LogNote(_ , Vat . suck _ _ AMOUNT)  ) => totalDebtBoundedRun(... debt: DEBT +Rad AMOUNT, dsr: DSR)
     rule derive( totalDebtBoundedRun(... debt: DEBT, dsr: DSR)          , LogNote(_ , Pot . file dsr DSR')    ) => totalDebtBoundedRun(... debt: DEBT, dsr: DSR')

--- a/kmcd-props.md
+++ b/kmcd-props.md
@@ -20,13 +20,23 @@ Measurables
 
 ### Lookup Defaulting to 0
 
-Sometimes you need a lookup to default to zero, and want to cast the result as a `Rat`.
+Sometimes you need a lookup to default to zero, and want to cast the result as a `Wad`, `Ray`, or `Rad`.
 
 ```k
-    syntax Rat ::= #lookup ( Map , Address ) [function]
- // ---------------------------------------------------
-    rule #lookup(M, A) => { M[A] }:>Rat requires A in_keys(M)
-    rule #lookup(M, A) => 0             [owise]
+    syntax Wad ::= #lookupWad ( Map , Address ) [function]
+ // ------------------------------------------------------
+    rule #lookupWad(M, A) => { M[A] }:>Wad requires A in_keys(M)
+    rule #lookupWad(M, A) => 0Wad          [owise]
+
+    syntax Ray ::= #lookupRay ( Map , Address ) [function]
+ // ------------------------------------------------------
+    rule #lookupRay(M, A) => { M[A] }:>Ray requires A in_keys(M)
+    rule #lookupRay(M, A) => 0Ray          [owise]
+
+    syntax Rad ::= #lookupRad ( Map , Address ) [function]
+ // ------------------------------------------------------
+    rule #lookupRad(M, A) => { M[A] }:>Rad requires A in_keys(M)
+    rule #lookupRad(M, A) => 0Rad          [owise]
 ```
 
 ### Measure Event
@@ -34,7 +44,7 @@ Sometimes you need a lookup to default to zero, and want to cast the result as a
 ```k
     syntax Event ::= Measure
     syntax Measure ::= Measure () [function]
-                     | Measure ( debt: Rat , controlDai: Map , potChi: Rat , potPie: Rat , sumOfScaledArts: Rat , vice: Rat , endDebt: Rat , sumOfAllFlapLots: Rat , dai: Map , sumOfAllFlapBids: Rat , mkrBalances: Map, ash: Rat ) [klabel(LogMeasure), symbol]
+                     | Measure ( debt: Rad , controlDai: Map , potChi: Ray , potPie: Wad , sumOfScaledArts: Rad , vice: Rad , endDebt: Rad , sumOfAllFlapLots: Rad , dai: Map , sumOfAllFlapBids: Wad , mkrBalances: Map, ash: Rad ) [klabel(LogMeasure), symbol]
  // -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     rule [[ Measure() => Measure(... debt: DEBT, controlDai: controlDais(keys_list(VAT_DAIS)), potChi: POT_CHI, potPie: POT_PIE, sumOfScaledArts: calcSumOfScaledArts(VAT_ILKS, VAT_URNS), vice: VAT_VICE, endDebt: END_DEBT, sumOfAllFlapLots: sumOfAllFlapLots(FLAP_BIDS), dai: VAT_DAIS, sumOfAllFlapBids: sumOfAllFlapBids(FLAP_BIDS), mkrBalances: mkrBalances(), ash: VOW_ASH) ]]
          <vat-debt>     DEBT      </vat-debt>
@@ -62,30 +72,30 @@ State predicates that capture undesirable states in the system (representing vio
     rule controlDaisAux(.List               , USER_DAIS) => USER_DAIS
     rule controlDaisAux(ListItem(ADDR) REST , USER_DAIS) => controlDaisAux(REST, USER_DAIS [ ADDR <- controlDaiForUser(ADDR) ])
 
-    syntax Rat ::= controlDaiForUser ( Address ) [function]
+    syntax Rad ::= controlDaiForUser ( Address ) [function]
                  | vatDaiForUser     ( Address ) [function]
                  | erc20DaiForUser   ( Address ) [function]
                  | potDaiForUser     ( Address ) [function]
  // -------------------------------------------------------
-    rule controlDaiForUser(ADDR) => vatDaiForUser(ADDR) +Rat potDaiForUser(ADDR) +Rat erc20DaiForUser(ADDR)
+    rule controlDaiForUser(ADDR) => (vatDaiForUser(ADDR) +Rad potDaiForUser(ADDR)) +Rad erc20DaiForUser(ADDR)
 
-    rule    vatDaiForUser(_) => 0 [owise]
+    rule    vatDaiForUser(_)    => 0Rad [owise]
     rule [[ vatDaiForUser(ADDR) => VAT_DAI ]]
-         <vat-dai> ... ADDR |-> VAT_DAI:Rat ... </vat-dai>
+         <vat-dai> ... ADDR |-> VAT_DAI:Rad ... </vat-dai>
 
-    rule potDaiForUser(ADDR) => vatDaiForUser(Pot) *Rat portionOfPie(ADDR)
+    rule potDaiForUser(ADDR) => vatDaiForUser(Pot) *Rad Wad2Rad(portionOfPie(ADDR))
 
-    rule    erc20DaiForUser(_) => 0 [owise]
-    rule [[ erc20DaiForUser(ADDR) => USER_ADAPT_DAI ]]
-         <dai-balance> ... ADDR |-> USER_ADAPT_DAI ... </dai-balance>
+    rule    erc20DaiForUser(_)    => 0Rad [owise]
+    rule [[ erc20DaiForUser(ADDR) => Wad2Rad(USER_ADAPT_DAI) ]]
+         <dai-balance> ... ADDR |-> USER_ADAPT_DAI:Wad ... </dai-balance>
 
-    syntax Rat ::= portionOfPie ( Address ) [function]
+    syntax Wad ::= portionOfPie ( Address ) [function]
  // --------------------------------------------------
-    rule    portionOfPie(_) => 0 [owise]
-    rule [[ portionOfPie(ADDR) => USER_PIE /Rat PIE ]]
-         <pot-pies> ... ADDR |-> USER_PIE ... </pot-pies>
+    rule    portionOfPie(_)    => 0Wad [owise]
+    rule [[ portionOfPie(ADDR) => USER_PIE /Wad PIE ]]
+         <pot-pies> ... ADDR |-> USER_PIE:Wad ... </pot-pies>
          <pot-pie> PIE </pot-pie>
-      requires PIE =/=Rat 0
+      requires PIE =/=Wad 0Wad
        andBool ADDR =/=K Pot
 ```
 
@@ -110,11 +120,11 @@ By default, we assume the MKR balances are negative, but otherwise just grab the
 Art of an ilk = Sum of all urn art across all users for that ilk.
 
 ```k
-    syntax Rat ::= sumOfUrnArt(Map, String, Rat) [function, functional]
+    syntax Wad ::= sumOfUrnArt(Map, String, Wad) [function, functional]
  // -------------------------------------------------------------------
     rule sumOfUrnArt( {ILKID , ADDR} |-> Urn (... art: ART) URNS, ILKID', SUM)
       => #if ILKID ==K ILKID'
-            #then sumOfUrnArt( URNS, ILKID', SUM +Rat ART)
+            #then sumOfUrnArt( URNS, ILKID', SUM +Wad ART)
             #else sumOfUrnArt( URNS, ILKID', SUM)
          #fi
 
@@ -126,13 +136,13 @@ Art of an ilk = Sum of all urn art across all users for that ilk.
 Total backed debt (sum over each CDP's art times corresponding ilk's rate)
 
 ```k
-    syntax Rat ::= calcSumOfScaledArts(Map, Map) [function]
-                 | calcSumOfScaledArtsAux(List, Map, Map, Rat) [function]
+    syntax Rad ::= calcSumOfScaledArts   (      Map, Map     ) [function]
+                 | calcSumOfScaledArtsAux(List, Map, Map, Rad) [function]
  // ---------------------------------------------------------------------
-    rule calcSumOfScaledArts(VAT_ILKS, VAT_URNS) => calcSumOfScaledArtsAux(keys_list(VAT_ILKS), VAT_ILKS, VAT_URNS, 0)
+    rule calcSumOfScaledArts(VAT_ILKS, VAT_URNS) => calcSumOfScaledArtsAux(keys_list(VAT_ILKS), VAT_ILKS, VAT_URNS, 0Rad)
 
     rule calcSumOfScaledArtsAux(                        .List ,        _ ,        _ , TOTAL ) => TOTAL
-    rule calcSumOfScaledArtsAux( ListItem(ILK_ID) VAT_ILK_IDS , VAT_ILKS , VAT_URNS , TOTAL ) => calcSumOfScaledArtsAux(VAT_ILK_IDS, VAT_ILKS, VAT_URNS, TOTAL +Rat (sumOfUrnArt(VAT_URNS, ILK_ID, 0) *Rat rate({VAT_ILKS[ILK_ID]}:>VatIlk)))
+    rule calcSumOfScaledArtsAux( ListItem(ILK_ID) VAT_ILK_IDS , VAT_ILKS , VAT_URNS , TOTAL ) => calcSumOfScaledArtsAux(VAT_ILK_IDS, VAT_ILKS, VAT_URNS, TOTAL +Rad (sumOfUrnArt(VAT_URNS, ILK_ID, 0Wad) *RateWad rate({VAT_ILKS[ILK_ID]}:>VatIlk)))
 ```
 
 ### Flap Measures
@@ -140,25 +150,25 @@ Total backed debt (sum over each CDP's art times corresponding ilk's rate)
 Sum of all lot values (i.e. total surplus dai up for auction).
 
 ```k
-    syntax Rat ::= sumOfAllFlapLots(Map) [function]
-                 | sumOfAllFlapLotsAux(List, Map, Rat) [function]
+    syntax Rad ::= sumOfAllFlapLots   (      Map     ) [function]
+                 | sumOfAllFlapLotsAux(List, Map, Rad) [function]
  // -------------------------------------------------------------
-    rule sumOfAllFlapLots(FLAP_BIDS) => sumOfAllFlapLotsAux(keys_list(FLAP_BIDS), FLAP_BIDS, 0)
+    rule sumOfAllFlapLots(FLAP_BIDS) => sumOfAllFlapLotsAux(keys_list(FLAP_BIDS), FLAP_BIDS, 0Rad)
 
     rule sumOfAllFlapLotsAux(                          .List ,         _ , SUM ) => SUM
-    rule sumOfAllFlapLotsAux( ListItem(BID_ID) FLAP_BIDS_IDS , FLAP_BIDS , SUM ) => sumOfAllFlapLotsAux(FLAP_BIDS_IDS, FLAP_BIDS, SUM +Rat lot({FLAP_BIDS[BID_ID]}:>FlapBid))
+    rule sumOfAllFlapLotsAux( ListItem(BID_ID) FLAP_BIDS_IDS , FLAP_BIDS , SUM ) => sumOfAllFlapLotsAux(FLAP_BIDS_IDS, FLAP_BIDS, SUM +Rad lot({FLAP_BIDS[BID_ID]}:>FlapBid))
 ```
 
 Sum of all bid values (i.e. total amount of MKR that's been bid on dai currently up for auction).
 
 ```k
-    syntax Rat ::= sumOfAllFlapBids(Map) [function]
-                 | sumOfAllFlapBidsAux(List, Map, Rat) [function]
+    syntax Wad ::= sumOfAllFlapBids   (      Map     ) [function]
+                 | sumOfAllFlapBidsAux(List, Map, Wad) [function]
  // -------------------------------------------------------------
-    rule sumOfAllFlapBids(FLAP_BIDS) => sumOfAllFlapBidsAux(keys_list(FLAP_BIDS), FLAP_BIDS, 0)
+    rule sumOfAllFlapBids(FLAP_BIDS) => sumOfAllFlapBidsAux(keys_list(FLAP_BIDS), FLAP_BIDS, 0Wad)
 
     rule sumOfAllFlapBidsAux(                          .List ,         _ , SUM ) => SUM
-    rule sumOfAllFlapBidsAux( ListItem(BID_ID) FLAP_BIDS_IDS , FLAP_BIDS , SUM ) => sumOfAllFlapBidsAux(FLAP_BIDS_IDS, FLAP_BIDS, SUM +Rat bid({FLAP_BIDS[BID_ID]}:>FlapBid))
+    rule sumOfAllFlapBidsAux( ListItem(BID_ID) FLAP_BIDS_IDS , FLAP_BIDS , SUM ) => sumOfAllFlapBidsAux(FLAP_BIDS_IDS, FLAP_BIDS, SUM +Wad bid({FLAP_BIDS[BID_ID]}:>FlapBid))
 ```
 
 Violations
@@ -169,17 +179,17 @@ A violation occurs if any of the properties above holds.
 ```k
     syntax Map ::= "#violationFSMs" [function]
  // ------------------------------------------
-    rule #violationFSMs => ( "Zero-Time Pot Interest Accumulation" |-> zeroTimePotInterest                      )
-                           ( "Pot Interest Accumulation After End" |-> potEndInterest                           )
-                           ( "Unauthorized Flip Kick"              |-> unAuthFlipKick                           )
-                           ( "Unauthorized Flap Kick"              |-> unAuthFlapKick                           )
-                           ( "Total Bound on Debt"                 |-> totalDebtBounded(... dsr: 1)             )
-                           ( "PotChi PotPie VatPot"                |-> potChiPieDai(... offset: 0, joining: 0)  )
-                           ( "Total Backed Debt Consistency"       |-> totalBackedDebtConsistency               )
-                           ( "Debt Constant After Thaw"            |-> debtConstantAfterThaw                    )
-                           ( "Flap Dai Consistency"                |-> flapDaiConsistency                       )
-                           ( "Flap MKR Consistency"                |-> flapMkrConsistency                       )
-                           ( "Flop Block Check"                    |-> flopBlockCheck(... embers: 0, dented: 0) )
+    rule #violationFSMs => ( "Zero-Time Pot Interest Accumulation" |-> zeroTimePotInterest                           )
+                           ( "Pot Interest Accumulation After End" |-> potEndInterest                                )
+                           ( "Unauthorized Flip Kick"              |-> unAuthFlipKick                                )
+                           ( "Unauthorized Flap Kick"              |-> unAuthFlapKick                                )
+                           ( "Total Bound on Debt"                 |-> totalDebtBounded(... dsr: 1Ray)               )
+                           ( "PotChi PotPie VatPot"                |-> potChiPieDai(... offset: 0Rad, joining: 0Wad) )
+                           ( "Total Backed Debt Consistency"       |-> totalBackedDebtConsistency                    )
+                           ( "Debt Constant After Thaw"            |-> debtConstantAfterThaw                         )
+                           ( "Flap Dai Consistency"                |-> flapDaiConsistency                            )
+                           ( "Flap MKR Consistency"                |-> flapMkrConsistency                            )
+                           ( "Flop Block Check"                    |-> flopBlockCheck(... embers: 0Rad, dented: 0)   )
 ```
 
 A violation can be checked using the Admin step `assert`. If a violation is detected,
@@ -250,7 +260,7 @@ Vat.debt minus Vat.vice should equal the sum over all ilks and CDP accounts of t
 ```k
     syntax ViolationFSM ::= "totalBackedDebtConsistency"
  // ----------------------------------------------------
-    rule derive(totalBackedDebtConsistency, Measure(... debt: DEBT, sumOfScaledArts: SUM, vice: VICE)) => Violated(totalBackedDebtConsistency) requires SUM =/=Rat (DEBT -Rat VICE)
+    rule derive(totalBackedDebtConsistency, Measure(... debt: DEBT, sumOfScaledArts: SUM, vice: VICE)) => Violated(totalBackedDebtConsistency) requires SUM =/=Rad (DEBT -Rad VICE)
 ```
 
 ### Debt Constant After Thaw
@@ -260,7 +270,7 @@ Vat.debt should not change after End.thaw is called, as this implies the creatio
 ```k
     syntax ViolationFSM ::= "debtConstantAfterThaw"
  // -----------------------------------------------
-    rule derive(debtConstantAfterThaw, Measure(... debt: DEBT, endDebt: END_DEBT)) => Violated(debtConstantAfterThaw) requires (END_DEBT =/=Rat 0) andBool (DEBT =/=Rat END_DEBT)
+    rule derive(debtConstantAfterThaw, Measure(... debt: DEBT, endDebt: END_DEBT)) => Violated(debtConstantAfterThaw) requires (END_DEBT =/=Rad 0Rad) andBool (DEBT =/=Rad END_DEBT)
 ```
 
 ### Bounded Debt Growth
@@ -268,20 +278,20 @@ Vat.debt should not change after End.thaw is called, as this implies the creatio
 The Debt growth should be bounded in principle by the interest rates available in the system.
 
 ```k
-    syntax ViolationFSM ::= totalDebtBounded    (             dsr: Rat )
-                          | totalDebtBoundedRun ( debt: Rat , dsr: Rat )
-                          | totalDebtBoundedEnd ( debt: Rat            )
+    syntax ViolationFSM ::= totalDebtBounded    (             dsr: Ray )
+                          | totalDebtBoundedRun ( debt: Rad , dsr: Ray )
+                          | totalDebtBoundedEnd ( debt: Rad            )
  // --------------------------------------------------------------------
     rule derive(totalDebtBounded(... dsr: DSR), Measure(... debt: DEBT)) => totalDebtBoundedRun(... debt: DEBT, dsr: DSR)
 
-    rule derive( totalDebtBoundedRun(... debt: DEBT, dsr: _  ) #as PREV , Measure(... debt: DEBT')            ) => Violated(PREV) requires DEBT' >Rat DEBT
-    rule derive( totalDebtBoundedRun(... debt: DEBT, dsr: DSR)          , TimeStep(TIME, _)                   ) => totalDebtBoundedRun(... debt: DEBT +Rat (vatDaiForUser(Pot) *Rat ((DSR ^Rat TIME) -Rat 1)), dsr: DSR)
+    rule derive( totalDebtBoundedRun(... debt: DEBT, dsr: _  ) #as PREV , Measure(... debt: DEBT')            ) => Violated(PREV) requires DEBT' >Rad DEBT
+    rule derive( totalDebtBoundedRun(... debt: DEBT, dsr: DSR)          , TimeStep(TIME, _)                   ) => totalDebtBoundedRun(... debt: DEBT +Rad (vatDaiForUser(Pot) *RateRad ((DSR ^Ray TIME) -Ray 1Ray)), dsr: DSR)
     rule derive( totalDebtBoundedRun(... debt: DEBT, dsr: DSR)          , LogNote(_ , Vat . frob _ _ _ _ _ _) ) => totalDebtBounded(... dsr: DSR)
-    rule derive( totalDebtBoundedRun(... debt: DEBT, dsr: DSR)          , LogNote(_ , Vat . suck _ _ WAD    ) ) => totalDebtBoundedRun(... debt: DEBT +Rat WAD, dsr: DSR)
+    rule derive( totalDebtBoundedRun(... debt: DEBT, dsr: DSR)          , LogNote(_ , Vat . suck _ _ AMOUNT)  ) => totalDebtBoundedRun(... debt: DEBT +Rad AMOUNT, dsr: DSR)
     rule derive( totalDebtBoundedRun(... debt: DEBT, dsr: DSR)          , LogNote(_ , Pot . file dsr DSR')    ) => totalDebtBoundedRun(... debt: DEBT, dsr: DSR')
     rule derive( totalDebtBoundedRun(... debt: DEBT, dsr: _  )          , LogNote(_ , End . cage         )    ) => totalDebtBoundedEnd(... debt: DEBT)
 
-    rule derive(totalDebtBoundedEnd(... debt: DEBT) #as PREV, Measure(... debt: DEBT')) => Violated(PREV) requires DEBT' =/=Rat DEBT
+    rule derive(totalDebtBoundedEnd(... debt: DEBT) #as PREV, Measure(... debt: DEBT')) => Violated(PREV) requires DEBT' =/=Rad DEBT
 ```
 
 ### Pot Chi * Pot Pie == Vat Dai(Pot)
@@ -289,14 +299,14 @@ The Debt growth should be bounded in principle by the interest rates available i
 The Pot Chi multiplied by Pot Pie should equal the Vat Dai for the Pot
 
 ```k
-    syntax ViolationFSM ::= potChiPieDai ( offset: Rat , joining: Rat )
+    syntax ViolationFSM ::= potChiPieDai ( offset: Rad , joining: Wad )
  // -------------------------------------------------------------------
-    rule derive( potChiPieDai(... offset: OFFSET, joining: JOINING ) , LogNote(_, Pot . join WAD)       ) => potChiPieDai(... offset: OFFSET          , joining: JOINING +Rat WAD )
-    rule derive( potChiPieDai(... offset: OFFSET, joining: JOINING ) , LogNote(_, Vat . move _ Pot WAD) ) => potChiPieDai(... offset: OFFSET +Rat WAD , joining: JOINING          )
+    rule derive( potChiPieDai(... offset: OFFSET, joining: JOINING ) , LogNote(_, Pot . join WAD)       ) => potChiPieDai(... offset: OFFSET          , joining: JOINING +Wad WAD )
+    rule derive( potChiPieDai(... offset: OFFSET, joining: JOINING ) , LogNote(_, Vat . move _ Pot RAD) ) => potChiPieDai(... offset: OFFSET +Rad RAD , joining: JOINING          )
 
-    rule derive(potChiPieDai(... offset: OFFSET => OFFSET -Rat (JOINING *Rat POT_CHI), joining: JOINING => 0), Measure(... potChi: POT_CHI)) requires JOINING =/=Rat 0
+    rule derive(potChiPieDai(... offset: OFFSET => OFFSET -Rad (JOINING *RateWad POT_CHI), joining: JOINING => 0Wad), Measure(... potChi: POT_CHI)) requires JOINING =/=Wad 0Wad
 
-    rule derive(potChiPieDai(... offset: OFFSET, joining: 0) #as PREV, Measure(... controlDai: CONTROL_DAI, potChi: POT_CHI, potPie: POT_PIE)) => Violated(PREV) requires POT_CHI *Rat POT_PIE =/=Rat #lookup(CONTROL_DAI, Pot) -Rat OFFSET
+    rule derive(potChiPieDai(... offset: OFFSET, joining: 0Wad) #as PREV, Measure(... controlDai: CONTROL_DAI, potChi: POT_CHI, potPie: POT_PIE)) => Violated(PREV) requires POT_PIE *RateWad POT_CHI =/=Rad #lookupRad(CONTROL_DAI, Pot) -Rad OFFSET
 ```
 
 ### Kicking off a fake `flip` auction (inspired by lucash-flip)
@@ -332,7 +342,7 @@ The property checks if an `End . cage` is eventually followed by a successful `P
 
 ### Earning interest from a pot in zero time (inspired by the lucash-pot attack)
 
-The property checks if a successful `Pot . join` is preceded by a `TimeStep` more recently than a `Pot . drip'.
+The property checks if a successful `Pot . join` is preceded by a `TimeStep` more recently than a `Pot . drip`.
 
 ```k
     syntax ViolationFSM ::= "zeroTimePotInterest" | "zeroTimePotInterestEnd"
@@ -349,7 +359,7 @@ The property checks if a successful `Pot . join` is preceded by a `TimeStep` mor
 ```k
     syntax ViolationFSM ::= "flapDaiConsistency" | "flapDaiConsistencyEnd"
  // ----------------------------------------------------------------------
-    rule derive(flapDaiConsistency, Measure(... sumOfAllFlapLots: SUM, dai: VAT_DAI)) => Violated(flapDaiConsistency) requires (SUM >Rat #lookup(VAT_DAI, Flap))
+    rule derive(flapDaiConsistency, Measure(... sumOfAllFlapLots: SUM, dai: VAT_DAI)) => Violated(flapDaiConsistency) requires (SUM >Rad #lookupRad(VAT_DAI, Flap))
     rule derive(flapDaiConsistency, LogNote(_ , End . cage)                         ) => flapDaiConsistencyEnd
 ```
 
@@ -358,17 +368,17 @@ The property checks if a successful `Pot . join` is preceded by a `TimeStep` mor
 ```k
     syntax ViolationFSM ::= "flapMkrConsistency"
  // --------------------------------------------
-    rule derive(flapMkrConsistency, Measure(... sumOfAllFlapBids: SUM, mkrBalances: BALS)) => Violated(flapMkrConsistency) requires (SUM >Rat #lookup(BALS, Flap))
+    rule derive(flapMkrConsistency, Measure(... sumOfAllFlapBids: SUM, mkrBalances: BALS)) => Violated(flapMkrConsistency) requires (SUM >Wad #lookupWad(BALS, Flap))
 ```
 
 ### Flop Blocking
 ```k
-    syntax ViolationFSM ::= flopBlockCheck(embers: Rat, dented: Int)
+    syntax ViolationFSM ::= flopBlockCheck(embers: Rad, dented: Int)
  // ----------------------------------------------------------------
     rule derive(flopBlockCheck(... embers: EMBERS, dented: DENTED), Measure(... dai: VAT_DAI, ash: ASH)) => Violated(flopBlockCheck(... embers: EMBERS, dented: DENTED))
-        requires (ASH -Rat #lookup(VAT_DAI, Vow) >Rat EMBERS)
-    rule derive(flopBlockCheck(... embers: EMBERS, dented: DENTED), LogNote(_ , Flop . kick ID _ BID)) => flopBlockCheck(... embers: EMBERS +Rat BID, dented: DENTED)
-    rule derive(flopBlockCheck(... embers: EMBERS, dented: DENTED), LogNote(_ , Flop . dent ID _ BID)) => flopBlockCheck(... embers: EMBERS -Rat BID, dented: DENTED +Int (2 ^Int ID)) 
+        requires (ASH -Rad #lookupRad(VAT_DAI, Vow) >Rad EMBERS)
+    rule derive(flopBlockCheck(... embers: EMBERS, dented: DENTED), LogNote(_ , Flop . kick ID _ BID)) => flopBlockCheck(... embers: EMBERS +Rad BID, dented: DENTED)
+    rule derive(flopBlockCheck(... embers: EMBERS, dented: DENTED), LogNote(_ , Flop . dent ID _ BID)) => flopBlockCheck(... embers: EMBERS -Rad BID, dented: DENTED +Int (2 ^Int ID)) 
         requires ( ( ( DENTED /Int ( 2 ^Int ID ) ) modInt 2 ) ==Int 0 )
     rule derive(flopBlockCheck(... embers: EMBERS, dented: DENTED), LogNote(_ , Flop . dent ID _ BID)) => flopBlockCheck(... embers: EMBERS, dented: DENTED) [owise]
 ```

--- a/kmcd-props.md
+++ b/kmcd-props.md
@@ -142,7 +142,7 @@ Total backed debt (sum over each CDP's art times corresponding ilk's rate)
     rule calcSumOfScaledArts(VAT_ILKS, VAT_URNS) => calcSumOfScaledArtsAux(keys_list(VAT_ILKS), VAT_ILKS, VAT_URNS, 0Rad)
 
     rule calcSumOfScaledArtsAux(                        .List ,        _ ,        _ , TOTAL ) => TOTAL
-    rule calcSumOfScaledArtsAux( ListItem(ILK_ID) VAT_ILK_IDS , VAT_ILKS , VAT_URNS , TOTAL ) => calcSumOfScaledArtsAux(VAT_ILK_IDS, VAT_ILKS, VAT_URNS, TOTAL +Rad (sumOfUrnArt(VAT_URNS, ILK_ID, 0Wad) *RateWad rate({VAT_ILKS[ILK_ID]}:>VatIlk)))
+    rule calcSumOfScaledArtsAux( ListItem(ILK_ID) VAT_ILK_IDS , VAT_ILKS , VAT_URNS , TOTAL ) => calcSumOfScaledArtsAux(VAT_ILK_IDS, VAT_ILKS, VAT_URNS, TOTAL +Rad (sumOfUrnArt(VAT_URNS, ILK_ID, 0Wad) *Rate rate({VAT_ILKS[ILK_ID]}:>VatIlk)))
 ```
 
 ### Flap Measures
@@ -304,9 +304,9 @@ The Pot Chi multiplied by Pot Pie should equal the Vat Dai for the Pot
     rule derive( potChiPieDai(... offset: OFFSET, joining: JOINING ) , LogNote(_, Pot . join WAD)       ) => potChiPieDai(... offset: OFFSET          , joining: JOINING +Wad WAD )
     rule derive( potChiPieDai(... offset: OFFSET, joining: JOINING ) , LogNote(_, Vat . move _ Pot RAD) ) => potChiPieDai(... offset: OFFSET +Rad RAD , joining: JOINING          )
 
-    rule derive(potChiPieDai(... offset: OFFSET => OFFSET -Rad (JOINING *RateWad POT_CHI), joining: JOINING => 0Wad), Measure(... potChi: POT_CHI)) requires JOINING =/=Wad 0Wad
+    rule derive(potChiPieDai(... offset: OFFSET => OFFSET -Rad (JOINING *Rate POT_CHI), joining: JOINING => 0Wad), Measure(... potChi: POT_CHI)) requires JOINING =/=Wad 0Wad
 
-    rule derive(potChiPieDai(... offset: OFFSET, joining: 0Wad) #as PREV, Measure(... controlDai: CONTROL_DAI, potChi: POT_CHI, potPie: POT_PIE)) => Violated(PREV) requires POT_PIE *RateWad POT_CHI =/=Rad #lookupRad(CONTROL_DAI, Pot) -Rad OFFSET
+    rule derive(potChiPieDai(... offset: OFFSET, joining: 0Wad) #as PREV, Measure(... controlDai: CONTROL_DAI, potChi: POT_CHI, potPie: POT_PIE)) => Violated(PREV) requires POT_PIE *Rate POT_CHI =/=Rad #lookupRad(CONTROL_DAI, Pot) -Rad OFFSET
 ```
 
 ### Kicking off a fake `flip` auction (inspired by lucash-flip)

--- a/kmcd-props.md
+++ b/kmcd-props.md
@@ -18,6 +18,17 @@ module KMCD-PROPS
 Measurables
 -----------
 
+### Lookup Defaulting to 0
+
+Sometimes you need a lookup to default to zero, and want to cast the result as a `Rat`.
+
+```k
+    syntax Rat ::= #lookup ( Map , Address ) [function]
+ // ---------------------------------------------------
+    rule #lookup(M, A) => { M[A] }:>Rat requires A in_keys(M)
+    rule #lookup(M, A) => 0             [owise]
+```
+
 ### Measure Event
 
 ```k

--- a/kmcd-props.md
+++ b/kmcd-props.md
@@ -110,11 +110,11 @@ By default, we assume the MKR balances are negative, but otherwise just grab the
 Art of an ilk = Sum of all urn art across all users for that ilk.
 
 ```k
-    syntax Int ::= sumOfUrnArt(Map, String, Int) [function, functional]
+    syntax Rat ::= sumOfUrnArt(Map, String, Rat) [function, functional]
  // -------------------------------------------------------------------
-    rule sumOfUrnArt( {ILKID , ADDR} |-> Urn ( _ , ART) URNS, ILKID', SUM)
+    rule sumOfUrnArt( {ILKID , ADDR} |-> Urn (... art: ART) URNS, ILKID', SUM)
       => #if ILKID ==K ILKID'
-            #then sumOfUrnArt( URNS, ILKID', SUM +Int ART)
+            #then sumOfUrnArt( URNS, ILKID', SUM +Rat ART)
             #else sumOfUrnArt( URNS, ILKID', SUM)
          #fi
 

--- a/kmcd-props.md
+++ b/kmcd-props.md
@@ -123,49 +123,6 @@ Art of an ilk = Sum of all urn art across all users for that ilk.
     rule sumOfUrnArt(.Map, _, SUM) => SUM
 ```
 
-Ink of an ilk = Sum of all urn ink across all users for that ilk.
-
-Total debt = Sum of all debt across all users.
-
-```k
-    syntax Int ::= sumOfAllDebt(Map, Int) [function, functional]
- // ------------------------------------------------------------
-    rule sumOfAllDebt( ADDR |-> DAI USERDAI, SUM)
-      => sumOfAllDebt( USERDAI, SUM +Int DAI)
-
-    rule sumOfAllDebt( _ |-> _ USERDAI, SUM ) => sumOfAllDebt( USERDAI, SUM ) [owise]
-
-    rule sumOfAllDebt(.Map, SUM) => SUM
-```
-
-Total vice = Sum of all sin across all users.
-
-```k
-    syntax Int ::= sumOfAllSin(Map, Int) [function, functional]
- // ------------------------------------------------------------
-    rule sumOfAllSin( ADDR |-> SIN USERSIN, SUM)
-      => sumOfAllSin( USERSIN, SUM +Int SIN)
-
-    rule sumOfAllSin( _ |-> _ USERSIN, SUM ) => sumOfAllSin( USERSIN, SUM ) [owise]
-
-    rule sumOfAllSin(.Map, SUM) => SUM
-```
-
-Total dai of all users = CDP debt for all users and gem + system debt (vice)
-
-```k
-    syntax Rat ::= sumOfAllUserDebt( ilks: Map, urns: Map, sum: Rat) [function, functional]
- // ---------------------------------------------------------------------------------------
-    rule sumOfAllUserDebt(
-             ILKID |-> ILK ILKS => ILKS,
-             URNS,
-             SUM => SUM +Rat (rate(ILK) *Rat sumOfUrnArt(URNS, ILKID, 0)) )
-
-    rule sumOfAllUserDebt(_ |-> _ ILKS => ILKS, URNS, SUM) [owise]
-
-    rule sumOfAllUserDebt(.Map, _, SUM) => SUM
-```
-
 Total backed debt (sum over each CDP's art times corresponding ilk's rate)
 
 ```k

--- a/pot.md
+++ b/pot.md
@@ -100,7 +100,7 @@ Pot Semantics
 ```k
     syntax PotStep ::= "drip"
  // -------------------------
-    rule <k> Pot . drip => call Vat . suck VOW THIS ( PIE *RateWad ( CHI *Ray ( DSR ^Ray (NOW -Int RHO) -Ray 1Ray ) ) ) ... </k>
+    rule <k> Pot . drip => call Vat . suck VOW THIS ( PIE *Rate ( CHI *Ray ( DSR ^Ray (NOW -Int RHO) -Ray 1Ray ) ) ) ... </k>
          <this> THIS </this>
          <current-time> NOW </current-time>
          <pot-chi> CHI => CHI *Ray (DSR ^Ray (NOW -Int RHO)) </pot-chi>
@@ -113,7 +113,7 @@ Pot Semantics
 
     syntax PotStep ::= "join" Wad
  // -----------------------------
-    rule <k> Pot . join WAD => call Vat . move MSGSENDER THIS ( WAD *RateWad CHI ) ... </k>
+    rule <k> Pot . join WAD => call Vat . move MSGSENDER THIS ( WAD *Rate CHI ) ... </k>
          <this> THIS </this>
          <current-time> NOW </current-time>
          <msg-sender> MSGSENDER </msg-sender>
@@ -126,7 +126,7 @@ Pot Semantics
 
     syntax PotStep ::= "exit" Wad
  // -----------------------------
-    rule <k> Pot . exit WAD => call Vat . move THIS MSGSENDER ( WAD *RateWad CHI ) ... </k>
+    rule <k> Pot . exit WAD => call Vat . move THIS MSGSENDER ( WAD *Rate CHI ) ... </k>
          <this> THIS </this>
          <msg-sender> MSGSENDER </msg-sender>
          <pot-pies> ... MSGSENDER |-> ( MSGSENDER_PIE => MSGSENDER_PIE -Wad WAD ) ... </pot-pies>

--- a/pot.md
+++ b/pot.md
@@ -15,9 +15,9 @@ Pot Configuration
       <pot>
         <pot-wards> .Set      </pot-wards>
         <pot-pies>  .Map      </pot-pies> // mapping (address => uint256) Address |-> Wad
-        <pot-pie>   0:Wad     </pot-pie>
-        <pot-dsr>   1:Ray     </pot-dsr>
-        <pot-chi>   1:Ray     </pot-chi>
+        <pot-pie>   0Wad      </pot-pie>
+        <pot-dsr>   1Ray      </pot-dsr>
+        <pot-chi>   1Ray      </pot-chi>
         <pot-vow>   0:Address </pot-vow>
         <pot-rho>   0         </pot-rho>
         <pot-live>  true      </pot-live>
@@ -71,7 +71,7 @@ These parameters are controlled by governance:
          <current-time> NOW </current-time>
          <pot-live> true </pot-live>
       requires NOW ==Int RHO
-       andBool DSR >=Rat 0
+       andBool DSR >=Ray 0Ray
 
     rule <k> Pot . file vow-file ADDR => . ... </k>
          <pot-vow> _ => ADDR </pot-vow>
@@ -90,7 +90,7 @@ Because data isn't explicitely initialized to 0 in KMCD, we need explicit initia
     syntax PotAuthStep ::= "initUser" Address
  // -----------------------------------------
     rule <k> Pot . initUser ADDR => . ... </k>
-         <pot-pies> PIES => PIES [ ADDR <- 0 ] </pot-pies>
+         <pot-pies> PIES => PIES [ ADDR <- 0Wad ] </pot-pies>
       requires notBool ADDR in_keys(PIES)
 ```
 
@@ -100,46 +100,46 @@ Pot Semantics
 ```k
     syntax PotStep ::= "drip"
  // -------------------------
-    rule <k> Pot . drip => call Vat . suck VOW THIS ( PIE *Rat CHI *Rat ( DSR ^Rat (NOW -Int RHO) -Rat 1 ) ) ... </k>
+    rule <k> Pot . drip => call Vat . suck VOW THIS ( PIE *Rate ( CHI *Ray ( DSR ^Ray (NOW -Int RHO) -Ray 1Ray ) ) ) ... </k>
          <this> THIS </this>
          <current-time> NOW </current-time>
-         <pot-chi> CHI => CHI *Rat (DSR ^Rat (NOW -Int RHO)) </pot-chi>
+         <pot-chi> CHI => CHI *Ray (DSR ^Ray (NOW -Int RHO)) </pot-chi>
          <pot-rho> RHO => NOW </pot-rho>
          <pot-dsr> DSR </pot-dsr>
          <pot-vow> VOW </pot-vow>
          <pot-pie> PIE </pot-pie>
       requires NOW >=Int RHO
-       andBool DSR >=Rat 1 // to ensure positive interest rate
+       andBool DSR >=Ray 1Ray // to ensure positive interest rate
 
     syntax PotStep ::= "join" Wad
  // -----------------------------
-    rule <k> Pot . join WAD => call Vat . move MSGSENDER THIS ( CHI *Rat WAD ) ... </k>
+    rule <k> Pot . join WAD => call Vat . move MSGSENDER THIS ( WAD *Rate CHI ) ... </k>
          <this> THIS </this>
          <current-time> NOW </current-time>
          <msg-sender> MSGSENDER </msg-sender>
-         <pot-pies> ... MSGSENDER |-> ( MSGSENDER_PIE => MSGSENDER_PIE +Rat WAD ) ... </pot-pies>
-         <pot-pie> PIE => PIE +Rat WAD </pot-pie>
+         <pot-pies> ... MSGSENDER |-> ( MSGSENDER_PIE => MSGSENDER_PIE +Wad WAD ) ... </pot-pies>
+         <pot-pie> PIE => PIE +Wad WAD </pot-pie>
          <pot-chi> CHI </pot-chi>
          <pot-rho> RHO </pot-rho>
-      requires WAD >=Rat 0
+      requires WAD >=Wad 0Wad
        andBool NOW ==Int RHO
 
     syntax PotStep ::= "exit" Wad
  // -----------------------------
-    rule <k> Pot . exit WAD => call Vat . move THIS MSGSENDER ( CHI *Rat WAD ) ... </k>
+    rule <k> Pot . exit WAD => call Vat . move THIS MSGSENDER ( WAD *Rate CHI ) ... </k>
          <this> THIS </this>
          <msg-sender> MSGSENDER </msg-sender>
-         <pot-pies> ... MSGSENDER |-> ( MSGSENDER_PIE => MSGSENDER_PIE -Rat WAD ) ... </pot-pies>
-         <pot-pie> PIE => PIE -Rat WAD </pot-pie>
+         <pot-pies> ... MSGSENDER |-> ( MSGSENDER_PIE => MSGSENDER_PIE -Wad WAD ) ... </pot-pies>
+         <pot-pie> PIE => PIE -Wad WAD </pot-pie>
          <pot-chi> CHI </pot-chi>
-      requires WAD >=Rat 0
-       andBool MSGSENDER_PIE >=Rat WAD
+      requires WAD >=Wad 0Wad
+       andBool MSGSENDER_PIE >=Wad WAD
 
     syntax PotAuthStep ::= "cage"
  // -----------------------------
     rule <k> Pot . cage => . ... </k>
          <pot-live> _ => false </pot-live>
-         <pot-dsr> _ => 1 </pot-dsr>
+         <pot-dsr> _ => 1Ray </pot-dsr>
 ```
 
 ```k

--- a/pot.md
+++ b/pot.md
@@ -100,7 +100,7 @@ Pot Semantics
 ```k
     syntax PotStep ::= "drip"
  // -------------------------
-    rule <k> Pot . drip => call Vat . suck VOW THIS ( PIE *Rate ( CHI *Ray ( DSR ^Ray (NOW -Int RHO) -Ray 1Ray ) ) ) ... </k>
+    rule <k> Pot . drip => call Vat . suck VOW THIS ( PIE *RateWad ( CHI *Ray ( DSR ^Ray (NOW -Int RHO) -Ray 1Ray ) ) ) ... </k>
          <this> THIS </this>
          <current-time> NOW </current-time>
          <pot-chi> CHI => CHI *Ray (DSR ^Ray (NOW -Int RHO)) </pot-chi>
@@ -113,7 +113,7 @@ Pot Semantics
 
     syntax PotStep ::= "join" Wad
  // -----------------------------
-    rule <k> Pot . join WAD => call Vat . move MSGSENDER THIS ( WAD *Rate CHI ) ... </k>
+    rule <k> Pot . join WAD => call Vat . move MSGSENDER THIS ( WAD *RateWad CHI ) ... </k>
          <this> THIS </this>
          <current-time> NOW </current-time>
          <msg-sender> MSGSENDER </msg-sender>
@@ -126,7 +126,7 @@ Pot Semantics
 
     syntax PotStep ::= "exit" Wad
  // -----------------------------
-    rule <k> Pot . exit WAD => call Vat . move THIS MSGSENDER ( WAD *Rate CHI ) ... </k>
+    rule <k> Pot . exit WAD => call Vat . move THIS MSGSENDER ( WAD *RateWad CHI ) ... </k>
          <this> THIS </this>
          <msg-sender> MSGSENDER </msg-sender>
          <pot-pies> ... MSGSENDER |-> ( MSGSENDER_PIE => MSGSENDER_PIE -Wad WAD ) ... </pot-pies>

--- a/pot.md
+++ b/pot.md
@@ -17,7 +17,7 @@ Pot Configuration
         <pot-pies>  .Map      </pot-pies> // mapping (address => uint256) Address |-> Wad
         <pot-pie>   0:Wad     </pot-pie>
         <pot-dsr>   1:Ray     </pot-dsr>
-        <pot-chi>   1:Rat     </pot-chi> // arbitrary precision
+        <pot-chi>   1:Ray     </pot-chi>
         <pot-vow>   0:Address </pot-vow>
         <pot-rho>   0         </pot-rho>
         <pot-live>  true      </pot-live>

--- a/spot.md
+++ b/spot.md
@@ -13,10 +13,10 @@ Spot Configuration
 ```k
     configuration
       <spot>
-        <spot-wards> .Set  </spot-wards>
-        <spot-ilks>  .Map  </spot-ilks> // mapping (bytes32 => ilk)  String  |-> SpotIlk
-        <spot-par>   1:Ray </spot-par>
-        <spot-live>  true  </spot-live>
+        <spot-wards> .Set </spot-wards>
+        <spot-ilks>  .Map </spot-ilks> // mapping (bytes32 => ilk)  String  |-> SpotIlk
+        <spot-par>   1Ray </spot-par>
+        <spot-live>  true </spot-live>
       </spot>
 ```
 
@@ -85,17 +85,17 @@ These parameters are controlled by governance/oracles:
     rule <k> Spot . file pip ILKID WAD:Wad => . ... </k>
          <spot-live> true </spot-live>
          <spot-ilks> ... ILKID |-> SpotIlk ( ... pip: (_ => WAD) ) ... </spot-ilks>
-      requires WAD >=Rat 0
+      requires WAD >=Wad 0Wad
 
     rule <k> Spot . file mat ILKID MAT => . ... </k>
          <spot-live> true </spot-live>
          <spot-ilks> ... ILKID |-> SpotIlk ( ... mat: (_ => MAT) ) ... </spot-ilks>
-      requires MAT >=Rat 0
+      requires MAT >=Ray 0Ray
 
     rule <k> Spot . file par PAR => . ... </k>
          <spot-live> true </spot-live>
          <spot-par> _ => PAR </spot-par>
-      requires PAR >=Rat 0
+      requires PAR >=Ray 0Ray
 ```
 
 **TODO**: We currently store a `MaybeWad` for `pip` instead of a contract address to call to get that data.
@@ -122,7 +122,7 @@ Because data isn't explicitely initialized to 0 in KMCD, we need explicit initia
                           | "setPrice" String Wad
  // ---------------------------------------------
     rule <k> Spot . init ILKID => . ... </k>
-         <spot-ilks> ILKS => ILKS [ ILKID <- SpotIlk( ... pip: .Wad, mat: 0 ) ] </spot-ilks>
+         <spot-ilks> ILKS => ILKS [ ILKID <- SpotIlk( ... pip: .Wad, mat: 0Ray ) ] </spot-ilks>
       requires notBool ILKID in_keys(ILKS)
 
     rule <k> Spot . setPrice ILKID PRICE => . ... </k>
@@ -135,10 +135,10 @@ Spot Semantics
 ```k
     syntax SpotStep ::= "poke" String
  // ---------------------------------
-    rule <k> Spot . poke ILK => call Vat . file spot ILK ((VALUE /Rat PAR) /Rat MAT) ... </k>
+    rule <k> Spot . poke ILK => call Vat . file spot ILK ((Wad2Ray(VALUE) /Ray PAR) /Ray MAT) ... </k>
          <spot-ilks> ... ILK |-> SpotIlk (... pip: VALUE, mat: MAT ) ... </spot-ilks>
          <spot-par> PAR </spot-par>
-         <frame-events> ... (.List => ListItem(Poke(ILK, VALUE, VALUE /Rat PAR /Rat MAT))) </frame-events>
+         <frame-events> ... (.List => ListItem(Poke(ILK, VALUE, (Wad2Ray(VALUE) /Ray PAR) /Ray MAT))) </frame-events>
       requires VALUE =/=K .Wad
 
     rule <k> Spot . poke ILK => . ... </k>

--- a/tests/attacks/blocked-flop.mcd
+++ b/tests/attacks/blocked-flop.mcd
@@ -9,16 +9,16 @@ STEPS ( ATTACK-PRELUDE )
 // Vow.dump = 30 (flop initial lot size)
 
 // Use suck to give Bobby some DAI, which conveniently also creates enough free, unbacked debt for 2 flop auctions
-transact ADMIN Vat . suck Vow "Bobby" 100
+transact ADMIN Vat . suck Vow "Bobby" rad(100)
 
 // Start a flop auction
 transact "Bobby" Vow . flop
 
 // Bobby bids (1 = auction id, 25 = MKR lot, 50 = DAI bid)
-transact "Bobby" Flop . dent 1 25 50
+transact "Bobby" Flop . dent 1 wad(25) rad(50)
 
 // Bobby calls heal (should actually call kiss to avoid the bug)
-transact "Bobby" Vow . heal 50
+transact "Bobby" Vow . heal rad(50)
 
 // Now we can't flop because debt is stuck as Ash
 transact "Bobby" Vow . flop

--- a/tests/attacks/lucash-flap-end.mcd
+++ b/tests/attacks/lucash-flap-end.mcd
@@ -5,18 +5,18 @@ STEPS ( ATTACK-PRELUDE )
 // ---------------
 
 // Give Bobby some MKR
-transact ADMIN Gem "MKR" . mint "Bobby" 20
+transact ADMIN Gem "MKR" . mint "Bobby" wad(20)
 
 // Cheat a little to get a Flap auction started w/o going through full surplus generation cycle
 // (dump sin into the End, out-of-sight of the accounting logic)
-transact ADMIN Vat . suck End Vow 1 ether
+transact ADMIN Vat . suck End Vow rad(1 ether)
 transact ADMIN Vow . flap
 
 // Bobby bids on flap auction
-transact "Bobby" Flap . tend 1 1 ether 20
+transact "Bobby" Flap . tend 1 rad(1 ether) wad(20)
 
 transact "Alice" Vat . hope Flap
-transact "Alice" Flap . kick 1 20 // step that shouldn't go through
+transact "Alice" Flap . kick rad(1) wad(20) // step that shouldn't go through
 
 transact ADMIN End . cage
 transact "Alice" Flap . yank 2

--- a/tests/attacks/lucash-flip-end.mcd
+++ b/tests/attacks/lucash-flip-end.mcd
@@ -4,7 +4,7 @@ STEPS ( ATTACK-PRELUDE )
 // Attack Sequence
 // ---------------
 
-transact "Bobby" GemJoin "gold" . join "Bobby" 1
+transact "Bobby" GemJoin "gold" . join "Bobby" wad(1)
 transact ADMIN End . cage
 transact ADMIN End . cage "gold"
 TimeStep 1 hour
@@ -12,7 +12,7 @@ transact ADMIN End . thaw
 transact ADMIN End . flow "gold"
 
 // Every call after this reverts in fixed version
-transact "Bobby" Flip "gold" . kick End "Bobby" 1001 ether 1 1000 ether
+transact "Bobby" Flip "gold" . kick End "Bobby" rad(1001 ether) wad(1) rad(1000 ether)
 transact "Bobby" End . skip "gold" 1
 
 // Now Bobby has more dai than he should.

--- a/tests/attacks/lucash-pot-end.mcd
+++ b/tests/attacks/lucash-pot-end.mcd
@@ -10,11 +10,11 @@ transact ADMIN End . skim "gold" "Alice"
 transact ADMIN End . skim "gold" "Bobby"
 transact ADMIN End . thaw
 transact ADMIN End . flow "gold"
-transact "Alice" Pot . join 10
-transact ADMIN Pot . file dsr 2
+transact "Alice" Pot . join wad(10)
+transact ADMIN Pot . file dsr ray(2)
 TimeStep 1 second
 transact "Alice" Pot . drip
-transact "Alice" Pot . exit 10
+transact "Alice" Pot . exit wad(10)
 
 assert
 

--- a/tests/attacks/lucash-pot.mcd
+++ b/tests/attacks/lucash-pot.mcd
@@ -5,12 +5,12 @@ STEPS ( ATTACK-PRELUDE )
 // ---------------
 
 // Earn Interest
-transact ADMIN Pot . file dsr 5            // set interest rate
+transact ADMIN Pot . file dsr ray(5)       // set interest rate
 TimeStep 1 second                          // earn interest for a second
 
-transact "Alice" Pot . join 10
+transact "Alice" Pot . join wad(10)
 transact "Alice" Pot . drip
-transact "Alice" Pot . exit 10
+transact "Alice" Pot . exit wad(10)
 
 assert
 

--- a/tests/fixes/debtBoundDSR.mcd
+++ b/tests/fixes/debtBoundDSR.mcd
@@ -1,8 +1,8 @@
 STEPS ( DEPLOY-PRELUDE )
 STEPS ( ATTACK-PRELUDE )
 
-transact "Bobby" Vat . move "Bobby" Pot 985 /Rat 128
-transact ADMIN Pot . file dsr 9 /Rat 8
+transact "Bobby" Vat . move "Bobby" Pot rad(985 /Rat 128)
+transact ADMIN Pot . file dsr ray(9 /Rat 8)
 TimeStep 1
 transact ADMIN End . cage
 

--- a/tests/fixes/potChiPieDai.mcd
+++ b/tests/fixes/potChiPieDai.mcd
@@ -1,9 +1,9 @@
 STEPS ( DEPLOY-PRELUDE )
 STEPS ( ATTACK-PRELUDE )
 
-transact ADMIN Pot . file dsr 23 /Rat 20
+transact ADMIN Pot . file dsr ray(23 /Rat 20)
 TimeStep 1
-transact "Bobby" Vat . move "Bobby" Pot 495 /Rat 64
+transact "Bobby" Vat . move "Bobby" Pot wad(495 /Rat 64)
 
 assert
 

--- a/tests/fixes/potChiPieDai.mcd
+++ b/tests/fixes/potChiPieDai.mcd
@@ -3,7 +3,7 @@ STEPS ( ATTACK-PRELUDE )
 
 transact ADMIN Pot . file dsr ray(23 /Rat 20)
 TimeStep 1
-transact "Bobby" Vat . move "Bobby" Pot wad(495 /Rat 64)
+transact "Bobby" Vat . move "Bobby" Pot rad(495 /Rat 64)
 
 assert
 

--- a/vat.md
+++ b/vat.md
@@ -112,8 +112,8 @@ CDP Data
  // -----------------------------------------------------------------------
     rule urnBalance(ILK, URN) => urnCollateral(ILK, URN) -Rad urnDebt(ILK, URN)
 
-    rule urnDebt      (ILK, URN) => art(URN) *RateWad rate(ILK)
-    rule urnCollateral(ILK, URN) => ink(URN) *RateWad spot(ILK)
+    rule urnDebt      (ILK, URN) => art(URN) *Rate rate(ILK)
+    rule urnCollateral(ILK, URN) => ink(URN) *Rate spot(ILK)
 ```
 
 File-able Fields
@@ -385,14 +385,14 @@ This is quite permissive, and would allow the account to drain all your locked c
     syntax VatAuthStep ::= "grab" String Address Address Address Wad Wad
  // --------------------------------------------------------------------
     rule <k> Vat . grab ILKID ADDRU ADDRV ADDRW DINK DART => . ... </k>
-         <vat-vice> VICE => VICE -Rad (DART *RateWad RATE) </vat-vice>
+         <vat-vice> VICE => VICE -Rad (DART *Rate RATE) </vat-vice>
          <vat-urns> ... { ILKID , ADDRU } |-> Urn ( INK => INK +Wad DINK , URNART => URNART +Wad DART ) ... </vat-urns>
          <vat-ilks> ... ILKID |-> Ilk ( ILKART => ILKART +Wad DART , RATE , _ , _ , _ ) ... </vat-ilks>
          <vat-gem> ... { ILKID , ADDRV } |-> ( ILKV => ILKV -Wad DINK ) ... </vat-gem>
-         <vat-sin> ... ADDRW |-> ( SINW => SINW -Rad (DART *RateWad RATE) ) ... </vat-sin>
+         <vat-sin> ... ADDRW |-> ( SINW => SINW -Rad (DART *Rate RATE) ) ... </vat-sin>
       requires ILKV >=Wad DINK
-       andBool SINW >=Rad (DART *RateWad RATE)
-       andBool VICE >=Rad (DART *RateWad RATE)
+       andBool SINW >=Rad (DART *Rate RATE)
+       andBool VICE >=Rad (DART *Rate RATE)
 
     syntax VatStep ::= "frob" String Address Address Address Wad Wad
  // ----------------------------------------------------------------
@@ -400,25 +400,25 @@ This is quite permissive, and would allow the account to drain all your locked c
          ...
          </k>
          <vat-live> true </vat-live>
-         <vat-debt> DEBT => DEBT +Rad (DART *RateWad RATE) </vat-debt>
+         <vat-debt> DEBT => DEBT +Rad (DART *Rate RATE) </vat-debt>
          <vat-urns> ... { ILKID , ADDRU } |-> Urn ( INK => INK +Wad DINK , URNART => URNART +Wad DART ) ... </vat-urns>
          <vat-ilks> ... ILKID |-> Ilk (... Art: ILKART => ILKART +Wad DART , rate: RATE , spot: SPOT, line: ILKLINE, dust: DUST ) ... </vat-ilks>
          <vat-gem> ... { ILKID , ADDRV } |-> ( ILKV => ILKV -Wad DINK ) ... </vat-gem>
-         <vat-dai> ... ADDRW |-> ( DAIW => DAIW +Rad (DART *RateWad RATE) ) ... </vat-dai>
+         <vat-dai> ... ADDRW |-> ( DAIW => DAIW +Rad (DART *Rate RATE) ) ... </vat-dai>
          <vat-Line> LINE </vat-Line>
       requires ILKV >=Wad DINK
        andBool ( DART <=Wad 0Wad
-               orBool ((ILKART +Wad DART) *RateWad RATE <=Rad ILKLINE andBool DEBT +Rad (DART *RateWad RATE) <=Rad LINE)
+               orBool ((ILKART +Wad DART) *Rate RATE <=Rad ILKLINE andBool DEBT +Rad (DART *Rate RATE) <=Rad LINE)
                     )
        andBool      ( (DART <=Wad 0Wad andBool DINK >=Wad 0Wad)
-               orBool (URNART +Wad DART) *RateWad RATE <=Rad (INK +Wad DINK) *RateWad SPOT
+               orBool (URNART +Wad DART) *Rate RATE <=Rad (INK +Wad DINK) *Rate SPOT
                     )
        andBool      ( (DART <=Wad 0Wad andBool DINK >=Wad 0Wad)
                orBool wish ADDRU
                     )
        andBool (DINK <=Wad 0Wad orBool wish ADDRV)
        andBool (DART >=Wad 0Wad orBool wish ADDRW)
-       andBool (URNART +Wad DART ==Wad 0Wad orBool (URNART +Wad DART) *RateWad RATE >=Rad DUST)
+       andBool (URNART +Wad DART ==Wad 0Wad orBool (URNART +Wad DART) *Rate RATE >=Rad DUST)
 ```
 
 ### Debt/Dai manipulation (`<vat-debt>`, `<vat-dai>`, `<vat-vice>`, `<vat-sin>`)
@@ -460,9 +460,9 @@ This is quite permissive, and would allow the account to drain all your locked c
  // ------------------------------------------------
     rule <k> Vat . fold ILKID ADDRU RATE => . ... </k>
          <vat-live> true </vat-live>
-         <vat-debt> DEBT => DEBT +Rad (ILKART *RateWad RATE) </vat-debt>
+         <vat-debt> DEBT => DEBT +Rad (ILKART *Rate RATE) </vat-debt>
          <vat-ilks> ... ILKID |-> Ilk ( ILKART , ILKRATE => ILKRATE +Ray RATE , _ , _ , _ ) ... </vat-ilks>
-         <vat-dai> ... ADDRU |-> ( DAI => DAI +Rad (ILKART *RateWad RATE) ) ... </vat-dai>
+         <vat-dai> ... ADDRU |-> ( DAI => DAI +Rad (ILKART *Rate RATE) ) ... </vat-dai>
 ```
 
 ```k

--- a/vat.md
+++ b/vat.md
@@ -317,7 +317,7 @@ This is quite permissive, and would allow the account to drain all your locked c
     **TODO**: Should `Vat.move` use `Vat.consent` or `Vat.wish`?
 
 ```k
-    syntax VatStep ::= "move" Address Address Wad
+    syntax VatStep ::= "move" Address Address Rad
  // ---------------------------------------------
     rule <k> Vat . move ADDRFROM ADDRTO DAI => . ... </k>
          <vat-dai>

--- a/vat.md
+++ b/vat.md
@@ -112,8 +112,8 @@ CDP Data
  // -----------------------------------------------------------------------
     rule urnBalance(ILK, URN) => urnCollateral(ILK, URN) -Rad urnDebt(ILK, URN)
 
-    rule urnDebt      (ILK, URN) => art(URN) *Rate rate(ILK)
-    rule urnCollateral(ILK, URN) => ink(URN) *Rate spot(ILK)
+    rule urnDebt      (ILK, URN) => art(URN) *RateWad rate(ILK)
+    rule urnCollateral(ILK, URN) => ink(URN) *RateWad spot(ILK)
 ```
 
 File-able Fields
@@ -385,14 +385,14 @@ This is quite permissive, and would allow the account to drain all your locked c
     syntax VatAuthStep ::= "grab" String Address Address Address Wad Wad
  // --------------------------------------------------------------------
     rule <k> Vat . grab ILKID ADDRU ADDRV ADDRW DINK DART => . ... </k>
-         <vat-vice> VICE => VICE -Rad (DART *Rate RATE) </vat-vice>
+         <vat-vice> VICE => VICE -Rad (DART *RateWad RATE) </vat-vice>
          <vat-urns> ... { ILKID , ADDRU } |-> Urn ( INK => INK +Wad DINK , URNART => URNART +Wad DART ) ... </vat-urns>
          <vat-ilks> ... ILKID |-> Ilk ( ILKART => ILKART +Wad DART , RATE , _ , _ , _ ) ... </vat-ilks>
          <vat-gem> ... { ILKID , ADDRV } |-> ( ILKV => ILKV -Wad DINK ) ... </vat-gem>
-         <vat-sin> ... ADDRW |-> ( SINW => SINW -Rad (DART *Rate RATE) ) ... </vat-sin>
+         <vat-sin> ... ADDRW |-> ( SINW => SINW -Rad (DART *RateWad RATE) ) ... </vat-sin>
       requires ILKV >=Wad DINK
-       andBool SINW >=Rad (DART *Rate RATE)
-       andBool VICE >=Rad (DART *Rate RATE)
+       andBool SINW >=Rad (DART *RateWad RATE)
+       andBool VICE >=Rad (DART *RateWad RATE)
 
     syntax VatStep ::= "frob" String Address Address Address Wad Wad
  // ----------------------------------------------------------------
@@ -400,25 +400,25 @@ This is quite permissive, and would allow the account to drain all your locked c
          ...
          </k>
          <vat-live> true </vat-live>
-         <vat-debt> DEBT => DEBT +Rad (DART *Rate RATE) </vat-debt>
+         <vat-debt> DEBT => DEBT +Rad (DART *RateWad RATE) </vat-debt>
          <vat-urns> ... { ILKID , ADDRU } |-> Urn ( INK => INK +Wad DINK , URNART => URNART +Wad DART ) ... </vat-urns>
          <vat-ilks> ... ILKID |-> Ilk (... Art: ILKART => ILKART +Wad DART , rate: RATE , spot: SPOT, line: ILKLINE, dust: DUST ) ... </vat-ilks>
          <vat-gem> ... { ILKID , ADDRV } |-> ( ILKV => ILKV -Wad DINK ) ... </vat-gem>
-         <vat-dai> ... ADDRW |-> ( DAIW => DAIW +Rad (DART *Rate RATE) ) ... </vat-dai>
+         <vat-dai> ... ADDRW |-> ( DAIW => DAIW +Rad (DART *RateWad RATE) ) ... </vat-dai>
          <vat-Line> LINE </vat-Line>
       requires ILKV >=Wad DINK
        andBool ( DART <=Wad 0Wad
-               orBool ((ILKART +Wad DART) *Rate RATE <=Rad ILKLINE andBool DEBT +Rad (DART *Rate RATE) <=Rad LINE)
+               orBool ((ILKART +Wad DART) *RateWad RATE <=Rad ILKLINE andBool DEBT +Rad (DART *RateWad RATE) <=Rad LINE)
                     )
        andBool      ( (DART <=Wad 0Wad andBool DINK >=Wad 0Wad)
-               orBool (URNART +Wad DART) *Rate RATE <=Rad (INK +Wad DINK) *Rate SPOT
+               orBool (URNART +Wad DART) *RateWad RATE <=Rad (INK +Wad DINK) *RateWad SPOT
                     )
        andBool      ( (DART <=Wad 0Wad andBool DINK >=Wad 0Wad)
                orBool wish ADDRU
                     )
        andBool (DINK <=Wad 0Wad orBool wish ADDRV)
        andBool (DART >=Wad 0Wad orBool wish ADDRW)
-       andBool (URNART +Wad DART ==Wad 0Wad orBool (URNART +Wad DART) *Rate RATE >=Rad DUST)
+       andBool (URNART +Wad DART ==Wad 0Wad orBool (URNART +Wad DART) *RateWad RATE >=Rad DUST)
 ```
 
 ### Debt/Dai manipulation (`<vat-debt>`, `<vat-dai>`, `<vat-vice>`, `<vat-sin>`)
@@ -460,9 +460,9 @@ This is quite permissive, and would allow the account to drain all your locked c
  // ------------------------------------------------
     rule <k> Vat . fold ILKID ADDRU RATE => . ... </k>
          <vat-live> true </vat-live>
-         <vat-debt> DEBT => DEBT +Rad (ILKART *Rate RATE) </vat-debt>
+         <vat-debt> DEBT => DEBT +Rad (ILKART *RateWad RATE) </vat-debt>
          <vat-ilks> ... ILKID |-> Ilk ( ILKART , ILKRATE => ILKRATE +Ray RATE , _ , _ , _ ) ... </vat-ilks>
-         <vat-dai> ... ADDRU |-> ( DAI => DAI +Rad (ILKART *Rate RATE) ) ... </vat-dai>
+         <vat-dai> ... ADDRU |-> ( DAI => DAI +Rad (ILKART *RateWad RATE) ) ... </vat-dai>
 ```
 
 ```k

--- a/vat.md
+++ b/vat.md
@@ -11,17 +11,17 @@ Vat Configuration
 ```k
     configuration
       <vat>
-        <vat-wards> .Set  </vat-wards>
-        <vat-can>   .Map  </vat-can>  // mapping (address (address => uint))       Address |-> Set
-        <vat-ilks>  .Map  </vat-ilks> // mapping (bytes32 => Ilk)                  String  |-> VatIlk
-        <vat-urns>  .Map  </vat-urns> // mapping (bytes32 => (address => Urn))     CDPID   |-> VatUrn
-        <vat-gem>   .Map  </vat-gem>  // mapping (bytes32 => (address => uint256)) CDPID   |-> Wad
-        <vat-dai>   .Map  </vat-dai>  // mapping (address => uint256)              Address |-> Rad
-        <vat-sin>   .Map  </vat-sin>  // mapping (address => uint256)              Address |-> Rad
-        <vat-debt>  0:Rad </vat-debt> // Total Dai Issued
-        <vat-vice>  0:Rad </vat-vice> // Total Unbacked Dai
-        <vat-Line>  0:Rad </vat-Line> // Total Debt Ceiling
-        <vat-live>  true  </vat-live> // Access Flag
+        <vat-wards> .Set </vat-wards>
+        <vat-can>   .Map </vat-can>  // mapping (address (address => uint))       Address |-> Set
+        <vat-ilks>  .Map </vat-ilks> // mapping (bytes32 => Ilk)                  String  |-> VatIlk
+        <vat-urns>  .Map </vat-urns> // mapping (bytes32 => (address => Urn))     CDPID   |-> VatUrn
+        <vat-gem>   .Map </vat-gem>  // mapping (bytes32 => (address => uint256)) CDPID   |-> Wad
+        <vat-dai>   .Map </vat-dai>  // mapping (address => uint256)              Address |-> Rad
+        <vat-sin>   .Map </vat-sin>  // mapping (address => uint256)              Address |-> Rad
+        <vat-debt>  0Rad </vat-debt> // Total Dai Issued
+        <vat-vice>  0Rad </vat-vice> // Total Unbacked Dai
+        <vat-Line>  0Rad </vat-Line> // Total Debt Ceiling
+        <vat-live>  true </vat-live> // Access Flag
       </vat>
 ```
 
@@ -110,10 +110,10 @@ CDP Data
                  | urnDebt       ( VatIlk , VatUrn ) [function, functional]
                  | urnCollateral ( VatIlk , VatUrn ) [function, functional]
  // -----------------------------------------------------------------------
-    rule urnBalance(ILK, URN) => urnCollateral(ILK, URN) -Rat urnDebt(ILK, URN)
+    rule urnBalance(ILK, URN) => urnCollateral(ILK, URN) -Rad urnDebt(ILK, URN)
 
-    rule urnDebt      (ILK, URN) => rate(ILK) *Rat art(URN)
-    rule urnCollateral(ILK, URN) => spot(ILK) *Rat ink(URN)
+    rule urnDebt      (ILK, URN) => art(URN) *Rate rate(ILK)
+    rule urnCollateral(ILK, URN) => ink(URN) *Rate spot(ILK)
 ```
 
 File-able Fields
@@ -138,22 +138,22 @@ The parameters controlled by governance are:
     rule <k> Vat . file Line LINE => . ... </k>
          <vat-live> true </vat-live>
          <vat-Line> _ => LINE </vat-Line>
-      requires LINE >=Rat 0
+      requires LINE >=Rad 0Rad
 
     rule <k> Vat . file spot ILKID SPOT => . ... </k>
          <vat-live> true </vat-live>
          <vat-ilks> ... ILKID |-> Ilk ( ... spot: (_ => SPOT) ) ... </vat-ilks>
-      requires SPOT >=Rat 0
+      requires SPOT >=Ray 0Ray
 
     rule <k> Vat . file line ILKID LINE => . ... </k>
          <vat-live> true </vat-live>
          <vat-ilks> ... ILKID |-> Ilk ( ... line: (_ => LINE) ) ... </vat-ilks>
-      requires LINE >=Rat 0
+      requires LINE >=Rad 0Rad
 
     rule <k> Vat . file dust ILKID DUST => . ... </k>
          <vat-live> true </vat-live>
          <vat-ilks> ... ILKID |-> Ilk ( ... dust: (_ => DUST) ) ... </vat-ilks>
-      requires DUST >=Rat 0
+      requires DUST >=Rad 0Rad
 ```
 
 Vat Initialization
@@ -173,23 +173,23 @@ Because data isn't explicitely initialized to 0 in KMCD, we need explicit initia
                          | "initCDP" String Address
  // -----------------------------------------------
     rule <k> Vat . initIlk ILKID => . ... </k>
-         <vat-ilks> ILKS => ILKS [ ILKID <- Ilk ( ... Art: 0 , rate: 1 , spot: 0 , line: 0 , dust: 0 ) ] </vat-ilks>
+         <vat-ilks> ILKS => ILKS [ ILKID <- Ilk ( ... Art: 0Wad , rate: 1Ray , spot: 0Ray , line: 0Rad , dust: 0Rad ) ] </vat-ilks>
       requires notBool ILKID in_keys(ILKS)
 
     rule <k> Vat . initUser ADDR => . ... </k>
          <vat-can> CAN => CAN [ ADDR <- .Set ] </vat-can>
-         <vat-dai> DAI => DAI [ ADDR <- 0    ] </vat-dai>
-         <vat-sin> SIN => SIN [ ADDR <- 0    ] </vat-sin>
+         <vat-dai> DAI => DAI [ ADDR <- 0Rad ] </vat-dai>
+         <vat-sin> SIN => SIN [ ADDR <- 0Rad ] </vat-sin>
       requires notBool ADDR in_keys(CAN)
        andBool notBool ADDR in_keys(DAI)
        andBool notBool ADDR in_keys(SIN)
 
     rule <k> Vat . initGem ILKID ADDR => . ... </k>
-         <vat-gem> GEMS => GEMS [ { ILKID , ADDR } <- 0 ] </vat-gem>
+         <vat-gem> GEMS => GEMS [ { ILKID , ADDR } <- 0Wad ] </vat-gem>
       requires notBool { ILKID , ADDR } in_keys(GEMS)
 
     rule <k> Vat . initCDP ILKID ADDR => . ... </k>
-         <vat-urns> URNS => URNS [ { ILKID , ADDR } <- Urn( ... ink: 0 , art: 0 ) ] </vat-urns>
+         <vat-urns> URNS => URNS [ { ILKID , ADDR } <- Urn( ... ink: 0Wad , art: 0Wad ) ] </vat-urns>
       requires notBool { ILKID , ADDR } in_keys(URNS)
 ```
 
@@ -253,15 +253,15 @@ This is quite permissive, and would allow the account to drain all your locked c
     rule <k> Vat . safe ILKID ADDR => . ... </k>
          <vat-ilks> ...   ILKID          |-> ILK ... </vat-ilks>
          <vat-urns> ... { ILKID , ADDR } |-> URN ... </vat-urns>
-      requires 0 <=Rat urnBalance(ILK, URN)
-       andBool urnDebt(ILK, URN) <=Rat line(ILK)
+      requires 0Rad <=Rad urnBalance(ILK, URN)
+       andBool urnDebt(ILK, URN) <=Rad line(ILK)
 
     syntax VatStep ::= "nondusty" String Address
  // --------------------------------------------
     rule <k> Vat . nondusty ILKID ADDR => . ... </k>
          <vat-ilks> ...   ILKID          |-> ILK ... </vat-ilks>
          <vat-urns> ... { ILKID , ADDR } |-> URN ... </vat-urns>
-      requires dust(ILK) <=Rat urnDebt(ILK, URN) orBool 0 ==Rat urnDebt(ILK, URN)
+      requires dust(ILK) <=Rad urnDebt(ILK, URN) orBool 0Rad ==Rad urnDebt(ILK, URN)
 ```
 
 ### Ilk Initialization (`<vat-ilks>`)
@@ -272,7 +272,7 @@ This is quite permissive, and would allow the account to drain all your locked c
     syntax VatAuthStep ::= "init" String
  // ------------------------------------
     rule <k> Vat . init ILKID => . ... </k>
-         <vat-ilks> ... ILKID |-> Ilk(... rate: 0 => 1) ... </vat-ilks>
+         <vat-ilks> ... ILKID |-> Ilk(... rate: 0Ray => 1Ray) ... </vat-ilks>
 ```
 
 ### Collateral manipulation (`<vat-gem>`)
@@ -289,26 +289,26 @@ This is quite permissive, and would allow the account to drain all your locked c
     syntax VatAuthStep ::= "slip" String Address Wad
  // ------------------------------------------------
     rule <k> Vat . slip ILKID ADDRTO NEWCOL => . ... </k>
-         <vat-gem> ... { ILKID , ADDRTO } |-> ( COL => COL +Rat NEWCOL ) ... </vat-gem>
-      requires NEWCOL >=Rat 0
+         <vat-gem> ... { ILKID , ADDRTO } |-> ( COL => COL +Wad NEWCOL ) ... </vat-gem>
+      requires NEWCOL >=Wad 0Wad
 
     syntax VatStep ::= "flux" String Address Address Wad
  // ----------------------------------------------------
     rule <k> Vat . flux ILKID ADDRFROM ADDRTO COL => . ... </k>
          <vat-gem>
            ...
-           { ILKID , ADDRFROM } |-> ( COLFROM => COLFROM -Rat COL )
-           { ILKID , ADDRTO   } |-> ( COLTO   => COLTO   +Rat COL )
+           { ILKID , ADDRFROM } |-> ( COLFROM => COLFROM -Wad COL )
+           { ILKID , ADDRTO   } |-> ( COLTO   => COLTO   +Wad COL )
            ...
          </vat-gem>
-      requires COL     >=Rat 0
-       andBool COLFROM >=Rat COL
+      requires COL     >=Wad 0Wad
+       andBool COLFROM >=Wad COL
        andBool wish ADDRFROM
 
     rule <k> Vat . flux ILKID ADDRFROM ADDRFROM COL => . ... </k>
          <vat-gem> ... { ILKID , ADDRFROM } |-> COLFROM ... </vat-gem>
-      requires COL     >=Rat 0
-       andBool COLFROM >=Rat COL
+      requires COL     >=Wad 0Wad
+       andBool COLFROM >=Wad COL
        andBool wish ADDRFROM
 ```
 
@@ -322,18 +322,18 @@ This is quite permissive, and would allow the account to drain all your locked c
     rule <k> Vat . move ADDRFROM ADDRTO DAI => . ... </k>
          <vat-dai>
            ...
-           ADDRFROM |-> (DAIFROM => DAIFROM -Rat DAI)
-           ADDRTO   |-> (DAITO   => DAITO   +Rat DAI)
+           ADDRFROM |-> (DAIFROM => DAIFROM -Rad DAI)
+           ADDRTO   |-> (DAITO   => DAITO   +Rad DAI)
            ...
          </vat-dai>
-      requires DAI     >=Rat 0
-       andBool DAIFROM >=Rat DAI
+      requires DAI     >=Rad 0Rad
+       andBool DAIFROM >=Rad DAI
        andBool wish ADDRFROM
 
     rule <k> Vat . move ADDRFROM ADDRFROM DAI => . ... </k>
          <vat-dai> ... ADDRFROM |-> DAIFROM ... </vat-dai>
-      requires DAI     >=Rat 0
-       andBool DAIFROM >=Rat DAI
+      requires DAI     >=Rad 0Rad
+       andBool DAIFROM >=Rad DAI
        andBool wish ADDRFROM
 ```
 
@@ -355,12 +355,12 @@ This is quite permissive, and would allow the account to drain all your locked c
          </k>
          <vat-urns>
            ...
-           { ILKID , ADDRFROM } |-> Urn ( INKFROM => INKFROM -Rat DINK , ARTFROM => ARTFROM -Rat DART )
-           { ILKID , ADDRTO   } |-> Urn ( INKTO   => INKTO   +Rat DINK , ARTTO   => ARTFROM +Rat DART )
+           { ILKID , ADDRFROM } |-> Urn ( INKFROM => INKFROM -Wad DINK , ARTFROM => ARTFROM -Wad DART )
+           { ILKID , ADDRTO   } |-> Urn ( INKTO   => INKTO   +Wad DINK , ARTTO   => ARTFROM +Wad DART )
            ...
          </vat-urns>
-      requires INKFROM >=Rat DINK
-       andBool ARTFROM >=Rat DART
+      requires INKFROM >=Wad DINK
+       andBool ARTFROM >=Wad DART
        andBool wish ADDRFROM
        andBool wish ADDRTO
 
@@ -370,8 +370,8 @@ This is quite permissive, and would allow the account to drain all your locked c
          ...
          </k>
          <vat-urns> ... { ILKID , ADDRFROM } |-> Urn ( INKFROM , ARTFROM ) ... </vat-urns>
-      requires INKFROM >=Rat DINK
-       andBool ARTFROM >=Rat DART
+      requires INKFROM >=Wad DINK
+       andBool ARTFROM >=Wad DART
        andBool wish ADDRFROM
 ```
 
@@ -385,14 +385,14 @@ This is quite permissive, and would allow the account to drain all your locked c
     syntax VatAuthStep ::= "grab" String Address Address Address Wad Wad
  // --------------------------------------------------------------------
     rule <k> Vat . grab ILKID ADDRU ADDRV ADDRW DINK DART => . ... </k>
-         <vat-vice> VICE => VICE -Rat (RATE *Rat DART) </vat-vice>
-         <vat-urns> ... { ILKID , ADDRU } |-> Urn ( INK => INK +Rat DINK , URNART => URNART +Rat DART ) ... </vat-urns>
-         <vat-ilks> ... ILKID |-> Ilk ( ILKART => ILKART +Rat DART , RATE , _ , _ , _ ) ... </vat-ilks>
-         <vat-gem> ... { ILKID , ADDRV } |-> ( ILKV => ILKV -Rat DINK ) ... </vat-gem>
-         <vat-sin> ... ADDRW |-> ( SINW => SINW -Rat (RATE *Rat DART) ) ... </vat-sin>
-      requires ILKV >=Rat DINK
-       andBool SINW >=Rat (RATE *Rat DART)
-       andBool VICE >=Rat (RATE *Rat DART)
+         <vat-vice> VICE => VICE -Rad (DART *Rate RATE) </vat-vice>
+         <vat-urns> ... { ILKID , ADDRU } |-> Urn ( INK => INK +Wad DINK , URNART => URNART +Wad DART ) ... </vat-urns>
+         <vat-ilks> ... ILKID |-> Ilk ( ILKART => ILKART +Wad DART , RATE , _ , _ , _ ) ... </vat-ilks>
+         <vat-gem> ... { ILKID , ADDRV } |-> ( ILKV => ILKV -Wad DINK ) ... </vat-gem>
+         <vat-sin> ... ADDRW |-> ( SINW => SINW -Rad (DART *Rate RATE) ) ... </vat-sin>
+      requires ILKV >=Wad DINK
+       andBool SINW >=Rad (DART *Rate RATE)
+       andBool VICE >=Rad (DART *Rate RATE)
 
     syntax VatStep ::= "frob" String Address Address Address Wad Wad
  // ----------------------------------------------------------------
@@ -400,25 +400,25 @@ This is quite permissive, and would allow the account to drain all your locked c
          ...
          </k>
          <vat-live> true </vat-live>
-         <vat-debt> DEBT => DEBT +Rat (RATE *Rat DART) </vat-debt>
-         <vat-urns> ... { ILKID , ADDRU } |-> Urn ( INK => INK +Rat DINK , URNART => URNART +Rat DART ) ... </vat-urns>
-         <vat-ilks> ... ILKID |-> Ilk (... Art: ILKART => ILKART +Rat DART , rate: RATE , spot: SPOT, line: ILKLINE, dust: DUST ) ... </vat-ilks>
-         <vat-gem> ... { ILKID , ADDRV } |-> ( ILKV => ILKV -Rat DINK ) ... </vat-gem>
-         <vat-dai> ... ADDRW |-> ( DAIW => DAIW +Rat (RATE *Rat DART) ) ... </vat-dai>
+         <vat-debt> DEBT => DEBT +Rad (DART *Rate RATE) </vat-debt>
+         <vat-urns> ... { ILKID , ADDRU } |-> Urn ( INK => INK +Wad DINK , URNART => URNART +Wad DART ) ... </vat-urns>
+         <vat-ilks> ... ILKID |-> Ilk (... Art: ILKART => ILKART +Wad DART , rate: RATE , spot: SPOT, line: ILKLINE, dust: DUST ) ... </vat-ilks>
+         <vat-gem> ... { ILKID , ADDRV } |-> ( ILKV => ILKV -Wad DINK ) ... </vat-gem>
+         <vat-dai> ... ADDRW |-> ( DAIW => DAIW +Rad (DART *Rate RATE) ) ... </vat-dai>
          <vat-Line> LINE </vat-Line>
-      requires ILKV >=Rat DINK
-       andBool ( DART <=Rat 0
-               orBool ((ILKART +Rat DART) *Rat RATE <=Rat ILKLINE andBool DEBT +Rat (RATE *Rat DART) <=Rat LINE)
+      requires ILKV >=Wad DINK
+       andBool ( DART <=Wad 0Wad
+               orBool ((ILKART +Wad DART) *Rate RATE <=Rad ILKLINE andBool DEBT +Rad (DART *Rate RATE) <=Rad LINE)
                     )
-       andBool      ( (DART <=Rat 0 andBool DINK >=Rat 0)
-               orBool (URNART +Rat DART) *Rat RATE <=Rat (INK +Rat DINK) *Rat SPOT
+       andBool      ( (DART <=Wad 0Wad andBool DINK >=Wad 0Wad)
+               orBool (URNART +Wad DART) *Rate RATE <=Rad (INK +Wad DINK) *Rate SPOT
                     )
-       andBool      ( (DART <=Rat 0 andBool DINK >=Rat 0)
+       andBool      ( (DART <=Wad 0Wad andBool DINK >=Wad 0Wad)
                orBool wish ADDRU
                     )
-       andBool (DINK <=Rat 0 orBool wish ADDRV)
-       andBool (DART >=Rat 0 orBool wish ADDRW)
-       andBool (URNART +Rat DART ==Rat 0 orBool (URNART +Rat DART) *Rat RATE >=Rat DUST)
+       andBool (DINK <=Wad 0Wad orBool wish ADDRV)
+       andBool (DART >=Wad 0Wad orBool wish ADDRW)
+       andBool (URNART +Wad DART ==Wad 0Wad orBool (URNART +Wad DART) *Rate RATE >=Rad DUST)
 ```
 
 ### Debt/Dai manipulation (`<vat-debt>`, `<vat-dai>`, `<vat-vice>`, `<vat-sin>`)
@@ -431,24 +431,24 @@ This is quite permissive, and would allow the account to drain all your locked c
  // -----------------------------
     rule <k> Vat . heal AMOUNT => . ... </k>
          <msg-sender> ADDRFROM </msg-sender>
-         <vat-debt> DEBT => DEBT -Rat AMOUNT </vat-debt>
-         <vat-vice> VICE => VICE -Rat AMOUNT </vat-vice>
-         <vat-sin> ... ADDRFROM |-> (SIN => SIN -Rat AMOUNT) ... </vat-sin>
-         <vat-dai> ... ADDRFROM |-> (DAI => DAI -Rat AMOUNT) ... </vat-dai>
-      requires AMOUNT >=Rat 0
-       andBool DEBT >=Rat AMOUNT
-       andBool VICE >=Rat AMOUNT
-       andBool SIN  >=Rat AMOUNT
-       andBool DAI  >=Rat AMOUNT
+         <vat-debt> DEBT => DEBT -Rad AMOUNT </vat-debt>
+         <vat-vice> VICE => VICE -Rad AMOUNT </vat-vice>
+         <vat-sin> ... ADDRFROM |-> (SIN => SIN -Rad AMOUNT) ... </vat-sin>
+         <vat-dai> ... ADDRFROM |-> (DAI => DAI -Rad AMOUNT) ... </vat-dai>
+      requires AMOUNT >=Rad 0Rad
+       andBool DEBT >=Rad AMOUNT
+       andBool VICE >=Rad AMOUNT
+       andBool SIN  >=Rad AMOUNT
+       andBool DAI  >=Rad AMOUNT
 
     syntax VatAuthStep ::= "suck" Address Address Rad
  // -------------------------------------------------
     rule <k> Vat . suck ADDRU ADDRV AMOUNT => . ... </k>
-         <vat-debt> DEBT => DEBT +Rat AMOUNT </vat-debt>
-         <vat-vice> VICE => VICE +Rat AMOUNT </vat-vice>
-         <vat-sin> ... ADDRU |-> (SIN => SIN +Rat AMOUNT) ... </vat-sin>
-         <vat-dai> ... ADDRV |-> (DAI => DAI +Rat AMOUNT) ... </vat-dai>
-      requires AMOUNT >=Rat 0
+         <vat-debt> DEBT => DEBT +Rad AMOUNT </vat-debt>
+         <vat-vice> VICE => VICE +Rad AMOUNT </vat-vice>
+         <vat-sin> ... ADDRU |-> (SIN => SIN +Rad AMOUNT) ... </vat-sin>
+         <vat-dai> ... ADDRV |-> (DAI => DAI +Rad AMOUNT) ... </vat-dai>
+      requires AMOUNT >=Rad 0Rad
 ```
 
 ### CDP Manipulation
@@ -460,9 +460,9 @@ This is quite permissive, and would allow the account to drain all your locked c
  // ------------------------------------------------
     rule <k> Vat . fold ILKID ADDRU RATE => . ... </k>
          <vat-live> true </vat-live>
-         <vat-debt> DEBT => DEBT +Rat (ILKART *Rat RATE) </vat-debt>
-         <vat-ilks> ... ILKID |-> Ilk ( ILKART , ILKRATE => ILKRATE +Rat RATE , _ , _ , _ ) ... </vat-ilks>
-         <vat-dai> ... ADDRU |-> ( DAI => DAI +Rat (ILKART *Rat RATE) ) ... </vat-dai>
+         <vat-debt> DEBT => DEBT +Rad (ILKART *Rate RATE) </vat-debt>
+         <vat-ilks> ... ILKID |-> Ilk ( ILKART , ILKRATE => ILKRATE +Ray RATE , _ , _ , _ ) ... </vat-ilks>
+         <vat-dai> ... ADDRU |-> ( DAI => DAI +Rad (ILKART *Rate RATE) ) ... </vat-dai>
 ```
 
 ```k

--- a/vow.md
+++ b/vow.md
@@ -17,16 +17,16 @@ Vow Configuration
 ```k
     configuration
       <vow>
-        <vow-wards> .Set  </vow-wards>
-        <vow-sins>  .Map  </vow-sins> // mapping (uint256 => uint256) Int |-> Rad
-        <vow-sin>   0:Rad </vow-sin>
-        <vow-ash>   0:Rad </vow-ash>
-        <vow-wait>  0     </vow-wait>
-        <vow-dump>  0:Wad </vow-dump>
-        <vow-sump>  0:Rad </vow-sump>
-        <vow-bump>  0:Rad </vow-bump>
-        <vow-hump>  0:Rad </vow-hump>
-        <vow-live>  true  </vow-live>
+        <vow-wards> .Set </vow-wards>
+        <vow-sins>  .Map </vow-sins> // mapping (uint256 => uint256) Int |-> Rad
+        <vow-sin>   0Rad </vow-sin>
+        <vow-ash>   0Rad </vow-ash>
+        <vow-wait>  0    </vow-wait>
+        <vow-dump>  0Wad </vow-dump>
+        <vow-sump>  0Rad </vow-sump>
+        <vow-bump>  0Rad </vow-bump>
+        <vow-hump>  0Rad </vow-hump>
+        <vow-live>  true </vow-live>
       </vow>
 ```
 
@@ -84,19 +84,19 @@ These praameters are set by governance:
 
     rule <k> Vow . file bump BUMP => . ... </k>
          <vow-bump> _ => BUMP </vow-bump>
-      requires BUMP >=Rat 0
+      requires BUMP >=Rad 0Rad
 
     rule <k> Vow . file hump HUMP => . ... </k>
          <vow-hump> _ => HUMP </vow-hump>
-      requires HUMP >=Rat 0
+      requires HUMP >=Rad 0Rad
 
     rule <k> Vow . file sump SUMP => . ... </k>
          <vow-sump> _ => SUMP </vow-sump>
-      requires SUMP >=Rat 0
+      requires SUMP >=Rad 0Rad
 
     rule <k> Vow . file dump DUMP => . ... </k>
          <vow-dump> _ => DUMP </vow-dump>
-      requires DUMP >=Rat 0
+      requires DUMP >=Wad 0Wad
 ```
 
 Vow Semantics
@@ -107,17 +107,17 @@ Vow Semantics
  // ---------------------------------
     rule <k> Vow . fess TAB => . ... </k>
          <current-time> NOW </current-time>
-         <vow-sins> ... NOW |-> (SIN' => SIN' +Rat TAB) ... </vow-sins>
-         <vow-sin> SIN => SIN +Rat TAB </vow-sin>
-      requires TAB >=Rat 0
+         <vow-sins> ... NOW |-> (SIN' => SIN' +Rad TAB) ... </vow-sins>
+         <vow-sin> SIN => SIN +Rad TAB </vow-sin>
+      requires TAB >=Rad 0Rad
 
     syntax VowStep ::= "flog" Int
  // -----------------------------
     rule <k> Vow . flog ERA => . ... </k>
          <current-time> NOW </current-time>
          <vow-wait> WAIT </vow-wait>
-         <vow-sins> ... ERA |-> (SIN' => 0) ... </vow-sins>
-         <vow-sin> SIN => SIN -Rat SIN' </vow-sin>
+         <vow-sins> ... ERA |-> (SIN' => 0Rad) ... </vow-sins>
+         <vow-sin> SIN => SIN -Rad SIN' </vow-sin>
       requires ERA >=Int 0
        andBool ERA +Int WAIT <=Int NOW
 
@@ -129,19 +129,19 @@ Vow Semantics
          <vat-sin> ... THIS |-> VATSIN ... </vat-sin>
          <vow-sin> SIN </vow-sin>
          <vow-ash> ASH </vow-ash>
-      requires AMOUNT >=Rat 0
-       andBool AMOUNT <=Rat VATDAI
-       andBool AMOUNT <=Rat VATSIN -Rat SIN -Rat ASH
+      requires AMOUNT >=Rad 0Rad
+       andBool AMOUNT <=Rad VATDAI
+       andBool AMOUNT <=Rad (VATSIN -Rad SIN) -Rad ASH
 
     syntax VowStep ::= "kiss" Rad
  // -----------------------------
     rule <k> Vow . kiss AMOUNT => call Vat . heal AMOUNT ... </k>
          <this> THIS </this>
          <vat-dai> ... THIS |-> VATDAI ... </vat-dai>
-         <vow-ash> ASH => ASH -Rat AMOUNT </vow-ash>
-       requires AMOUNT >=Rat 0
-        andBool AMOUNT <=Rat ASH
-        andBool AMOUNT <=Rat VATDAI
+         <vow-ash> ASH => ASH -Rad AMOUNT </vow-ash>
+       requires AMOUNT >=Rad 0Rad
+        andBool AMOUNT <=Rad ASH
+        andBool AMOUNT <=Rad VATDAI
 
     syntax VowStep ::= "flop"
  // -------------------------
@@ -150,15 +150,15 @@ Vow Semantics
          <vat-sin> ... THIS |-> VATSIN ... </vat-sin>
          <vat-dai> ... THIS |-> VATDAI ... </vat-dai>
          <vow-sin> SIN </vow-sin>
-         <vow-ash> ASH => ASH +Rat SUMP </vow-ash>
+         <vow-ash> ASH => ASH +Rad SUMP </vow-ash>
          <vow-sump> SUMP </vow-sump>
          <vow-dump> DUMP </vow-dump>
-      requires SUMP <=Rat VATSIN -Rat SIN -Rat ASH
-       andBool VATDAI ==Int 0
+      requires SUMP <=Rad (VATSIN -Rad SIN) -Rad ASH
+       andBool VATDAI ==Rad 0Rad
 
     syntax VowStep ::= "flap"
  // -------------------------
-    rule <k> Vow . flap => call Flap . kick BUMP 0 ... </k>
+    rule <k> Vow . flap => call Flap . kick BUMP 0Wad ... </k>
          <this> THIS </this>
          <vat-sin> ... THIS |-> VATSIN ... </vat-sin>
          <vat-dai> ... THIS |-> VATDAI ... </vat-dai>
@@ -166,15 +166,15 @@ Vow Semantics
          <vow-ash> ASH </vow-ash>
          <vow-bump> BUMP </vow-bump>
          <vow-hump> HUMP </vow-hump>
-      requires VATDAI >=Rat VATSIN +Rat BUMP +Rat HUMP
-       andBool VATSIN -Rat SIN -Rat ASH ==Rat 0
+      requires VATDAI >=Rad (VATSIN +Rad BUMP) +Rad HUMP
+       andBool (VATSIN -Rad SIN) -Rad ASH ==Rad 0Rad
 
     syntax VowAuthStep ::= "cage"
  // -----------------------------
     rule <k> Vow . cage
           => call Flap . cage FLAPDAI
           ~> call Flop . cage
-          ~> call Vat . heal minRat(VATDAI, VATSIN)
+          ~> call Vat . heal minRad(VATDAI, VATSIN)
          ...
          </k>
          <this> THIS </this>
@@ -186,8 +186,8 @@ Vow Semantics
            ...
          </vat-dai>
          <vow-live> _ => false </vow-live>
-         <vow-sin> _ => 0 </vow-sin>
-         <vow-ash> _ => 0 </vow-ash>
+         <vow-sin> _ => 0Rad </vow-sin>
+         <vow-ash> _ => 0Rad </vow-ash>
       requires THIS =/=K Flap
 ```
 


### PR DESCRIPTION
This is to make it easier to change out the underlying representation of Wad/Rad/Ray in the semantics without having to change every call-site. It will also provide stronger information at each call-site about the sorts of all quantities.