### PR TITLE
Implicit lower bounds on rule inputs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,3 +6,7 @@
     path = deps/k
     url = https://github.com/kframework/k
     ignore = untracked
+[submodule "deps/dss"]
+	path = deps/dss
+	url = https://github.com/makerdao/dss
+	ignore = untracked

--- a/cat.md
+++ b/cat.md
@@ -101,9 +101,11 @@ The parameters controlled by governance are:
 
     rule <k> Cat . file chop ILKID CHOP => . ... </k>
          <cat-ilks> ... ILKID |-> Ilk ( ... chop: (_ => CHOP) ) ... </cat-ilks>
+      requires CHOP >=Rat 0
 
     rule <k> Cat . file lump ILKID LUMP => . ... </k>
          <cat-ilks> ... ILKID |-> Ilk ( ... lump: (_ => LUMP) ) ... </cat-ilks>
+      requires LUMP >=Rat 0
 ```
 
 **NOTE**: `flip` is not fileable since we are assuming a unique liquidator for each ilk.

--- a/dai.md
+++ b/dai.md
@@ -79,7 +79,8 @@ The Dai token is a mintable/burnable ERC20 token.
          <msg-sender> ACCOUNT_SRC </msg-sender>
          <dai-balance> ... ACCOUNT_SRC |-> BALANCE_SRC ... </dai-balance>
          <frame-events> ... (.List => ListItem(Transfer(ACCOUNT_SRC, ACCOUNT_SRC, AMOUNT))) </frame-events>
-      requires BALANCE_SRC >=Rat AMOUNT
+      requires AMOUNT >=Rat 0
+       andBool BALANCE_SRC >=Rat AMOUNT
 
     rule <k> Dai . transfer ACCOUNT_DST AMOUNT => . ... </k>
          <msg-sender> ACCOUNT_SRC </msg-sender>
@@ -90,7 +91,8 @@ The Dai token is a mintable/burnable ERC20 token.
            ...
          </dai-balance>
          <frame-events> ... (.List => ListItem(Transfer(ACCOUNT_SRC, ACCOUNT_DST, AMOUNT))) </frame-events>
-      requires ACCOUNT_SRC =/=K ACCOUNT_DST
+      requires AMOUNT >=Rat 0
+       andBool ACCOUNT_SRC =/=K ACCOUNT_DST
        andBool BALANCE_SRC >=Rat AMOUNT
 
     syntax DaiStep ::= "transferFrom" Address Address Wad
@@ -98,7 +100,8 @@ The Dai token is a mintable/burnable ERC20 token.
     rule <k> Dai . transferFrom ACCOUNT_SRC ACCOUNT_SRC AMOUNT => . ... </k>
          <dai-balance> ... ACCOUNT_SRC |-> BALANCE_SRC ... </dai-balance>
          <frame-events> ... (.List => ListItem(Transfer(ACCOUNT_SRC, ACCOUNT_SRC, AMOUNT))) </frame-events>
-      requires BALANCE_SRC >=Rat AMOUNT
+      requires AMOUNT >=Rat 0
+       andBool BALANCE_SRC >=Rat AMOUNT
 
     rule <k> Dai . transferFrom ACCOUNT_SRC ACCOUNT_DST AMOUNT => . ... </k>
          <dai-allowance> ... { ACCOUNT_SRC -> ACCOUNT_DST } |-> (ALLOWANCE_SRC_DST => ALLOWANCE_SRC_DST -Rat AMOUNT) ... </dai-allowance>
@@ -109,7 +112,8 @@ The Dai token is a mintable/burnable ERC20 token.
            ...
          </dai-balance>
          <frame-events> ... (.List => ListItem(Transfer(ACCOUNT_SRC, ACCOUNT_DST, AMOUNT))) </frame-events>
-      requires ACCOUNT_SRC =/=K ACCOUNT_DST
+      requires AMOUNT >=Rat 0
+       andBool ACCOUNT_SRC =/=K ACCOUNT_DST
        andBool BALANCE_SRC >=Rat AMOUNT
        andBool ALLOWANCE_SRC_DST >=Rat AMOUNT
 
@@ -122,7 +126,8 @@ The Dai token is a mintable/burnable ERC20 token.
            ...
          </dai-balance>
          <frame-events> ... (.List => ListItem(Transfer(ACCOUNT_SRC, ACCOUNT_DST, AMOUNT))) </frame-events>
-      requires ACCOUNT_SRC =/=K ACCOUNT_DST
+      requires AMOUNT >=Rat 0
+       andBool ACCOUNT_SRC =/=K ACCOUNT_DST
        andBool BALANCE_SRC >=Rat AMOUNT
 
     syntax DaiAuthStep ::= "mint" Address Wad
@@ -131,6 +136,7 @@ The Dai token is a mintable/burnable ERC20 token.
          <dai-totalSupply> DAI_SUPPLY => DAI_SUPPLY +Rat AMOUNT </dai-totalSupply>
          <dai-balance> ... ACCOUNT_DST |-> (BALANCE_DST => BALANCE_DST +Rat AMOUNT) ... </dai-balance>
          <frame-events> ... (.List => ListItem(Transfer(0, ACCOUNT_DST, AMOUNT))) </frame-events>
+      requires AMOUNT >=Rat 0
 
     syntax DaiStep ::= "burn" Address Wad
  // -------------------------------------
@@ -138,6 +144,7 @@ The Dai token is a mintable/burnable ERC20 token.
          <dai-totalSupply> DAI_SUPPLY => DAI_SUPPLY -Rat AMOUNT </dai-totalSupply>
          <dai-balance> ... ACCOUNT_SRC |-> (AMOUNT_SRC => AMOUNT_SRC -Rat AMOUNT) ... </dai-balance>
          <frame-events> ... (.List => ListItem(Transfer(ACCOUNT_SRC, 0, AMOUNT))) </frame-events>
+      requires AMOUNT >=Rat 0
 
     syntax DaiStep ::= "approve" Address Wad
  // ----------------------------------------
@@ -145,20 +152,24 @@ The Dai token is a mintable/burnable ERC20 token.
          <msg-sender> ACCOUNT_SRC </msg-sender>
          <dai-allowance> ... { ACCOUNT_SRC -> ACCOUNT_DST } |-> (_ => AMOUNT) ... </dai-allowance>
          <frame-events> ... (.List => ListItem(Approval(ACCOUNT_SRC, ACCOUNT_DST, AMOUNT))) </frame-events>
+      requires AMOUNT >=Rat 0
 
     syntax DaiStep ::= "push" Address Wad
  // -------------------------------------
     rule <k> Dai . push ACCOUNT_DST AMOUNT => Dai . transferFrom ACCOUNT_SRC ACCOUNT_DST AMOUNT ... </k>
          <msg-sender> ACCOUNT_SRC </msg-sender>
+      requires AMOUNT >=Rat 0
 
     syntax DaiStep ::= "pull" Address Wad
  // -------------------------------------
     rule <k> Dai . pull ACCOUNT_SRC AMOUNT => Dai . transferFrom ACCOUNT_SRC ACCOUNT_DST AMOUNT ... </k>
          <msg-sender> ACCOUNT_DST </msg-sender>
+      requires AMOUNT >=Rat 0
 
     syntax DaiStep ::= "move" Address Address Wad
  // ---------------------------------------------
     rule <k> Dai . move ACCOUNT_SRC ACCOUNT_DST AMOUNT => Dai . transferFrom ACCOUNT_SRC ACCOUNT_DST AMOUNT ... </k>
+      requires AMOUNT >=Rat 0
 ```
 
 **TODO**: `permit` logic, seems to be a time-locked allowance.

--- a/end.md
+++ b/end.md
@@ -82,6 +82,7 @@ These parameters are controlled by governance:
     rule <k> End . file wait WAIT => . ... </k>
          <end-live> true </end-live>
          <end-wait> _ => WAIT </end-wait>
+      requires WAIT >=Int 0
 ```
 
 **NOTE**: We have not added `file` steps for `vat`, `cat`, `vow`, `pot`, or `spot` because this model does not deal with swapping out implementations.
@@ -221,7 +222,8 @@ End Semantics
          <msg-sender> MSGSENDER </msg-sender>
          <end-debt> DEBT </end-debt>
          <end-bag> ... MSGSENDER |-> (BAG => BAG +Rat AMOUNT) ... </end-bag>
-      requires DEBT =/=Rat 0
+      requires AMOUNT >=Rat 0
+       andBool DEBT =/=Rat 0
 
     syntax EndStep ::= "cash" String Wad
  // ------------------------------------
@@ -234,7 +236,8 @@ End Semantics
          <end-fix> ... ILK |-> FIX ... </end-fix>
          <end-out> ... {ILK, MSGSENDER} |-> (OUT => OUT +Rat AMOUNT) ... </end-out>
          <end-bag> ... MSGSENDER |-> BAG ... </end-bag>
-      requires FIX =/=Rat 0
+      requires AMOUNT >=Rat 0
+       andBool FIX =/=Rat 0
        andBool OUT +Rat AMOUNT <=Rat BAG
 ```
 

--- a/flap.md
+++ b/flap.md
@@ -89,12 +89,15 @@ The parameters controlled by governance are:
  // -----------------------------
     rule <k> Flap . file beg BEG => . ... </k>
          <flap-beg> _ => BEG </flap-beg>
+      requires BEG >=Rat 0
 
     rule <k> Flap . file ttl TTL => . ... </k>
          <flap-ttl> _ => TTL </flap-ttl>
+      requires TTL >=Int 0
 
     rule <k> Flap . file tau TAU => . ... </k>
          <flap-tau> _ => TAU </flap-tau>
+      requires TAU >=Int 0
 ```
 
 Flap Events
@@ -127,6 +130,8 @@ Flap Semantics
          <flap-live> true </flap-live>
          <flap-tau> TAU </flap-tau>
          <frame-events> ... (.List => ListItem(FlapKick(MSGSENDER, KICKS +Int 1, LOT, BID))) </frame-events>
+      requires LOT >=Rat 0
+       andBool BID >=Rat 0
 ```
 
 - tick(uint id)
@@ -160,7 +165,9 @@ Flap Semantics
          <flap-live> true </flap-live>
          <flap-ttl> TTL </flap-ttl>
          <flap-beg> BEG </flap-beg>
-      requires (TIC >Int NOW orBool TIC ==Int 0)
+      requires LOT >=Rat 0
+       andBool BID >=Rat 0
+       andBool (TIC >Int NOW orBool TIC ==Int 0)
        andBool END  >Int NOW
        andBool LOT ==Rat LOT'
        andBool BID  >Rat BID'
@@ -196,6 +203,7 @@ Flap Semantics
          <msg-sender> MSGSENDER </msg-sender>
          <this> THIS </this>
          <flap-live> _ => false </flap-live>
+      requires RAD >=Rat 0
 ```
 
 - yank(uint id)

--- a/flip.md
+++ b/flip.md
@@ -101,6 +101,7 @@ The parameters controlled by governance are:
            <flip-beg> _ => BEG </flip-beg>
            ...
          </flip>
+      requires BEG >=Rat 0
 
     rule <k> Flip ILKID . file ttl TTL => . ... </k>
          <flip>
@@ -108,6 +109,7 @@ The parameters controlled by governance are:
            <flip-ttl> _ => TTL </flip-ttl>
            ...
          </flip>
+      requires TTL >=Int 0
 
     rule <k> Flip ILKID . file tau TAU => . ... </k>
          <flip>
@@ -115,6 +117,7 @@ The parameters controlled by governance are:
            <flip-tau> _ => TAU </flip-tau>
            ...
          </flip>
+      requires TAU >=Int 0
 ```
 
 Flip Events
@@ -159,6 +162,9 @@ Flip Semantics
            ...
          </flip>
          <frame-events> ... (.List => ListItem(FlipKick(MSGSENDER, ILK, KICKS +Int 1, LOT, BID, TAB, USR, GAL))) </frame-events>
+      requires TAB >=Rat 0
+       andBool LOT >=Rat 0
+       andBool BID >=Rat 0
 
     syntax FlipStep ::= "tick" Int
  // ------------------------------
@@ -189,7 +195,9 @@ Flip Semantics
            <flip-bids> ... ID |-> FlipBid(... bid: BID' => BID, lot: LOT', guy: GUY => MSGSENDER, tic: TIC => NOW +Int TTL, end: END, gal: GAL, tab: TAB) ... </flip-bids>
            ...
          </flip>
-      requires GUY =/=K 0
+      requires LOT >=Rat 0
+       andBool BID >=Rat 0
+       andBool GUY =/=K 0
        andBool (TIC >Int NOW orBool TIC ==Int 0)
        andBool END >Int NOW
        andBool LOT ==Rat LOT'
@@ -214,7 +222,9 @@ Flip Semantics
            <flip-bids> ... ID |-> FlipBid(... bid: BID', lot: LOT' => LOT, guy: GUY => MSGSENDER, tic: TIC => NOW +Int TTL, end: END, usr: USR, tab: TAB) ... </flip-bids>
            ...
          </flip>
-      requires GUY =/=K 0
+      requires LOT >=Rat 0
+       andBool BID >=Rat 0
+       andBool GUY =/=K 0
        andBool (TIC >Int NOW orBool TIC ==Int 0)
        andBool END >Int NOW
        andBool BID ==Rat BID'

--- a/flop.md
+++ b/flop.md
@@ -91,15 +91,19 @@ The parameters controlled by governance are:
  // --------------------------------------
     rule <k> Flop . file beg BEG => . ... </k>
          <flop-beg> _ => BEG </flop-beg>
+      requires BEG >=Rat 0
 
     rule <k> Flop . file ttl TTL => . ... </k>
          <flop-ttl> _ => TTL </flop-ttl>
+      requires TTL >=Int 0
 
     rule <k> Flop . file tau TAU => . ... </k>
          <flop-tau> _ => TAU </flop-tau>
+      requires TAU >=Int 0
 
     rule <k> Flop . file pad PAD => . ... </k>
          <flop-pad> _ => PAD </flop-pad>
+      requires PAD >=Rat 0
 
     rule <k> Flop . file vow-file ADDR => . ... </k>
          <flop-vow> _ => ADDR </flop-vow>
@@ -134,6 +138,8 @@ Flop Semantics
          <flop-kicks> KICKS => KICKS +Int 1 </flop-kicks>
          <flop-tau> TAU </flop-tau>
          <frame-events> ... (.List => ListItem(FlopKick(KICKS +Int 1, LOT, BID, GAL))) </frame-events>
+      requires LOT >=Rat 0
+       andBool BID >=Rat 0
 ```
 
 - tick(uint id)
@@ -166,7 +172,9 @@ Flop Semantics
          <flop-live> true </flop-live>
          <flop-beg> BEG </flop-beg>
          <flop-ttl> TTL </flop-ttl>
-      requires (TIC >Int NOW orBool TIC ==Int 0)
+      requires LOT >=Rat 0
+       andBool BID >=Rat 0
+       andBool (TIC >Int NOW orBool TIC ==Int 0)
        andBool END >Int NOW
        andBool BID ==Rat BID'
        andBool LOT <Rat LOT'

--- a/gem.md
+++ b/gem.md
@@ -69,7 +69,8 @@ Gem Semantics
            </gem-balances>
            ...
          </gem>
-      requires ACCTSRC =/=K ACCTDST
+      requires VALUE >=Rat 0
+       andBool ACCTSRC =/=K ACCTDST
        andBool VALUE >=Rat 0
        andBool BALANCE_SRC >=Rat VALUE
 
@@ -85,21 +86,25 @@ Gem Semantics
     syntax GemStep ::= "move" Address Address Wad
  // ---------------------------------------------
     rule <k> Gem _ . (move ACCTSRC ACCTDST VALUE => transferFrom ACCTSRC ACCTDST VALUE) ... </k>
+      requires VALUE >=Rat 0
 
     syntax GemStep ::= "push" Address Wad
  // -------------------------------------
     rule <k> Gem _ . (push ACCTDST VALUE => transferFrom MSGSENDER ACCTDST VALUE) ... </k>
          <msg-sender> MSGSENDER </msg-sender>
+      requires VALUE >=Rat 0
 
     syntax GemStep ::= "pull" Address Wad
  // -------------------------------------
     rule <k> Gem _ . (pull ACCTSRC VALUE => transferFrom ACCTSRC MSGSENDER VALUE) ... </k>
          <msg-sender> MSGSENDER </msg-sender>
+      requires VALUE >=Rat 0
 
     syntax GemStep ::= "transfer" Address Wad
  // -----------------------------------------
     rule <k> Gem _ . (transfer ACCTDST VALUE => transferFrom MSGSENDER ACCTDST VALUE) ... </k>
          <msg-sender> MSGSENDER </msg-sender>
+      requires VALUE >=Rat 0
 
     syntax GemStep ::= "mint" Address Wad
  // -------------------------------------

--- a/jug.md
+++ b/jug.md
@@ -80,9 +80,11 @@ These parameters are controlled by governance:
          <jug-ilks> ... ILK |-> Ilk ( ... duty: (_ => DUTY) , rho: RHO ) ... </jug-ilks>
          <current-time> NOW </current-time>
       requires NOW ==Int RHO
+       andBool DUTY >=Rat 0
 
     rule <k> Jug . file base BASE => . ... </k>
          <jug-base> _ => BASE </jug-base>
+      requires BASE >=Rat 0
 
     rule <k> Jug . file vow-file ADDR => . ... </k>
          <jug-vow> _ => ADDR </jug-vow>

--- a/pot.md
+++ b/pot.md
@@ -71,6 +71,7 @@ These parameters are controlled by governance:
          <current-time> NOW </current-time>
          <pot-live> true </pot-live>
       requires NOW ==Int RHO
+       andBool DSR >=Rat 0
 
     rule <k> Pot . file vow-file ADDR => . ... </k>
          <pot-vow> _ => ADDR </pot-vow>
@@ -120,7 +121,8 @@ Pot Semantics
          <pot-pie> PIE => PIE +Rat WAD </pot-pie>
          <pot-chi> CHI </pot-chi>
          <pot-rho> RHO </pot-rho>
-      requires NOW ==Int RHO
+      requires WAD >=Rat 0
+       andBool NOW ==Int RHO
 
     syntax PotStep ::= "exit" Wad
  // -----------------------------
@@ -130,7 +132,8 @@ Pot Semantics
          <pot-pies> ... MSGSENDER |-> ( MSGSENDER_PIE => MSGSENDER_PIE -Rat WAD ) ... </pot-pies>
          <pot-pie> PIE => PIE -Rat WAD </pot-pie>
          <pot-chi> CHI </pot-chi>
-      requires MSGSENDER_PIE >=Rat WAD
+      requires WAD >=Rat 0
+       andBool MSGSENDER_PIE >=Rat WAD
 
     syntax PotAuthStep ::= "cage"
  // -----------------------------

--- a/spot.md
+++ b/spot.md
@@ -78,17 +78,24 @@ These parameters are controlled by governance/oracles:
                       | "mat" String Ray
                       | "par" Ray
  // -----------------------------
-    rule <k> Spot . file pip ILKID PIP => . ... </k>
+    rule <k> Spot . file pip ILKID .Wad => . ... </k>
          <spot-live> true </spot-live>
-         <spot-ilks> ... ILKID |-> SpotIlk ( ... pip: (_ => PIP) ) ... </spot-ilks>
+         <spot-ilks> ... ILKID |-> SpotIlk ( ... pip: (_ => .Wad) ) ... </spot-ilks>
+
+    rule <k> Spot . file pip ILKID WAD:Wad => . ... </k>
+         <spot-live> true </spot-live>
+         <spot-ilks> ... ILKID |-> SpotIlk ( ... pip: (_ => WAD) ) ... </spot-ilks>
+      requires WAD >=Rat 0
 
     rule <k> Spot . file mat ILKID MAT => . ... </k>
          <spot-live> true </spot-live>
          <spot-ilks> ... ILKID |-> SpotIlk ( ... mat: (_ => MAT) ) ... </spot-ilks>
+      requires MAT >=Rat 0
 
     rule <k> Spot . file par PAR => . ... </k>
          <spot-live> true </spot-live>
          <spot-par> _ => PAR </spot-par>
+      requires PAR >=Rat 0
 ```
 
 **TODO**: We currently store a `MaybeWad` for `pip` instead of a contract address to call to get that data.

--- a/vat.md
+++ b/vat.md
@@ -138,18 +138,22 @@ The parameters controlled by governance are:
     rule <k> Vat . file Line LINE => . ... </k>
          <vat-live> true </vat-live>
          <vat-Line> _ => LINE </vat-Line>
+      requires LINE >=Rat 0
 
     rule <k> Vat . file spot ILKID SPOT => . ... </k>
          <vat-live> true </vat-live>
          <vat-ilks> ... ILKID |-> Ilk ( ... spot: (_ => SPOT) ) ... </vat-ilks>
+      requires SPOT >=Rat 0
 
     rule <k> Vat . file line ILKID LINE => . ... </k>
          <vat-live> true </vat-live>
          <vat-ilks> ... ILKID |-> Ilk ( ... line: (_ => LINE) ) ... </vat-ilks>
+      requires LINE >=Rat 0
 
     rule <k> Vat . file dust ILKID DUST => . ... </k>
          <vat-live> true </vat-live>
          <vat-ilks> ... ILKID |-> Ilk ( ... dust: (_ => DUST) ) ... </vat-ilks>
+      requires DUST >=Rat 0
 ```
 
 Vat Initialization
@@ -286,6 +290,7 @@ This is quite permissive, and would allow the account to drain all your locked c
  // ------------------------------------------------
     rule <k> Vat . slip ILKID ADDRTO NEWCOL => . ... </k>
          <vat-gem> ... { ILKID , ADDRTO } |-> ( COL => COL +Rat NEWCOL ) ... </vat-gem>
+      requires NEWCOL >=Rat 0
 
     syntax VatStep ::= "flux" String Address Address Wad
  // ----------------------------------------------------


### PR DESCRIPTION
Many places in the solidity use `uint ...`, which is an implicit positivity constraint on the inputs to the functions.

This adds those constraints to the model.

This also adds `dss` repo as a submodule for convenience of conformance testing. This means that this submodule needs to be updated periodically and any updates to the model added in.