### PR TITLE
Wrapped rat representation for `Wad/Ray/Rad`

### DIFF
--- a/cat.md
+++ b/cat.md
@@ -124,7 +124,7 @@ Cat Semantics
           => #fun(TAB
           => call Vat . grab ILK URN THIS VOWADDR (0Wad -Wad LOT) (0Wad -Wad ART)
           ~> call Vow . fess TAB
-          ~> call Flip ILK . kick URN VOWADDR rmulRad(TAB, CHOP) LOT 0Rad
+          ~> call Flip ILK . kick URN VOWADDR rmul(TAB, CHOP) LOT 0Rad
           ~> emitBite ILK URN LOT ART TAB)
           (ART *Rate RATE))
           (minWad(URNART, (LOT *Wad URNART) /Wad INK)))

--- a/end.md
+++ b/end.md
@@ -167,12 +167,12 @@ End Semantics
     syntax EndStep ::= "skim" String Address
  // ----------------------------------------
     rule <k> End . skim ILK ADDR
-          => call Vat . grab ILK ADDR THIS Vow (0Wad -Wad minWad(INK, rmulWad(rmulWad(ART, RATE), TAG))) (0Wad -Wad ART)
+          => call Vat . grab ILK ADDR THIS Vow (0Wad -Wad minWad(INK, rmul(rmul(ART, RATE), TAG))) (0Wad -Wad ART)
          ...
          </k>
          <this> THIS </this>
          <end-tag> ... ILK |-> TAG ... </end-tag>
-         <end-gap> ... ILK |-> (GAP => GAP +Wad (rmulWad(rmulWad(ART, RATE), TAG) -Wad minWad(INK, rmulWad(rmulWad(ART, RATE), TAG)))) ... </end-gap>
+         <end-gap> ... ILK |-> (GAP => GAP +Wad (rmul(rmul(ART, RATE), TAG) -Wad minWad(INK, rmul(rmul(ART, RATE), TAG)))) ... </end-gap>
          <vat-ilks> ... ILK |-> Ilk(... rate: RATE)::VatIlk ... </vat-ilks>
          <vat-urns> ... {ILK, ADDR} |-> Urn(... ink: INK, art: ART) ... </vat-urns>
       requires TAG =/=Ray 0Ray
@@ -204,13 +204,13 @@ End Semantics
  // --------------------------------
     rule <k> End . flow ILK => . ... </k>
          <end-debt> DEBT </end-debt>
-         <end-fix> FIX => FIX [ ILK <- rdiv(Wad2Ray(rmulWad(rmulWad(ART, RATE), TAG) -Wad GAP), DEBT) ] </end-fix>
+         <end-fix> FIX => FIX [ ILK <- rdiv(Wad2Ray(rmul(rmul(ART, RATE), TAG) -Wad GAP), DEBT) ] </end-fix>
          <end-tag> ... ILK |-> TAG ... </end-tag>
          <end-gap> ... ILK |-> GAP ... </end-gap>
          <end-art> ... ILK |-> ART ... </end-art>
          <vat-ilks> ... ILK |-> Ilk(... rate: RATE)::VatIlk ... </vat-ilks>
       requires DEBT =/=Rad 0Rad
-       andBool rmulWad(rmulWad(ART, RATE), TAG) >=Wad GAP
+       andBool rmul(rmul(ART, RATE), TAG) >=Wad GAP
        andBool notBool ILK in_keys(FIX)
 
     syntax EndStep ::= "pack" Wad
@@ -228,7 +228,7 @@ End Semantics
     syntax EndStep ::= "cash" String Wad
  // ------------------------------------
     rule <k> End . cash ILK AMOUNT
-          => call Vat . flux ILK THIS MSGSENDER rmulWad(AMOUNT, FIX)
+          => call Vat . flux ILK THIS MSGSENDER rmul(AMOUNT, FIX)
          ...
          </k>
          <msg-sender> MSGSENDER </msg-sender>

--- a/flap.md
+++ b/flap.md
@@ -15,13 +15,13 @@ Flap Configuration
 ```k
     configuration
       <flap-state>
-        <flap-wards> .Set                   </flap-wards>
-        <flap-bids>  .Map                   </flap-bids>  // mapping (uint => Bid) Int |-> FlapBid
-        <flap-kicks> 0                      </flap-kicks>
-        <flap-live>  true                   </flap-live>
-        <flap-beg>   wad(105) /Wad wad(100) </flap-beg>
-        <flap-ttl>   3 hours                </flap-ttl>
-        <flap-tau>   2 days                 </flap-tau>
+        <flap-wards> .Set              </flap-wards>
+        <flap-bids>  .Map              </flap-bids>  // mapping (uint => Bid) Int |-> FlapBid
+        <flap-kicks> 0                 </flap-kicks>
+        <flap-live>  true              </flap-live>
+        <flap-beg>   wad(105 /Rat 100) </flap-beg>
+        <flap-ttl>   3 hours           </flap-ttl>
+        <flap-tau>   2 days            </flap-tau>
       </flap-state>
 ```
 

--- a/flap.md
+++ b/flap.md
@@ -15,13 +15,13 @@ Flap Configuration
 ```k
     configuration
       <flap-state>
-        <flap-wards> .Set         </flap-wards>
-        <flap-bids>  .Map         </flap-bids>  // mapping (uint => Bid) Int |-> FlapBid
-        <flap-kicks> 0            </flap-kicks>
-        <flap-live>  true         </flap-live>
-        <flap-beg>   105 /Wad 100 </flap-beg>
-        <flap-ttl>   3 hours      </flap-ttl>
-        <flap-tau>   2 days       </flap-tau>
+        <flap-wards> .Set                   </flap-wards>
+        <flap-bids>  .Map                   </flap-bids>  // mapping (uint => Bid) Int |-> FlapBid
+        <flap-kicks> 0                      </flap-kicks>
+        <flap-live>  true                   </flap-live>
+        <flap-beg>   wad(105) /Wad wad(100) </flap-beg>
+        <flap-ttl>   3 hours                </flap-ttl>
+        <flap-tau>   2 days                 </flap-tau>
       </flap-state>
 ```
 

--- a/flip.md
+++ b/flip.md
@@ -14,13 +14,13 @@ Flip Configuration
     configuration
       <flips>
         <flip multiplicity="*" type="Map">
-          <flip-ilk>   ""           </flip-ilk>
-          <flip-wards> .Set         </flip-wards>
-          <flip-bids>  .Map         </flip-bids> // mapping (uint => Bid) Int |-> FlipBid
-          <flip-beg>   105 /Wad 100 </flip-beg>  // Minimum Bid Increase
-          <flip-ttl>   3 hours      </flip-ttl>  // Single Bid Lifetime
-          <flip-tau>   2 days       </flip-tau>  // Total Auction Length
-          <flip-kicks> 0            </flip-kicks>
+          <flip-ilk>   ""                     </flip-ilk>
+          <flip-wards> .Set                   </flip-wards>
+          <flip-bids>  .Map                   </flip-bids> // mapping (uint => Bid) Int |-> FlipBid
+          <flip-beg>   wad(105) /Wad wad(100) </flip-beg>  // Minimum Bid Increase
+          <flip-ttl>   3 hours                </flip-ttl>  // Single Bid Lifetime
+          <flip-tau>   2 days                 </flip-tau>  // Total Auction Length
+          <flip-kicks> 0                      </flip-kicks>
         </flip>
       </flips>
 ```

--- a/flip.md
+++ b/flip.md
@@ -14,13 +14,13 @@ Flip Configuration
     configuration
       <flips>
         <flip multiplicity="*" type="Map">
-          <flip-ilk>   ""                     </flip-ilk>
-          <flip-wards> .Set                   </flip-wards>
-          <flip-bids>  .Map                   </flip-bids> // mapping (uint => Bid) Int |-> FlipBid
-          <flip-beg>   wad(105) /Wad wad(100) </flip-beg>  // Minimum Bid Increase
-          <flip-ttl>   3 hours                </flip-ttl>  // Single Bid Lifetime
-          <flip-tau>   2 days                 </flip-tau>  // Total Auction Length
-          <flip-kicks> 0                      </flip-kicks>
+          <flip-ilk>   ""                </flip-ilk>
+          <flip-wards> .Set              </flip-wards>
+          <flip-bids>  .Map              </flip-bids> // mapping (uint => Bid) Int |-> FlipBid
+          <flip-beg>   wad(105 /Rat 100) </flip-beg>  // Minimum Bid Increase
+          <flip-ttl>   3 hours           </flip-ttl>  // Single Bid Lifetime
+          <flip-tau>   2 days            </flip-tau>  // Total Auction Length
+          <flip-kicks> 0                 </flip-kicks>
         </flip>
       </flips>
 ```

--- a/flop.md
+++ b/flop.md
@@ -15,15 +15,15 @@ Flop Configuration
 ```k
     configuration
       <flop-state>
-        <flop-wards> .Set                    </flop-wards>
-        <flop-bids>  .Map                    </flop-bids>  // mapping (uint => Bid) Int |-> FlopBid
-        <flop-kicks>  0                      </flop-kicks>
-        <flop-live>   true                   </flop-live>
-        <flop-beg>    wad(105) /Wad wad(100) </flop-beg>
-        <flop-pad>    wad(150) /Wad wad(100) </flop-pad>
-        <flop-ttl>    3 hours                </flop-ttl>
-        <flop-tau>    2 days                 </flop-tau>
-        <flop-vow>    0:Address              </flop-vow>
+        <flop-wards> .Set               </flop-wards>
+        <flop-bids>  .Map               </flop-bids>  // mapping (uint => Bid) Int |-> FlopBid
+        <flop-kicks>  0                 </flop-kicks>
+        <flop-live>   true              </flop-live>
+        <flop-beg>    wad(105 /Rat 100) </flop-beg>
+        <flop-pad>    wad(150 /Rat 100) </flop-pad>
+        <flop-ttl>    3 hours           </flop-ttl>
+        <flop-tau>    2 days            </flop-tau>
+        <flop-vow>    0:Address         </flop-vow>
       </flop-state>
 ```
 

--- a/flop.md
+++ b/flop.md
@@ -15,15 +15,15 @@ Flop Configuration
 ```k
     configuration
       <flop-state>
-        <flop-wards> .Set          </flop-wards>
-        <flop-bids>  .Map          </flop-bids>  // mapping (uint => Bid) Int |-> FlopBid
-        <flop-kicks>  0            </flop-kicks>
-        <flop-live>   true         </flop-live>
-        <flop-beg>    105 /Wad 100 </flop-beg>
-        <flop-pad>    150 /Wad 100 </flop-pad>
-        <flop-ttl>    3 hours      </flop-ttl>
-        <flop-tau>    2 days       </flop-tau>
-        <flop-vow>    0:Address    </flop-vow>
+        <flop-wards> .Set                    </flop-wards>
+        <flop-bids>  .Map                    </flop-bids>  // mapping (uint => Bid) Int |-> FlopBid
+        <flop-kicks>  0                      </flop-kicks>
+        <flop-live>   true                   </flop-live>
+        <flop-beg>    wad(105) /Wad wad(100) </flop-beg>
+        <flop-pad>    wad(150) /Wad wad(100) </flop-pad>
+        <flop-ttl>    3 hours                </flop-ttl>
+        <flop-tau>    2 days                 </flop-tau>
+        <flop-vow>    0:Address              </flop-vow>
       </flop-state>
 ```
 

--- a/kmcd-data.md
+++ b/kmcd-data.md
@@ -184,13 +184,13 @@ We model everything with arbitrary precision rationals, but use sort information
  // -----------------------------------------
     rule rad(R1) /Rate ray(R2) => wad(R1 /Rat R2)
 
-    syntax Wad ::= rmulWad ( Wad , Ray ) [function]
- // -----------------------------------------------
-    rule rmulWad(wad(R1), ray(R2)) => wad(R1 *Rat R2)
+    syntax Wad ::= rmul ( Wad , Ray ) [function]
+ // --------------------------------------------
+    rule rmul(wad(R1), ray(R2)) => wad(R1 *Rat R2)
 
-    syntax Rad ::= rmulRad ( Rad , Ray ) [function]
- // -----------------------------------------------
-    rule rmulRad(rad(R1), ray(R2)) => rad(R1 *Rat R2)
+    syntax Rad ::= rmul ( Rad , Ray ) [function]
+ // --------------------------------------------
+    rule rmul(rad(R1), ray(R2)) => rad(R1 *Rat R2)
 
     syntax Ray ::= rdiv ( Ray , Rad ) [function]
  // --------------------------------------------

--- a/kmcd-data.md
+++ b/kmcd-data.md
@@ -54,13 +54,17 @@ We model everything with arbitrary precision rationals, but use sort information
 ```
 
 ```k
-    syntax Ray ::= Wad2Ray ( Wad ) [function]
+    syntax Wad ::= Rad2Wad ( Rad ) [function]
+                 | Ray2Wad ( Ray ) [function]
  // -----------------------------------------
-    rule Wad2Ray(W) => W
+    rule Ray2Wad(ray(R)) => wad(R)
+    rule Rad2Wad(rad(R)) => wad(R)
 
     syntax Ray ::= Wad2Ray ( Wad ) [function]
+                 | Rad2Ray ( Rad ) [function]
  // -----------------------------------------
     rule Wad2Ray(wad(W)) => ray(W)
+    rule Rad2Ray(rad(R)) => ray(R)
 
     syntax Rad ::= Wad2Rad ( Wad ) [function]
                  | Ray2Rad ( Ray ) [function]

--- a/kmcd-data.md
+++ b/kmcd-data.md
@@ -23,20 +23,14 @@ We model everything with arbitrary precision rationals, but use sort information
 -   `Rad`: result of multiplying `Wad` and `Ray` (highest precision). Represented in implementation as 1e45 fixed point.
 
 ```k
-    syntax Wad = Rat
     syntax Wad ::= wad ( Rat )
  // --------------------------
-    rule wad(R) => R [macro]
 
-    syntax Ray = Rat
     syntax Ray ::= ray ( Rat )
  // --------------------------
-    rule ray(R) => R [macro]
 
-    syntax Rad = Rat
     syntax Rad ::= rad ( Rat )
  // --------------------------
-    rule rad(R) => R [macro]
 
     syntax MaybeWad ::= Wad | ".Wad"
  // --------------------------------
@@ -45,18 +39,18 @@ We model everything with arbitrary precision rationals, but use sort information
 ```k
     syntax Wad ::= "0Wad" | "1Wad"
  // ------------------------------
-    rule 0Wad => 0 [macro]
-    rule 1Wad => 1 [macro]
+    rule 0Wad => wad(0) [macro]
+    rule 1Wad => wad(1) [macro]
 
     syntax Ray ::= "0Ray" | "1Ray"
  // ------------------------------
-    rule 0Ray => 0 [macro]
-    rule 1Ray => 1 [macro]
+    rule 0Ray => ray(0) [macro]
+    rule 1Ray => ray(1) [macro]
 
     syntax Rad ::= "0Rad" | "1Rad"
  // ------------------------------
-    rule 0Rad => 0 [macro]
-    rule 1Rad => 1 [macro]
+    rule 0Rad => rad(0) [macro]
+    rule 1Rad => rad(1) [macro]
 ```
 
 ```k
@@ -64,11 +58,15 @@ We model everything with arbitrary precision rationals, but use sort information
  // -----------------------------------------
     rule Wad2Ray(W) => W
 
+    syntax Ray ::= Wad2Ray ( Wad ) [function]
+ // -----------------------------------------
+    rule Wad2Ray(wad(W)) => ray(W)
+
     syntax Rad ::= Wad2Rad ( Wad ) [function]
                  | Ray2Rad ( Ray ) [function]
  // -----------------------------------------
-    rule Wad2Rad(W) => W
-    rule Ray2Rad(R) => R
+    rule Wad2Rad(wad(W)) => rad(W)
+    rule Ray2Rad(ray(R)) => rad(R)
 ```
 
 ```k
@@ -78,11 +76,11 @@ We model everything with arbitrary precision rationals, but use sort information
                  > Wad "+Wad" Wad [function]
                  | Wad "-Wad" Wad [function]
  // ----------------------------------------
-    rule R1 *Wad R2 => R1 *Rat R2
-    rule R1 /Wad R2 => R1 /Rat R2
-    rule R1 ^Wad R2 => R1 ^Rat R2
-    rule R1 +Wad R2 => R1 +Rat R2
-    rule R1 -Wad R2 => R1 -Rat R2
+    rule wad(R1) *Wad wad(R2) => wad(R1 *Rat R2)
+    rule wad(R1) /Wad wad(R2) => wad(R1 /Rat R2)
+    rule wad(R1) ^Wad I       => wad(R1 ^Rat I)
+    rule wad(R1) +Wad wad(R2) => wad(R1 +Rat R2)
+    rule wad(R1) -Wad wad(R2) => wad(R1 -Rat R2)
 
     syntax Ray ::= Ray "*Ray" Ray [function]
                  | Ray "/Ray" Ray [function]
@@ -90,11 +88,11 @@ We model everything with arbitrary precision rationals, but use sort information
                  > Ray "+Ray" Ray [function]
                  | Ray "-Ray" Ray [function]
  // ----------------------------------------
-    rule R1 *Ray R2 => R1 *Rat R2
-    rule R1 /Ray R2 => R1 /Rat R2
-    rule R1 ^Ray R2 => R1 ^Rat R2
-    rule R1 +Ray R2 => R1 +Rat R2
-    rule R1 -Ray R2 => R1 -Rat R2
+    rule ray(R1) *Ray ray(R2) => ray(R1 *Rat R2)
+    rule ray(R1) /Ray ray(R2) => ray(R1 /Rat R2)
+    rule ray(R1) ^Ray I       => ray(R1 ^Rat I)
+    rule ray(R1) +Ray ray(R2) => ray(R1 +Rat R2)
+    rule ray(R1) -Ray ray(R2) => ray(R1 -Rat R2)
 
     syntax Rad ::= Rad "*Rad" Rad [function]
                  | Rad "/Rad" Rad [function]
@@ -102,31 +100,31 @@ We model everything with arbitrary precision rationals, but use sort information
                  > Rad "+Rad" Rad [function]
                  | Rad "-Rad" Rad [function]
  // ----------------------------------------
-    rule R1 *Rad R2 => R1 *Rat R2
-    rule R1 /Rad R2 => R1 /Rat R2
-    rule R1 ^Rad R2 => R1 ^Rat R2
-    rule R1 +Rad R2 => R1 +Rat R2
-    rule R1 -Rad R2 => R1 -Rat R2
+    rule rad(R1) *Rad rad(R2) => rad(R1 *Rat R2)
+    rule rad(R1) /Rad rad(R2) => rad(R1 /Rat R2)
+    rule rad(R1) ^Rad I       => rad(R1 ^Rat I)
+    rule rad(R1) +Rad rad(R2) => rad(R1 +Rat R2)
+    rule rad(R1) -Rad rad(R2) => rad(R1 -Rat R2)
 ```
 
 ```k
     syntax Wad ::= minWad ( Wad , Wad ) [function]
                  | maxWad ( Wad , Wad ) [function]
  // ----------------------------------------------
-    rule minWad(W1, W2) => minRat(W1, W2)
-    rule maxWad(W1, W2) => maxRat(W1, W2)
+    rule minWad(wad(W1), wad(W2)) => wad(minRat(W1, W2))
+    rule maxWad(wad(W1), wad(W2)) => wad(maxRat(W1, W2))
 
     syntax Ray ::= minRay ( Ray , Ray ) [function]
                  | maxRay ( Ray , Ray ) [function]
  // ----------------------------------------------
-    rule minRay(W1, W2) => minRat(W1, W2)
-    rule maxRay(W1, W2) => maxRat(W1, W2)
+    rule minRay(ray(W1), ray(W2)) => ray(minRat(W1, W2))
+    rule maxRay(ray(W1), ray(W2)) => ray(maxRat(W1, W2))
 
     syntax Rad ::= minRad ( Rad , Rad ) [function]
                  | maxRad ( Rad , Rad ) [function]
  // ----------------------------------------------
-    rule minRad(W1, W2) => minRat(W1, W2)
-    rule maxRad(W1, W2) => maxRat(W1, W2)
+    rule minRad(rad(W1), rad(W2)) => rad(minRat(W1, W2))
+    rule maxRad(rad(W1), rad(W2)) => rad(maxRat(W1, W2))
 ```
 
 ```k
@@ -137,12 +135,12 @@ We model everything with arbitrary precision rationals, but use sort information
                   | Wad  "==Wad" Wad [function]
                   | Wad "=/=Wad" Wad [function]
  // -------------------------------------------
-    rule W1  <=Wad W2 => W1  <=Rat W2
-    rule W1   <Wad W2 => W1   <Rat W2
-    rule W1  >=Wad W2 => W1  >=Rat W2
-    rule W1   >Wad W2 => W1   >Rat W2
-    rule W1  ==Wad W2 => W1  ==Rat W2
-    rule W1 =/=Wad W2 => W1 =/=Rat W2
+    rule wad(W1)  <=Wad wad(W2) => W1  <=Rat W2
+    rule wad(W1)   <Wad wad(W2) => W1   <Rat W2
+    rule wad(W1)  >=Wad wad(W2) => W1  >=Rat W2
+    rule wad(W1)   >Wad wad(W2) => W1   >Rat W2
+    rule wad(W1)  ==Wad wad(W2) => W1  ==Rat W2
+    rule wad(W1) =/=Wad wad(W2) => W1 =/=Rat W2
 
     syntax Bool ::= Ray  "<=Ray" Ray [function]
                   | Ray   "<Ray" Ray [function]
@@ -151,12 +149,12 @@ We model everything with arbitrary precision rationals, but use sort information
                   | Ray  "==Ray" Ray [function]
                   | Ray "=/=Ray" Ray [function]
  // -------------------------------------------
-    rule W1  <=Ray W2 => W1  <=Rat W2
-    rule W1   <Ray W2 => W1   <Rat W2
-    rule W1  >=Ray W2 => W1  >=Rat W2
-    rule W1   >Ray W2 => W1   >Rat W2
-    rule W1  ==Ray W2 => W1  ==Rat W2
-    rule W1 =/=Ray W2 => W1 =/=Rat W2
+    rule ray(W1)  <=Ray ray(W2) => W1  <=Rat W2
+    rule ray(W1)   <Ray ray(W2) => W1   <Rat W2
+    rule ray(W1)  >=Ray ray(W2) => W1  >=Rat W2
+    rule ray(W1)   >Ray ray(W2) => W1   >Rat W2
+    rule ray(W1)  ==Ray ray(W2) => W1  ==Rat W2
+    rule ray(W1) =/=Ray ray(W2) => W1 =/=Rat W2
 
     syntax Bool ::= Rad  "<=Rad" Rad [function]
                   | Rad   "<Rad" Rad [function]
@@ -165,38 +163,38 @@ We model everything with arbitrary precision rationals, but use sort information
                   | Rad  "==Rad" Rad [function]
                   | Rad "=/=Rad" Rad [function]
  // -------------------------------------------
-    rule W1  <=Rad W2 => W1  <=Rat W2
-    rule W1   <Rad W2 => W1   <Rat W2
-    rule W1  >=Rad W2 => W1  >=Rat W2
-    rule W1   >Rad W2 => W1   >Rat W2
-    rule W1  ==Rad W2 => W1  ==Rat W2
-    rule W1 =/=Rad W2 => W1 =/=Rat W2
+    rule rad(W1)  <=Rad rad(W2) => W1  <=Rat W2
+    rule rad(W1)   <Rad rad(W2) => W1   <Rat W2
+    rule rad(W1)  >=Rad rad(W2) => W1  >=Rat W2
+    rule rad(W1)   >Rad rad(W2) => W1   >Rat W2
+    rule rad(W1)  ==Rad rad(W2) => W1  ==Rat W2
+    rule rad(W1) =/=Rad rad(W2) => W1 =/=Rat W2
 ```
 
 ```k
     syntax Rad ::= Wad "*Rate" Ray [function]
  // -----------------------------------------
-    rule R1 *Rate R2 => R1 *Rat R2
+    rule wad(R1) *Rate ray(R2) => rad(R1 *Rat R2)
 
     syntax Wad ::= Rad "/Rate" Ray [function]
  // -----------------------------------------
-    rule R1 /Rate R2 => R1 /Rat R2
+    rule rad(R1) /Rate ray(R2) => wad(R1 /Rat R2)
 
     syntax Wad ::= rmulWad ( Wad , Ray ) [function]
  // -----------------------------------------------
-    rule rmulWad(R1, R2) => R1 *Rat R2
+    rule rmulWad(wad(R1), ray(R2)) => wad(R1 *Rat R2)
 
     syntax Rad ::= rmulRad ( Rad , Ray ) [function]
  // -----------------------------------------------
-    rule rmulRad(R1, R2) => R1 *Rat R2
+    rule rmulRad(rad(R1), ray(R2)) => rad(R1 *Rat R2)
 
     syntax Ray ::= rdiv ( Ray , Rad ) [function]
  // --------------------------------------------
-    rule rdiv(R1, R2) => R1 /Rat R2
+    rule rdiv(ray(R1), rad(R2)) => ray(R1 /Rat R2)
 
     syntax Ray ::= wdiv ( Ray , Wad ) [function]
  // --------------------------------------------
-    rule wdiv(R1, R2) => R1 /Rat R2
+    rule wdiv(ray(R1), wad(R2)) => ray(R1 /Rat R2)
 ```
 
 Time Increments
@@ -278,15 +276,15 @@ module KMCD-RANDOM-CHOICES
 
     syntax Wad ::= randWadBounded ( Int , Wad ) [function]
  // ------------------------------------------------------
-    rule randWadBounded(I, W) => randRatBounded(I, W)
+    rule randWadBounded(I, wad(W)) => wad(randRatBounded(I, W))
 
     syntax Ray ::= randRayBounded ( Int , Ray ) [function]
  // ------------------------------------------------------
-    rule randRayBounded(I, R) => randRatBounded(I, R)
+    rule randRayBounded(I, ray(R)) => ray(randRatBounded(I, R))
 
     syntax Rad ::= randRadBounded ( Int , Rad ) [function]
  // ------------------------------------------------------
-    rule randRadBounded(I, R) => randRatBounded(I, R)
+    rule randRadBounded(I, rad(R)) => rad(randRatBounded(I, R))
 ```
 
 ```k

--- a/kmcd-prelude.md
+++ b/kmcd-prelude.md
@@ -638,7 +638,7 @@ module KMCD-GEN
       requires lengthBytes(BS) >Int 0
        andBool size(END_BAGS) >Int 0
 
-    rule <k> GenEndPack ADDRESS => LogGen ( transact ADDRESS End . pack randIntBounded(head(BS), VAT_DAI) ) ... </k>
+    rule <k> GenEndPack ADDRESS => LogGen ( transact ADDRESS End . pack randWadBounded(head(BS), Rad2Wad(VAT_DAI)) ) ... </k>
          <random> BS => tail(BS) </random>
          <used-random> BS' => BS' +Bytes headAsBytes(BS) </used-random>
          <vat-dai> ... ADDRESS |-> VAT_DAI ... </vat-dai>

--- a/kmcd-props.md
+++ b/kmcd-props.md
@@ -285,7 +285,7 @@ The Debt growth should be bounded in principle by the interest rates available i
     rule derive(totalDebtBounded(... dsr: DSR), Measure(... debt: DEBT)) => totalDebtBoundedRun(... debt: DEBT, dsr: DSR)
 
     rule derive( totalDebtBoundedRun(... debt: DEBT, dsr: _  ) #as PREV , Measure(... debt: DEBT')            ) => Violated(PREV) requires DEBT' >Rad DEBT
-    rule derive( totalDebtBoundedRun(... debt: DEBT, dsr: DSR)          , TimeStep(TIME, _)                   ) => totalDebtBoundedRun(... debt: DEBT +Rad rmulRad(vatDaiForUser(Pot), (DSR ^Ray TIME) -Ray 1Ray), dsr: DSR)
+    rule derive( totalDebtBoundedRun(... debt: DEBT, dsr: DSR)          , TimeStep(TIME, _)                   ) => totalDebtBoundedRun(... debt: DEBT +Rad rmul(vatDaiForUser(Pot), (DSR ^Ray TIME) -Ray 1Ray), dsr: DSR)
     rule derive( totalDebtBoundedRun(... debt: DEBT, dsr: DSR)          , LogNote(_ , Vat . frob _ _ _ _ _ _) ) => totalDebtBounded(... dsr: DSR)
     rule derive( totalDebtBoundedRun(... debt: DEBT, dsr: DSR)          , LogNote(_ , Vat . suck _ _ AMOUNT)  ) => totalDebtBoundedRun(... debt: DEBT +Rad AMOUNT, dsr: DSR)
     rule derive( totalDebtBoundedRun(... debt: DEBT, dsr: DSR)          , LogNote(_ , Pot . file dsr DSR')    ) => totalDebtBoundedRun(... debt: DEBT, dsr: DSR')

--- a/tests/attacks/blocked-flop.mcd.expected
+++ b/tests/attacks/blocked-flop.mcd.expected
@@ -41,7 +41,7 @@
                 .Set
               </dai-wards>
               <dai-totalSupply>
-                0
+                wad ( 0 )
               </dai-totalSupply>
               <dai-account-id>
                 0
@@ -74,13 +74,13 @@
                   0
                 </end-wait>
                 <end-debt>
-                  0
+                  rad ( 0 )
                 </end-debt>
                 <end-tag>
                   .Map
                 </end-tag>
                 <end-gap>
-                  "gold" |-> 0
+                  "gold" |-> wad ( 0 )
                 </end-gap>
                 <end-art>
                   .Map
@@ -89,12 +89,12 @@
                   .Map
                 </end-fix>
                 <end-bag>
-                  "Alice" |-> 0
-                  "Bobby" |-> 0
+                  "Alice" |-> wad ( 0 )
+                  "Bobby" |-> wad ( 0 )
                 </end-bag>
                 <end-out>
-                  { "gold" , "Alice" } |-> 0
-                  { "gold" , "Bobby" } |-> 0
+                  { "gold" , "Alice" } |-> wad ( 0 )
+                  { "gold" , "Bobby" } |-> wad ( 0 )
                 </end-out>
               </end>
             </end-state>
@@ -112,7 +112,7 @@
                 true
               </flap-live>
               <flap-beg>
-                21 /Rat 20
+                wad ( 21 /Rat 20 )
               </flap-beg>
               <flap-ttl>
                 10800
@@ -133,7 +133,7 @@
                   .Map
                 </flip-bids>
                 <flip-beg>
-                  21 /Rat 20
+                  wad ( 21 /Rat 20 )
                 </flip-beg>
                 <flip-ttl>
                   10800
@@ -151,7 +151,7 @@
                 SetItem ( Vow )
               </flop-wards>
               <flop-bids>
-                1 |-> FlopBid ( 50 , 25 , "Bobby" , 10800 , 3600 )
+                1 |-> FlopBid ( rad ( 50 ) , wad ( 25 ) , "Bobby" , 10800 , 3600 )
               </flop-bids>
               <flop-kicks>
                 1
@@ -160,10 +160,10 @@
                 true
               </flop-live>
               <flop-beg>
-                21 /Rat 20
+                wad ( 21 /Rat 20 )
               </flop-beg>
               <flop-pad>
-                3 /Rat 2
+                wad ( 3 /Rat 2 )
               </flop-pad>
               <flop-ttl>
                 10800
@@ -184,11 +184,11 @@
                   .Set
                 </gem-wards>
                 <gem-balances>
-                  "Alice" |-> 0
-                  "Bobby" |-> 0
-                  Flap |-> 0
-                  GemJoin "MKR" |-> 0
-                  Vow |-> 0
+                  "Alice" |-> wad ( 0 )
+                  "Bobby" |-> wad ( 0 )
+                  Flap |-> wad ( 0 )
+                  GemJoin "MKR" |-> wad ( 0 )
+                  Vow |-> wad ( 0 )
                 </gem-balances>
               </gem> <gem>
                 <gem-id>
@@ -198,9 +198,9 @@
                   .Set
                 </gem-wards>
                 <gem-balances>
-                  "Alice" |-> 10
-                  "Bobby" |-> 10
-                  GemJoin "gold" |-> 20
+                  "Alice" |-> wad ( 10 )
+                  "Bobby" |-> wad ( 10 )
+                  GemJoin "gold" |-> wad ( 20 )
                 </gem-balances>
               </gem>
             </gems>
@@ -248,7 +248,7 @@
                 0
               </jug-vow>
               <jug-base>
-                0
+                ray ( 0 )
               </jug-base>
             </jug>
             <pot>
@@ -256,17 +256,17 @@
                 SetItem ( End )
               </pot-wards>
               <pot-pies>
-                "Alice" |-> 0
-                "Bobby" |-> 0
+                "Alice" |-> wad ( 0 )
+                "Bobby" |-> wad ( 0 )
               </pot-pies>
               <pot-pie>
-                0
+                wad ( 0 )
               </pot-pie>
               <pot-dsr>
-                1
+                ray ( 1 )
               </pot-dsr>
               <pot-chi>
-                1
+                ray ( 1 )
               </pot-chi>
               <pot-vow>
                 Vow
@@ -283,10 +283,10 @@
                 .Set
               </spot-wards>
               <spot-ilks>
-                "gold" |-> SpotIlk ( 3000000000 , 1 )
+                "gold" |-> SpotIlk ( wad ( 3000000000 ) , ray ( 1 ) )
               </spot-ilks>
               <spot-par>
-                1
+                ray ( 1 )
               </spot-par>
               <spot-live>
                 true
@@ -314,43 +314,43 @@
                 Vow |-> SetItem ( Flap )
               </vat-can>
               <vat-ilks>
-                "gold" |-> Ilk ( 20 , 1 , 3000000000 , 1000000000000 , 0 )
+                "gold" |-> Ilk ( wad ( 20 ) , ray ( 1 ) , ray ( 3000000000 ) , rad ( 1000000000000 ) , rad ( 0 ) )
               </vat-ilks>
               <vat-urns>
-                { "gold" , "Alice" } |-> Urn ( 10 , 10 )
-                { "gold" , "Bobby" } |-> Urn ( 10 , 10 )
-                { "gold" , End } |-> Urn ( 0 , 0 )
+                { "gold" , "Alice" } |-> Urn ( wad ( 10 ) , wad ( 10 ) )
+                { "gold" , "Bobby" } |-> Urn ( wad ( 10 ) , wad ( 10 ) )
+                { "gold" , End } |-> Urn ( wad ( 0 ) , wad ( 0 ) )
               </vat-urns>
               <vat-gem>
-                { "gold" , "Alice" } |-> 0
-                { "gold" , "Bobby" } |-> 0
-                { "gold" , End } |-> 0
-                { "gold" , Flip "gold" } |-> 0
+                { "gold" , "Alice" } |-> wad ( 0 )
+                { "gold" , "Bobby" } |-> wad ( 0 )
+                { "gold" , End } |-> wad ( 0 )
+                { "gold" , Flip "gold" } |-> wad ( 0 )
               </vat-gem>
               <vat-dai>
-                "Alice" |-> 10
-                "Bobby" |-> 60
-                End |-> 0
-                Flap |-> 0
-                Pot |-> 0
-                Vow |-> 50
+                "Alice" |-> rad ( 10 )
+                "Bobby" |-> rad ( 60 )
+                End |-> rad ( 0 )
+                Flap |-> rad ( 0 )
+                Pot |-> rad ( 0 )
+                Vow |-> rad ( 50 )
               </vat-dai>
               <vat-sin>
-                "Alice" |-> 0
-                "Bobby" |-> 0
-                End |-> 0
-                Flap |-> 0
-                Pot |-> 0
-                Vow |-> 100
+                "Alice" |-> rad ( 0 )
+                "Bobby" |-> rad ( 0 )
+                End |-> rad ( 0 )
+                Flap |-> rad ( 0 )
+                Pot |-> rad ( 0 )
+                Vow |-> rad ( 100 )
               </vat-sin>
               <vat-debt>
-                120
+                rad ( 120 )
               </vat-debt>
               <vat-vice>
-                100
+                rad ( 100 )
               </vat-vice>
               <vat-Line>
-                1000000000000
+                rad ( 1000000000000 )
               </vat-Line>
               <vat-live>
                 true
@@ -365,25 +365,25 @@
                 .Map
               </vow-sins>
               <vow-sin>
-                0
+                rad ( 0 )
               </vow-sin>
               <vow-ash>
-                50
+                rad ( 50 )
               </vow-ash>
               <vow-wait>
                 0
               </vow-wait>
               <vow-dump>
-                30
+                wad ( 30 )
               </vow-dump>
               <vow-sump>
-                50
+                rad ( 50 )
               </vow-sump>
               <vow-bump>
-                1000000000
+                rad ( 1000000000 )
               </vow-bump>
               <vow-hump>
-                0
+                rad ( 0 )
               </vow-hump>
               <vow-live>
                 true
@@ -418,7 +418,7 @@
             .Set
           </dai-wards>
           <dai-totalSupply>
-            0
+            wad ( 0 )
           </dai-totalSupply>
           <dai-account-id>
             0
@@ -451,13 +451,13 @@
               0
             </end-wait>
             <end-debt>
-              0
+              rad ( 0 )
             </end-debt>
             <end-tag>
               .Map
             </end-tag>
             <end-gap>
-              "gold" |-> 0
+              "gold" |-> wad ( 0 )
             </end-gap>
             <end-art>
               .Map
@@ -466,12 +466,12 @@
               .Map
             </end-fix>
             <end-bag>
-              "Alice" |-> 0
-              "Bobby" |-> 0
+              "Alice" |-> wad ( 0 )
+              "Bobby" |-> wad ( 0 )
             </end-bag>
             <end-out>
-              { "gold" , "Alice" } |-> 0
-              { "gold" , "Bobby" } |-> 0
+              { "gold" , "Alice" } |-> wad ( 0 )
+              { "gold" , "Bobby" } |-> wad ( 0 )
             </end-out>
           </end>
         </end-state>
@@ -489,7 +489,7 @@
             true
           </flap-live>
           <flap-beg>
-            21 /Rat 20
+            wad ( 21 /Rat 20 )
           </flap-beg>
           <flap-ttl>
             10800
@@ -510,7 +510,7 @@
               .Map
             </flip-bids>
             <flip-beg>
-              21 /Rat 20
+              wad ( 21 /Rat 20 )
             </flip-beg>
             <flip-ttl>
               10800
@@ -528,7 +528,7 @@
             SetItem ( Vow )
           </flop-wards>
           <flop-bids>
-            1 |-> FlopBid ( 50 , 25 , "Bobby" , 10800 , 3600 )
+            1 |-> FlopBid ( rad ( 50 ) , wad ( 25 ) , "Bobby" , 10800 , 3600 )
           </flop-bids>
           <flop-kicks>
             1
@@ -537,10 +537,10 @@
             true
           </flop-live>
           <flop-beg>
-            21 /Rat 20
+            wad ( 21 /Rat 20 )
           </flop-beg>
           <flop-pad>
-            3 /Rat 2
+            wad ( 3 /Rat 2 )
           </flop-pad>
           <flop-ttl>
             10800
@@ -561,11 +561,11 @@
               .Set
             </gem-wards>
             <gem-balances>
-              "Alice" |-> 0
-              "Bobby" |-> 0
-              Flap |-> 0
-              GemJoin "MKR" |-> 0
-              Vow |-> 0
+              "Alice" |-> wad ( 0 )
+              "Bobby" |-> wad ( 0 )
+              Flap |-> wad ( 0 )
+              GemJoin "MKR" |-> wad ( 0 )
+              Vow |-> wad ( 0 )
             </gem-balances>
           </gem> <gem>
             <gem-id>
@@ -575,9 +575,9 @@
               .Set
             </gem-wards>
             <gem-balances>
-              "Alice" |-> 10
-              "Bobby" |-> 10
-              GemJoin "gold" |-> 20
+              "Alice" |-> wad ( 10 )
+              "Bobby" |-> wad ( 10 )
+              GemJoin "gold" |-> wad ( 20 )
             </gem-balances>
           </gem>
         </gems>
@@ -625,7 +625,7 @@
             0
           </jug-vow>
           <jug-base>
-            0
+            ray ( 0 )
           </jug-base>
         </jug>
         <pot>
@@ -633,17 +633,17 @@
             SetItem ( End )
           </pot-wards>
           <pot-pies>
-            "Alice" |-> 0
-            "Bobby" |-> 0
+            "Alice" |-> wad ( 0 )
+            "Bobby" |-> wad ( 0 )
           </pot-pies>
           <pot-pie>
-            0
+            wad ( 0 )
           </pot-pie>
           <pot-dsr>
-            1
+            ray ( 1 )
           </pot-dsr>
           <pot-chi>
-            1
+            ray ( 1 )
           </pot-chi>
           <pot-vow>
             Vow
@@ -660,10 +660,10 @@
             .Set
           </spot-wards>
           <spot-ilks>
-            "gold" |-> SpotIlk ( 3000000000 , 1 )
+            "gold" |-> SpotIlk ( wad ( 3000000000 ) , ray ( 1 ) )
           </spot-ilks>
           <spot-par>
-            1
+            ray ( 1 )
           </spot-par>
           <spot-live>
             true
@@ -691,43 +691,43 @@
             Vow |-> SetItem ( Flap )
           </vat-can>
           <vat-ilks>
-            "gold" |-> Ilk ( 20 , 1 , 3000000000 , 1000000000000 , 0 )
+            "gold" |-> Ilk ( wad ( 20 ) , ray ( 1 ) , ray ( 3000000000 ) , rad ( 1000000000000 ) , rad ( 0 ) )
           </vat-ilks>
           <vat-urns>
-            { "gold" , "Alice" } |-> Urn ( 10 , 10 )
-            { "gold" , "Bobby" } |-> Urn ( 10 , 10 )
-            { "gold" , End } |-> Urn ( 0 , 0 )
+            { "gold" , "Alice" } |-> Urn ( wad ( 10 ) , wad ( 10 ) )
+            { "gold" , "Bobby" } |-> Urn ( wad ( 10 ) , wad ( 10 ) )
+            { "gold" , End } |-> Urn ( wad ( 0 ) , wad ( 0 ) )
           </vat-urns>
           <vat-gem>
-            { "gold" , "Alice" } |-> 0
-            { "gold" , "Bobby" } |-> 0
-            { "gold" , End } |-> 0
-            { "gold" , Flip "gold" } |-> 0
+            { "gold" , "Alice" } |-> wad ( 0 )
+            { "gold" , "Bobby" } |-> wad ( 0 )
+            { "gold" , End } |-> wad ( 0 )
+            { "gold" , Flip "gold" } |-> wad ( 0 )
           </vat-gem>
           <vat-dai>
-            "Alice" |-> 10
-            "Bobby" |-> 60
-            End |-> 0
-            Flap |-> 0
-            Pot |-> 0
-            Vow |-> 0
+            "Alice" |-> rad ( 10 )
+            "Bobby" |-> rad ( 60 )
+            End |-> rad ( 0 )
+            Flap |-> rad ( 0 )
+            Pot |-> rad ( 0 )
+            Vow |-> rad ( 0 )
           </vat-dai>
           <vat-sin>
-            "Alice" |-> 0
-            "Bobby" |-> 0
-            End |-> 0
-            Flap |-> 0
-            Pot |-> 0
-            Vow |-> 50
+            "Alice" |-> rad ( 0 )
+            "Bobby" |-> rad ( 0 )
+            End |-> rad ( 0 )
+            Flap |-> rad ( 0 )
+            Pot |-> rad ( 0 )
+            Vow |-> rad ( 50 )
           </vat-sin>
           <vat-debt>
-            70
+            rad ( 70 )
           </vat-debt>
           <vat-vice>
-            50
+            rad ( 50 )
           </vat-vice>
           <vat-Line>
-            1000000000000
+            rad ( 1000000000000 )
           </vat-Line>
           <vat-live>
             true
@@ -742,25 +742,25 @@
             .Map
           </vow-sins>
           <vow-sin>
-            0
+            rad ( 0 )
           </vow-sin>
           <vow-ash>
-            50
+            rad ( 50 )
           </vow-ash>
           <vow-wait>
             0
           </vow-wait>
           <vow-dump>
-            30
+            wad ( 30 )
           </vow-dump>
           <vow-sump>
-            50
+            rad ( 50 )
           </vow-sump>
           <vow-bump>
-            1000000000
+            rad ( 1000000000 )
           </vow-bump>
           <vow-hump>
-            0
+            rad ( 0 )
           </vow-hump>
           <vow-live>
             true
@@ -770,835 +770,835 @@
     </kmcd>
     <processed-events>
       ListItem ( LogNote ( ADMIN , Vat . rely Pot ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . rely End ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . rely Spot ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Pot . rely End ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vow . rely Pot ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vow . rely End ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Cat . rely End ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Flap . rely Vow ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Flop . rely Vow ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser Vow ) )
-      ListItem ( Measure ( 0 , Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , Vow |-> 0 , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , Vow |-> rad ( 0 ) , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser Pot ) )
-      ListItem ( Measure ( 0 , Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , Pot |-> 0
-      Vow |-> 0 , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser Flap ) )
-      ListItem ( Measure ( 0 , Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , GemJoin "MKR" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , GemJoin "MKR" |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , GemJoin "MKR" |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Vow ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Flap ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Pot . file vow-file Vow ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( Vow , Vat . hope Flap ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vat . file Line 1000000000000 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vow . file bump 1000000000 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vow . file hump 0 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vow . file sump 50 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vow . file dump 30 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vat . file Line rad ( 1000000000000 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vow . file bump rad ( 1000000000 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vow . file hump rad ( 0 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vow . file sump rad ( 50 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vow . file dump wad ( 30 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Flop . file tau 3600 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , GemJoin "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . rely GemJoin "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" Flip "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Spot . init "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 3000000000 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Spot . file mat "gold" 1 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Spot . file par 1 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" wad ( 3000000000 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Spot . file mat "gold" ray ( 1 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Spot . file par ray ( 1 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Flip "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Flip "gold" . rely End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . initGap "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initIlk "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ANYONE , Vat . file spot "gold" 3000000000 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vat . file line "gold" rad ( 1000000000000 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ANYONE , Vat . file spot "gold" ray ( 3000000000 ) ) )
       ListItem ( LogNote ( ANYONE , Spot . poke "gold" ) )
-      ListItem ( Poke ( "gold" , 3000000000 , 3000000000 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Poke ( "gold" , wad ( 3000000000 ) , ray ( 3000000000 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Alice" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Bobby" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Alice" 20 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Bobby" 20 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Alice" wad ( 20 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Bobby" wad ( 20 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Alice" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Bobby" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Pot . initUser "Alice" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Pot . initUser "Bobby" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser "Alice" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Alice" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Alice" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser "Bobby" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Bobby" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Bobby" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Alice" , Vat . hope Pot ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Alice" , Vat . hope Flip "gold" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Alice" , Vat . hope End ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Alice" , Vat . hope Flop ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope Pot ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope Flip "gold" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope End ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope Flop ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( "Alice" , Vat . slip "gold" "Alice" 10 ) )
-      ListItem ( LogNote ( "Alice" , Gem "gold" . transferFrom "Alice" GemJoin "gold" 10 ) )
-      ListItem ( LogNote ( "Alice" , GemJoin "gold" . join "Alice" 10 ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 10 ) )
-      ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 10 ) )
-      ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 10 ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( "Alice" , Vat . frob "gold" "Alice" "Alice" "Alice" 10 10 ) )
-      ListItem ( Measure ( 10 , "Alice" |-> 10
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 10 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( "Alice" , Vat . slip "gold" "Alice" wad ( 10 ) ) )
+      ListItem ( LogNote ( "Alice" , Gem "gold" . transferFrom "Alice" GemJoin "gold" wad ( 10 ) ) )
+      ListItem ( LogNote ( "Alice" , GemJoin "gold" . join "Alice" wad ( 10 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" wad ( 10 ) ) )
+      ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" wad ( 10 ) ) )
+      ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" wad ( 10 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( "Alice" , Vat . frob "gold" "Alice" "Alice" "Alice" wad ( 10 ) wad ( 10 ) ) )
+      ListItem ( Measure ( rad ( 10 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 10 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" wad ( 10 ) wad ( 10 ) ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vat . suck Vow "Bobby" 100 ) )
-      ListItem ( Measure ( 120 , "Alice" |-> 10
-      "Bobby" |-> 110
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 100 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 110
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( "Bobby" , Flop . kick Vow 30 50 ) )
-      ListItem ( FlopKick ( 1 , 30 , 50 , Vow ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vat . suck Vow "Bobby" rad ( 100 ) ) )
+      ListItem ( Measure ( rad ( 120 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 110 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 100 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 110 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( "Bobby" , Flop . kick Vow wad ( 30 ) rad ( 50 ) ) )
+      ListItem ( FlopKick ( 1 , wad ( 30 ) , rad ( 50 ) , Vow ) )
       ListItem ( LogNote ( "Bobby" , Vow . flop ) )
-      ListItem ( Measure ( 120 , "Alice" |-> 10
-      "Bobby" |-> 110
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 100 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 110
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 50 ) )
-      ListItem ( LogNote ( "Bobby" , Vat . move "Bobby" Vow 50 ) )
-      ListItem ( LogNote ( "Bobby" , Flop . dent 1 25 50 ) )
-      ListItem ( Measure ( 120 , "Alice" |-> 10
-      "Bobby" |-> 60
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 50 , 1 , 0 , 20 , 100 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 60
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 50 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 50 ) )
-      ListItem ( LogNote ( "Bobby" , Vat . heal 50 ) )
-      ListItem ( LogNote ( "Bobby" , Vow . heal 50 ) )
-      ListItem ( Measure ( 70 , "Alice" |-> 10
-      "Bobby" |-> 60
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 50 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 60
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 50 ) )
+      ListItem ( Measure ( rad ( 120 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 110 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 100 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 110 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 50 ) ) )
+      ListItem ( LogNote ( "Bobby" , Vat . move "Bobby" Vow rad ( 50 ) ) )
+      ListItem ( LogNote ( "Bobby" , Flop . dent 1 wad ( 25 ) rad ( 50 ) ) )
+      ListItem ( Measure ( rad ( 120 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 60 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 50 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 100 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 60 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 50 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 50 ) ) )
+      ListItem ( LogNote ( "Bobby" , Vat . heal rad ( 50 ) ) )
+      ListItem ( LogNote ( "Bobby" , Vow . heal rad ( 50 ) ) )
+      ListItem ( Measure ( rad ( 70 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 60 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 50 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 60 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 50 ) ) )
     </processed-events>
     <properties>
       "Debt Constant After Thaw" |-> debtConstantAfterThaw
       "Flap Dai Consistency" |-> flapDaiConsistency
       "Flap MKR Consistency" |-> flapMkrConsistency
-      "Flop Block Check" |-> Violated ( flopBlockCheck ( 0 , 2 ) )
+      "Flop Block Check" |-> Violated ( flopBlockCheck ( rad ( 0 ) , 2 ) )
       "Pot Interest Accumulation After End" |-> potEndInterest
-      "PotChi PotPie VatPot" |-> potChiPieDai ( 0 , 0 )
+      "PotChi PotPie VatPot" |-> potChiPieDai ( rad ( 0 ) , wad ( 0 ) )
       "Total Backed Debt Consistency" |-> totalBackedDebtConsistency
-      "Total Bound on Debt" |-> totalDebtBoundedRun ( 120 , 1 )
+      "Total Bound on Debt" |-> totalDebtBoundedRun ( rad ( 120 ) , ray ( 1 ) )
       "Unauthorized Flap Kick" |-> unAuthFlapKick
       "Unauthorized Flip Kick" |-> unAuthFlipKick
       "Zero-Time Pot Interest Accumulation" |-> zeroTimePotInterest

--- a/tests/attacks/lucash-flap-end.mcd.expected
+++ b/tests/attacks/lucash-flap-end.mcd.expected
@@ -50,7 +50,7 @@
             .Set
           </dai-wards>
           <dai-totalSupply>
-            0
+            wad ( 0 )
           </dai-totalSupply>
           <dai-account-id>
             0
@@ -83,13 +83,13 @@
               0
             </end-wait>
             <end-debt>
-              0
+              rad ( 0 )
             </end-debt>
             <end-tag>
               .Map
             </end-tag>
             <end-gap>
-              "gold" |-> 0
+              "gold" |-> wad ( 0 )
             </end-gap>
             <end-art>
               .Map
@@ -98,12 +98,12 @@
               .Map
             </end-fix>
             <end-bag>
-              "Alice" |-> 0
-              "Bobby" |-> 0
+              "Alice" |-> wad ( 0 )
+              "Bobby" |-> wad ( 0 )
             </end-bag>
             <end-out>
-              { "gold" , "Alice" } |-> 0
-              { "gold" , "Bobby" } |-> 0
+              { "gold" , "Alice" } |-> wad ( 0 )
+              { "gold" , "Bobby" } |-> wad ( 0 )
             </end-out>
           </end>
         </end-state>
@@ -112,7 +112,7 @@
             SetItem ( Vow )
           </flap-wards>
           <flap-bids>
-            1 |-> FlapBid ( 20 , 1000000000 , "Bobby" , 10800 , 172800 )
+            1 |-> FlapBid ( wad ( 20 ) , rad ( 1000000000 ) , "Bobby" , 10800 , 172800 )
           </flap-bids>
           <flap-kicks>
             1
@@ -121,7 +121,7 @@
             false
           </flap-live>
           <flap-beg>
-            21 /Rat 20
+            wad ( 21 /Rat 20 )
           </flap-beg>
           <flap-ttl>
             10800
@@ -142,7 +142,7 @@
               .Map
             </flip-bids>
             <flip-beg>
-              21 /Rat 20
+              wad ( 21 /Rat 20 )
             </flip-beg>
             <flip-ttl>
               10800
@@ -169,10 +169,10 @@
             false
           </flop-live>
           <flop-beg>
-            21 /Rat 20
+            wad ( 21 /Rat 20 )
           </flop-beg>
           <flop-pad>
-            3 /Rat 2
+            wad ( 3 /Rat 2 )
           </flop-pad>
           <flop-ttl>
             10800
@@ -193,11 +193,11 @@
               .Set
             </gem-wards>
             <gem-balances>
-              "Alice" |-> 0
-              "Bobby" |-> 0
-              Flap |-> 20
-              GemJoin "MKR" |-> 0
-              Vow |-> 0
+              "Alice" |-> wad ( 0 )
+              "Bobby" |-> wad ( 0 )
+              Flap |-> wad ( 20 )
+              GemJoin "MKR" |-> wad ( 0 )
+              Vow |-> wad ( 0 )
             </gem-balances>
           </gem> <gem>
             <gem-id>
@@ -207,9 +207,9 @@
               .Set
             </gem-wards>
             <gem-balances>
-              "Alice" |-> 10
-              "Bobby" |-> 10
-              GemJoin "gold" |-> 20
+              "Alice" |-> wad ( 10 )
+              "Bobby" |-> wad ( 10 )
+              GemJoin "gold" |-> wad ( 20 )
             </gem-balances>
           </gem>
         </gems>
@@ -257,7 +257,7 @@
             0
           </jug-vow>
           <jug-base>
-            0
+            ray ( 0 )
           </jug-base>
         </jug>
         <pot>
@@ -265,17 +265,17 @@
             SetItem ( End )
           </pot-wards>
           <pot-pies>
-            "Alice" |-> 0
-            "Bobby" |-> 0
+            "Alice" |-> wad ( 0 )
+            "Bobby" |-> wad ( 0 )
           </pot-pies>
           <pot-pie>
-            0
+            wad ( 0 )
           </pot-pie>
           <pot-dsr>
-            1
+            ray ( 1 )
           </pot-dsr>
           <pot-chi>
-            1
+            ray ( 1 )
           </pot-chi>
           <pot-vow>
             Vow
@@ -292,10 +292,10 @@
             .Set
           </spot-wards>
           <spot-ilks>
-            "gold" |-> SpotIlk ( 3000000000 , 1 )
+            "gold" |-> SpotIlk ( wad ( 3000000000 ) , ray ( 1 ) )
           </spot-ilks>
           <spot-par>
-            1
+            ray ( 1 )
           </spot-par>
           <spot-live>
             true
@@ -324,43 +324,43 @@
             Vow |-> SetItem ( Flap )
           </vat-can>
           <vat-ilks>
-            "gold" |-> Ilk ( 20 , 1 , 3000000000 , 1000000000000 , 0 )
+            "gold" |-> Ilk ( wad ( 20 ) , ray ( 1 ) , ray ( 3000000000 ) , rad ( 1000000000000 ) , rad ( 0 ) )
           </vat-ilks>
           <vat-urns>
-            { "gold" , "Alice" } |-> Urn ( 10 , 10 )
-            { "gold" , "Bobby" } |-> Urn ( 10 , 10 )
-            { "gold" , End } |-> Urn ( 0 , 0 )
+            { "gold" , "Alice" } |-> Urn ( wad ( 10 ) , wad ( 10 ) )
+            { "gold" , "Bobby" } |-> Urn ( wad ( 10 ) , wad ( 10 ) )
+            { "gold" , End } |-> Urn ( wad ( 0 ) , wad ( 0 ) )
           </vat-urns>
           <vat-gem>
-            { "gold" , "Alice" } |-> 0
-            { "gold" , "Bobby" } |-> 0
-            { "gold" , End } |-> 0
-            { "gold" , Flip "gold" } |-> 0
+            { "gold" , "Alice" } |-> wad ( 0 )
+            { "gold" , "Bobby" } |-> wad ( 0 )
+            { "gold" , End } |-> wad ( 0 )
+            { "gold" , Flip "gold" } |-> wad ( 0 )
           </vat-gem>
           <vat-dai>
-            "Alice" |-> 10
-            "Bobby" |-> 10
-            End |-> 0
-            Flap |-> 0
-            Pot |-> 0
-            Vow |-> 1000000000
+            "Alice" |-> rad ( 10 )
+            "Bobby" |-> rad ( 10 )
+            End |-> rad ( 0 )
+            Flap |-> rad ( 0 )
+            Pot |-> rad ( 0 )
+            Vow |-> rad ( 1000000000 )
           </vat-dai>
           <vat-sin>
-            "Alice" |-> 0
-            "Bobby" |-> 0
-            End |-> 1000000000
-            Flap |-> 0
-            Pot |-> 0
-            Vow |-> 0
+            "Alice" |-> rad ( 0 )
+            "Bobby" |-> rad ( 0 )
+            End |-> rad ( 1000000000 )
+            Flap |-> rad ( 0 )
+            Pot |-> rad ( 0 )
+            Vow |-> rad ( 0 )
           </vat-sin>
           <vat-debt>
-            1000000020
+            rad ( 1000000020 )
           </vat-debt>
           <vat-vice>
-            1000000000
+            rad ( 1000000000 )
           </vat-vice>
           <vat-Line>
-            1000000000000
+            rad ( 1000000000000 )
           </vat-Line>
           <vat-live>
             false
@@ -375,25 +375,25 @@
             .Map
           </vow-sins>
           <vow-sin>
-            0
+            rad ( 0 )
           </vow-sin>
           <vow-ash>
-            0
+            rad ( 0 )
           </vow-ash>
           <vow-wait>
             0
           </vow-wait>
           <vow-dump>
-            30
+            wad ( 30 )
           </vow-dump>
           <vow-sump>
-            50
+            rad ( 50 )
           </vow-sump>
           <vow-bump>
-            1000000000
+            rad ( 1000000000 )
           </vow-bump>
           <vow-hump>
-            0
+            rad ( 0 )
           </vow-hump>
           <vow-live>
             false
@@ -403,893 +403,893 @@
     </kmcd>
     <processed-events>
       ListItem ( LogNote ( ADMIN , Vat . rely Pot ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . rely End ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . rely Spot ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Pot . rely End ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vow . rely Pot ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vow . rely End ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Cat . rely End ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Flap . rely Vow ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Flop . rely Vow ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser Vow ) )
-      ListItem ( Measure ( 0 , Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , Vow |-> 0 , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , Vow |-> rad ( 0 ) , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser Pot ) )
-      ListItem ( Measure ( 0 , Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , Pot |-> 0
-      Vow |-> 0 , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser Flap ) )
-      ListItem ( Measure ( 0 , Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , GemJoin "MKR" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , GemJoin "MKR" |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , GemJoin "MKR" |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Vow ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Flap ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Pot . file vow-file Vow ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( Vow , Vat . hope Flap ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vat . file Line 1000000000000 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vow . file bump 1000000000 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vow . file hump 0 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vow . file sump 50 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vow . file dump 30 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vat . file Line rad ( 1000000000000 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vow . file bump rad ( 1000000000 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vow . file hump rad ( 0 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vow . file sump rad ( 50 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vow . file dump wad ( 30 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Flop . file tau 3600 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , GemJoin "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . rely GemJoin "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" Flip "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Spot . init "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 3000000000 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Spot . file mat "gold" 1 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Spot . file par 1 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" wad ( 3000000000 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Spot . file mat "gold" ray ( 1 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Spot . file par ray ( 1 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Flip "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Flip "gold" . rely End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . initGap "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initIlk "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ANYONE , Vat . file spot "gold" 3000000000 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vat . file line "gold" rad ( 1000000000000 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ANYONE , Vat . file spot "gold" ray ( 3000000000 ) ) )
       ListItem ( LogNote ( ANYONE , Spot . poke "gold" ) )
-      ListItem ( Poke ( "gold" , 3000000000 , 3000000000 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Poke ( "gold" , wad ( 3000000000 ) , ray ( 3000000000 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Alice" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Bobby" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Alice" 20 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Bobby" 20 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Alice" wad ( 20 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Bobby" wad ( 20 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Alice" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Bobby" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Pot . initUser "Alice" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Pot . initUser "Bobby" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser "Alice" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Alice" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Alice" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser "Bobby" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Bobby" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Bobby" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Alice" , Vat . hope Pot ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Alice" , Vat . hope Flip "gold" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Alice" , Vat . hope End ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Alice" , Vat . hope Flop ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope Pot ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope Flip "gold" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope End ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope Flop ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( "Alice" , Vat . slip "gold" "Alice" 10 ) )
-      ListItem ( LogNote ( "Alice" , Gem "gold" . transferFrom "Alice" GemJoin "gold" 10 ) )
-      ListItem ( LogNote ( "Alice" , GemJoin "gold" . join "Alice" 10 ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 10 ) )
-      ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 10 ) )
-      ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 10 ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( "Alice" , Vat . frob "gold" "Alice" "Alice" "Alice" 10 10 ) )
-      ListItem ( Measure ( 10 , "Alice" |-> 10
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 10 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( "Alice" , Vat . slip "gold" "Alice" wad ( 10 ) ) )
+      ListItem ( LogNote ( "Alice" , Gem "gold" . transferFrom "Alice" GemJoin "gold" wad ( 10 ) ) )
+      ListItem ( LogNote ( "Alice" , GemJoin "gold" . join "Alice" wad ( 10 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" wad ( 10 ) ) )
+      ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" wad ( 10 ) ) )
+      ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" wad ( 10 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( "Alice" , Vat . frob "gold" "Alice" "Alice" "Alice" wad ( 10 ) wad ( 10 ) ) )
+      ListItem ( Measure ( rad ( 10 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 10 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" wad ( 10 ) wad ( 10 ) ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Gem "MKR" . mint "Bobby" 20 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 20
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vat . suck End Vow 1000000000 ) )
-      ListItem ( Measure ( 1000000020 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 1000000000 , 1 , 0 , 20 , 1000000000 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 1000000000 , 0 , "Alice" |-> 0
-      "Bobby" |-> 20
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( Vow , Vat . move Vow Flap 1000000000 ) )
-      ListItem ( LogNote ( ADMIN , Flap . kick 1000000000 0 ) )
-      ListItem ( FlapKick ( Vow , 1 , 1000000000 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Gem "MKR" . mint "Bobby" wad ( 20 ) ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 20 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vat . suck End Vow rad ( 1000000000 ) ) )
+      ListItem ( Measure ( rad ( 1000000020 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 1000000000 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 1000000000 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 1000000000 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 20 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( Vow , Vat . move Vow Flap rad ( 1000000000 ) ) )
+      ListItem ( LogNote ( ADMIN , Flap . kick rad ( 1000000000 ) wad ( 0 ) ) )
+      ListItem ( FlapKick ( Vow , 1 , rad ( 1000000000 ) , wad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vow . flap ) )
-      ListItem ( Measure ( 1000000020 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 1000000000
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 1000000000 , 0 , 1000000000 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 1000000000
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 20
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( "Bobby" , Gem "MKR" . move "Bobby" Vow 0 ) )
-      ListItem ( LogNote ( "Bobby" , Gem "MKR" . move "Bobby" Flap 20 ) )
-      ListItem ( LogNote ( "Bobby" , Flap . tend 1 1000000000 20 ) )
-      ListItem ( Measure ( 1000000020 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 1000000000
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 1000000000 , 0 , 1000000000 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 1000000000
-      Pot |-> 0
-      Vow |-> 0 , 20 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 20
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 1000000020 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 1000000000 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 1000000000 ) , rad ( 0 ) , rad ( 1000000000 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 1000000000 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 20 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( "Bobby" , Gem "MKR" . move "Bobby" Vow wad ( 0 ) ) )
+      ListItem ( LogNote ( "Bobby" , Gem "MKR" . move "Bobby" Flap wad ( 20 ) ) )
+      ListItem ( LogNote ( "Bobby" , Flap . tend 1 rad ( 1000000000 ) wad ( 20 ) ) )
+      ListItem ( Measure ( rad ( 1000000020 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 1000000000 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 1000000000 ) , rad ( 0 ) , rad ( 1000000000 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 1000000000 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 20 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 20 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Alice" , Vat . hope Flap ) )
-      ListItem ( Measure ( 1000000020 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 1000000000
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 1000000000 , 0 , 1000000000 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 1000000000
-      Pot |-> 0
-      Vow |-> 0 , 20 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 20
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( Exception ( Flap . kick 1 20 ) )
+      ListItem ( Measure ( rad ( 1000000020 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 1000000000 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 1000000000 ) , rad ( 0 ) , rad ( 1000000000 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 1000000000 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 20 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 20 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( Exception ( Flap . kick rad ( 1 ) wad ( 20 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . cage ) )
       ListItem ( LogNote ( ADMIN , Cat . cage ) )
-      ListItem ( LogNote ( Vow , Vat . move Flap Vow 1000000000 ) )
-      ListItem ( LogNote ( End , Flap . cage 1000000000 ) )
+      ListItem ( LogNote ( Vow , Vat . move Flap Vow rad ( 1000000000 ) ) )
+      ListItem ( LogNote ( End , Flap . cage rad ( 1000000000 ) ) )
       ListItem ( LogNote ( End , Flop . cage ) )
-      ListItem ( LogNote ( End , Vat . heal 0 ) )
+      ListItem ( LogNote ( End , Vat . heal rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vow . cage ) )
       ListItem ( LogNote ( ADMIN , Pot . cage ) )
       ListItem ( LogNote ( ADMIN , End . cage ) )
-      ListItem ( Measure ( 1000000020 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 1000000000 , 1 , 0 , 20 , 1000000000 , 0 , 1000000000 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 1000000000 , 20 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 20
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 1000000020 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 1000000000 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 1000000000 ) , rad ( 0 ) , rad ( 1000000000 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 1000000000 ) , wad ( 20 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 20 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( Exception ( Flap . yank 2 ) )
-      ListItem ( Measure ( 1000000020 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 1000000000 , 1 , 0 , 20 , 1000000000 , 0 , 1000000000 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 1000000000 , 20 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 20
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 1000000020 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 1000000000 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 1000000000 ) , rad ( 0 ) , rad ( 1000000000 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 1000000000 ) , wad ( 20 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 20 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
     </processed-events>
     <properties>
       "Debt Constant After Thaw" |-> debtConstantAfterThaw
       "Flap Dai Consistency" |-> flapDaiConsistencyEnd
       "Flap MKR Consistency" |-> flapMkrConsistency
-      "Flop Block Check" |-> flopBlockCheck ( 0 , 0 )
+      "Flop Block Check" |-> flopBlockCheck ( rad ( 0 ) , 0 )
       "Pot Interest Accumulation After End" |-> potEndInterestEnd
-      "PotChi PotPie VatPot" |-> potChiPieDai ( 0 , 0 )
+      "PotChi PotPie VatPot" |-> potChiPieDai ( rad ( 0 ) , wad ( 0 ) )
       "Total Backed Debt Consistency" |-> totalBackedDebtConsistency
-      "Total Bound on Debt" |-> totalDebtBoundedEnd ( 1000000020 )
+      "Total Bound on Debt" |-> totalDebtBoundedEnd ( rad ( 1000000020 ) )
       "Unauthorized Flap Kick" |-> unAuthFlapKick
       "Unauthorized Flip Kick" |-> unAuthFlipKick
       "Zero-Time Pot Interest Accumulation" |-> zeroTimePotInterest

--- a/tests/attacks/lucash-flap-end.random.mcd.expected
+++ b/tests/attacks/lucash-flap-end.random.mcd.expected
@@ -50,7 +50,7 @@
             .Set
           </dai-wards>
           <dai-totalSupply>
-            0
+            wad ( 0 )
           </dai-totalSupply>
           <dai-account-id>
             0
@@ -83,13 +83,13 @@
               0
             </end-wait>
             <end-debt>
-              0
+              rad ( 0 )
             </end-debt>
             <end-tag>
               .Map
             </end-tag>
             <end-gap>
-              "gold" |-> 0
+              "gold" |-> wad ( 0 )
             </end-gap>
             <end-art>
               .Map
@@ -98,12 +98,12 @@
               .Map
             </end-fix>
             <end-bag>
-              "Alice" |-> 0
-              "Bobby" |-> 0
+              "Alice" |-> wad ( 0 )
+              "Bobby" |-> wad ( 0 )
             </end-bag>
             <end-out>
-              { "gold" , "Alice" } |-> 0
-              { "gold" , "Bobby" } |-> 0
+              { "gold" , "Alice" } |-> wad ( 0 )
+              { "gold" , "Bobby" } |-> wad ( 0 )
             </end-out>
           </end>
         </end-state>
@@ -121,7 +121,7 @@
             false
           </flap-live>
           <flap-beg>
-            21 /Rat 20
+            wad ( 21 /Rat 20 )
           </flap-beg>
           <flap-ttl>
             10800
@@ -142,7 +142,7 @@
               .Map
             </flip-bids>
             <flip-beg>
-              21 /Rat 20
+              wad ( 21 /Rat 20 )
             </flip-beg>
             <flip-ttl>
               10800
@@ -169,10 +169,10 @@
             false
           </flop-live>
           <flop-beg>
-            21 /Rat 20
+            wad ( 21 /Rat 20 )
           </flop-beg>
           <flop-pad>
-            3 /Rat 2
+            wad ( 3 /Rat 2 )
           </flop-pad>
           <flop-ttl>
             10800
@@ -193,11 +193,11 @@
               .Set
             </gem-wards>
             <gem-balances>
-              "Alice" |-> 0
-              "Bobby" |-> 0
-              Flap |-> 0
-              GemJoin "MKR" |-> 0
-              Vow |-> 0
+              "Alice" |-> wad ( 0 )
+              "Bobby" |-> wad ( 0 )
+              Flap |-> wad ( 0 )
+              GemJoin "MKR" |-> wad ( 0 )
+              Vow |-> wad ( 0 )
             </gem-balances>
           </gem> <gem>
             <gem-id>
@@ -207,9 +207,9 @@
               .Set
             </gem-wards>
             <gem-balances>
-              "Alice" |-> 10
-              "Bobby" |-> 1025 /Rat 128
-              GemJoin "gold" |-> 2815 /Rat 128
+              "Alice" |-> wad ( 10 )
+              "Bobby" |-> wad ( 1025 /Rat 128 )
+              GemJoin "gold" |-> wad ( 2815 /Rat 128 )
             </gem-balances>
           </gem>
         </gems>
@@ -257,7 +257,7 @@
             0
           </jug-vow>
           <jug-base>
-            0
+            ray ( 0 )
           </jug-base>
         </jug>
         <pot>
@@ -265,17 +265,17 @@
             SetItem ( End )
           </pot-wards>
           <pot-pies>
-            "Alice" |-> 0
-            "Bobby" |-> 0
+            "Alice" |-> wad ( 0 )
+            "Bobby" |-> wad ( 0 )
           </pot-pies>
           <pot-pie>
-            0
+            wad ( 0 )
           </pot-pie>
           <pot-dsr>
-            1
+            ray ( 1 )
           </pot-dsr>
           <pot-chi>
-            1
+            ray ( 1 )
           </pot-chi>
           <pot-vow>
             Vow
@@ -292,10 +292,10 @@
             .Set
           </spot-wards>
           <spot-ilks>
-            "gold" |-> SpotIlk ( 3000000000 , 1 )
+            "gold" |-> SpotIlk ( wad ( 3000000000 ) , ray ( 1 ) )
           </spot-ilks>
           <spot-par>
-            1
+            ray ( 1 )
           </spot-par>
           <spot-live>
             true
@@ -324,43 +324,43 @@
             Vow |-> SetItem ( Flap )
           </vat-can>
           <vat-ilks>
-            "gold" |-> Ilk ( 20 , 1 , 3000000000 , 1000000000000 , 0 )
+            "gold" |-> Ilk ( wad ( 20 ) , ray ( 1 ) , ray ( 3000000000 ) , rad ( 1000000000000 ) , rad ( 0 ) )
           </vat-ilks>
           <vat-urns>
-            { "gold" , "Alice" } |-> Urn ( 10 , 10 )
-            { "gold" , "Bobby" } |-> Urn ( 10 , 10 )
-            { "gold" , End } |-> Urn ( 0 , 0 )
+            { "gold" , "Alice" } |-> Urn ( wad ( 10 ) , wad ( 10 ) )
+            { "gold" , "Bobby" } |-> Urn ( wad ( 10 ) , wad ( 10 ) )
+            { "gold" , End } |-> Urn ( wad ( 0 ) , wad ( 0 ) )
           </vat-urns>
           <vat-gem>
-            { "gold" , "Alice" } |-> 0
-            { "gold" , "Bobby" } |-> 255 /Rat 128
-            { "gold" , End } |-> 0
-            { "gold" , Flip "gold" } |-> 0
+            { "gold" , "Alice" } |-> wad ( 0 )
+            { "gold" , "Bobby" } |-> wad ( 255 /Rat 128 )
+            { "gold" , End } |-> wad ( 0 )
+            { "gold" , Flip "gold" } |-> wad ( 0 )
           </vat-gem>
           <vat-dai>
-            "Alice" |-> 65 /Rat 8
-            "Bobby" |-> 10
-            End |-> 0
-            Flap |-> 0
-            Pot |-> 0
-            Vow |-> 15 /Rat 8
+            "Alice" |-> rad ( 65 /Rat 8 )
+            "Bobby" |-> rad ( 10 )
+            End |-> rad ( 0 )
+            Flap |-> rad ( 0 )
+            Pot |-> rad ( 0 )
+            Vow |-> rad ( 15 /Rat 8 )
           </vat-dai>
           <vat-sin>
-            "Alice" |-> 0
-            "Bobby" |-> 0
-            End |-> 0
-            Flap |-> 0
-            Pot |-> 0
-            Vow |-> 0
+            "Alice" |-> rad ( 0 )
+            "Bobby" |-> rad ( 0 )
+            End |-> rad ( 0 )
+            Flap |-> rad ( 0 )
+            Pot |-> rad ( 0 )
+            Vow |-> rad ( 0 )
           </vat-sin>
           <vat-debt>
-            20
+            rad ( 20 )
           </vat-debt>
           <vat-vice>
-            0
+            rad ( 0 )
           </vat-vice>
           <vat-Line>
-            1000000000000
+            rad ( 1000000000000 )
           </vat-Line>
           <vat-live>
             false
@@ -375,25 +375,25 @@
             .Map
           </vow-sins>
           <vow-sin>
-            0
+            rad ( 0 )
           </vow-sin>
           <vow-ash>
-            0
+            rad ( 0 )
           </vow-ash>
           <vow-wait>
             0
           </vow-wait>
           <vow-dump>
-            30
+            wad ( 30 )
           </vow-dump>
           <vow-sump>
-            50
+            rad ( 50 )
           </vow-sump>
           <vow-bump>
-            1000000000
+            rad ( 1000000000 )
           </vow-bump>
           <vow-hump>
-            0
+            rad ( 0 )
           </vow-hump>
           <vow-live>
             false
@@ -403,863 +403,863 @@
     </kmcd>
     <processed-events>
       ListItem ( LogNote ( ADMIN , Vat . rely Pot ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . rely End ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . rely Spot ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Pot . rely End ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vow . rely Pot ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vow . rely End ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Cat . rely End ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Flap . rely Vow ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Flop . rely Vow ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser Vow ) )
-      ListItem ( Measure ( 0 , Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , Vow |-> 0 , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , Vow |-> rad ( 0 ) , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser Pot ) )
-      ListItem ( Measure ( 0 , Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , Pot |-> 0
-      Vow |-> 0 , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser Flap ) )
-      ListItem ( Measure ( 0 , Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , GemJoin "MKR" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , GemJoin "MKR" |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , GemJoin "MKR" |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Vow ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Flap ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Pot . file vow-file Vow ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( Vow , Vat . hope Flap ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vat . file Line 1000000000000 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vow . file bump 1000000000 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vow . file hump 0 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vow . file sump 50 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vow . file dump 30 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vat . file Line rad ( 1000000000000 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vow . file bump rad ( 1000000000 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vow . file hump rad ( 0 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vow . file sump rad ( 50 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vow . file dump wad ( 30 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Flop . file tau 3600 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , GemJoin "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . rely GemJoin "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" Flip "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Spot . init "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 3000000000 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Spot . file mat "gold" 1 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Spot . file par 1 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" wad ( 3000000000 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Spot . file mat "gold" ray ( 1 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Spot . file par ray ( 1 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Flip "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Flip "gold" . rely End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . initGap "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initIlk "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ANYONE , Vat . file spot "gold" 3000000000 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vat . file line "gold" rad ( 1000000000000 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ANYONE , Vat . file spot "gold" ray ( 3000000000 ) ) )
       ListItem ( LogNote ( ANYONE , Spot . poke "gold" ) )
-      ListItem ( Poke ( "gold" , 3000000000 , 3000000000 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Poke ( "gold" , wad ( 3000000000 ) , ray ( 3000000000 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Alice" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Bobby" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Alice" 20 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Bobby" 20 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Alice" wad ( 20 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Bobby" wad ( 20 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Alice" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Bobby" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Pot . initUser "Alice" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Pot . initUser "Bobby" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser "Alice" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Alice" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Alice" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser "Bobby" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Bobby" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Bobby" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Alice" , Vat . hope Pot ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Alice" , Vat . hope Flip "gold" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Alice" , Vat . hope End ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Alice" , Vat . hope Flop ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope Pot ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope Flip "gold" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope End ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope Flop ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( "Alice" , Vat . slip "gold" "Alice" 10 ) )
-      ListItem ( LogNote ( "Alice" , Gem "gold" . transferFrom "Alice" GemJoin "gold" 10 ) )
-      ListItem ( LogNote ( "Alice" , GemJoin "gold" . join "Alice" 10 ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 10 ) )
-      ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 10 ) )
-      ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 10 ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( "Alice" , Vat . frob "gold" "Alice" "Alice" "Alice" 10 10 ) )
-      ListItem ( Measure ( 10 , "Alice" |-> 10
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 10 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( "Alice" , Vat . slip "gold" "Alice" wad ( 10 ) ) )
+      ListItem ( LogNote ( "Alice" , Gem "gold" . transferFrom "Alice" GemJoin "gold" wad ( 10 ) ) )
+      ListItem ( LogNote ( "Alice" , GemJoin "gold" . join "Alice" wad ( 10 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" wad ( 10 ) ) )
+      ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" wad ( 10 ) ) )
+      ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" wad ( 10 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( "Alice" , Vat . frob "gold" "Alice" "Alice" "Alice" wad ( 10 ) wad ( 10 ) ) )
+      ListItem ( Measure ( rad ( 10 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 10 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" wad ( 10 ) wad ( 10 ) ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( GenStep ( b"b0" , transact "Alice" Vat . move "Alice" Vow 15 /Rat 8 ) )
-      ListItem ( LogNote ( "Alice" , Vat . move "Alice" Vow 15 /Rat 8 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 65 /Rat 8
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 15 /Rat 8 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 65 /Rat 8
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 15 /Rat 8 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( GenStep ( b"b3" , transact "Bobby" GemJoin "gold" . join "Bobby" 255 /Rat 128 ) )
-      ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 255 /Rat 128 ) )
-      ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 255 /Rat 128 ) )
-      ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 255 /Rat 128 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 65 /Rat 8
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 15 /Rat 8 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 65 /Rat 8
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 15 /Rat 8 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( GenStep ( b"b0" , transact "Alice" Vat . move "Alice" Vow rad ( 15 /Rat 8 ) ) )
+      ListItem ( LogNote ( "Alice" , Vat . move "Alice" Vow rad ( 15 /Rat 8 ) ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 65 /Rat 8 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 15 /Rat 8 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 65 /Rat 8 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 15 /Rat 8 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( GenStep ( b"b3" , transact "Bobby" GemJoin "gold" . join "Bobby" wad ( 255 /Rat 128 ) ) )
+      ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" wad ( 255 /Rat 128 ) ) )
+      ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" wad ( 255 /Rat 128 ) ) )
+      ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" wad ( 255 /Rat 128 ) ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 65 /Rat 8 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 15 /Rat 8 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 65 /Rat 8 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 15 /Rat 8 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( GenStep ( b"b" , transact "Alice" Vat . hope Flap ) )
       ListItem ( LogNote ( "Alice" , Vat . hope Flap ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 65 /Rat 8
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 15 /Rat 8 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 65 /Rat 8
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 15 /Rat 8 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( GenStep ( b"b0Z" , transact "Alice" Flap . kick 195 /Rat 128 0 ) )
-      ListItem ( Exception ( Flap . kick 195 /Rat 128 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 65 /Rat 8 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 15 /Rat 8 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 65 /Rat 8 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 15 /Rat 8 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( GenStep ( b"b0Z" , transact "Alice" Flap . kick rad ( 195 /Rat 128 ) wad ( 0 ) ) )
+      ListItem ( Exception ( Flap . kick rad ( 195 /Rat 128 ) wad ( 0 ) ) )
       ListItem ( GenStep ( b"b" , transact ADMIN End . cage ) )
       ListItem ( LogNote ( ADMIN , Vat . cage ) )
       ListItem ( LogNote ( ADMIN , Cat . cage ) )
-      ListItem ( LogNote ( Vow , Vat . move Flap Vow 0 ) )
-      ListItem ( LogNote ( End , Flap . cage 0 ) )
+      ListItem ( LogNote ( Vow , Vat . move Flap Vow rad ( 0 ) ) )
+      ListItem ( LogNote ( End , Flap . cage rad ( 0 ) ) )
       ListItem ( LogNote ( End , Flop . cage ) )
-      ListItem ( LogNote ( End , Vat . heal 0 ) )
+      ListItem ( LogNote ( End , Vat . heal rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vow . cage ) )
       ListItem ( LogNote ( ADMIN , Pot . cage ) )
       ListItem ( LogNote ( ADMIN , End . cage ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 65 /Rat 8
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 15 /Rat 8 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 65 /Rat 8
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 15 /Rat 8 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 65 /Rat 8 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 15 /Rat 8 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 65 /Rat 8 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 15 /Rat 8 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( GenStepFailed ( b"b" , GenFlapYank ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 65 /Rat 8
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 15 /Rat 8 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 65 /Rat 8
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 15 /Rat 8 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 65 /Rat 8 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 15 /Rat 8 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 65 /Rat 8 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 15 /Rat 8 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
     </processed-events>
     <properties>
       "Debt Constant After Thaw" |-> debtConstantAfterThaw
       "Flap Dai Consistency" |-> flapDaiConsistencyEnd
       "Flap MKR Consistency" |-> flapMkrConsistency
-      "Flop Block Check" |-> flopBlockCheck ( 0 , 0 )
+      "Flop Block Check" |-> flopBlockCheck ( rad ( 0 ) , 0 )
       "Pot Interest Accumulation After End" |-> potEndInterestEnd
-      "PotChi PotPie VatPot" |-> potChiPieDai ( 0 , 0 )
+      "PotChi PotPie VatPot" |-> potChiPieDai ( rad ( 0 ) , wad ( 0 ) )
       "Total Backed Debt Consistency" |-> totalBackedDebtConsistency
-      "Total Bound on Debt" |-> totalDebtBoundedEnd ( 20 )
+      "Total Bound on Debt" |-> totalDebtBoundedEnd ( rad ( 20 ) )
       "Unauthorized Flap Kick" |-> unAuthFlapKick
       "Unauthorized Flip Kick" |-> unAuthFlipKick
       "Zero-Time Pot Interest Accumulation" |-> zeroTimePotInterest

--- a/tests/attacks/lucash-flip-end.mcd.expected
+++ b/tests/attacks/lucash-flip-end.mcd.expected
@@ -50,7 +50,7 @@
             .Set
           </dai-wards>
           <dai-totalSupply>
-            0
+            wad ( 0 )
           </dai-totalSupply>
           <dai-account-id>
             0
@@ -83,27 +83,27 @@
               0
             </end-wait>
             <end-debt>
-              20
+              rad ( 20 )
             </end-debt>
             <end-tag>
-              "gold" |-> 1 /Rat 3000000000
+              "gold" |-> ray ( 1 /Rat 3000000000 )
             </end-tag>
             <end-gap>
-              "gold" |-> 0
+              "gold" |-> wad ( 0 )
             </end-gap>
             <end-art>
-              "gold" |-> 20
+              "gold" |-> wad ( 20 )
             </end-art>
             <end-fix>
-              "gold" |-> 1 /Rat 3000000000
+              "gold" |-> ray ( 1 /Rat 3000000000 )
             </end-fix>
             <end-bag>
-              "Alice" |-> 0
-              "Bobby" |-> 0
+              "Alice" |-> wad ( 0 )
+              "Bobby" |-> wad ( 0 )
             </end-bag>
             <end-out>
-              { "gold" , "Alice" } |-> 0
-              { "gold" , "Bobby" } |-> 0
+              { "gold" , "Alice" } |-> wad ( 0 )
+              { "gold" , "Bobby" } |-> wad ( 0 )
             </end-out>
           </end>
         </end-state>
@@ -121,7 +121,7 @@
             false
           </flap-live>
           <flap-beg>
-            21 /Rat 20
+            wad ( 21 /Rat 20 )
           </flap-beg>
           <flap-ttl>
             10800
@@ -142,7 +142,7 @@
               .Map
             </flip-bids>
             <flip-beg>
-              21 /Rat 20
+              wad ( 21 /Rat 20 )
             </flip-beg>
             <flip-ttl>
               10800
@@ -169,10 +169,10 @@
             false
           </flop-live>
           <flop-beg>
-            21 /Rat 20
+            wad ( 21 /Rat 20 )
           </flop-beg>
           <flop-pad>
-            3 /Rat 2
+            wad ( 3 /Rat 2 )
           </flop-pad>
           <flop-ttl>
             10800
@@ -193,11 +193,11 @@
               .Set
             </gem-wards>
             <gem-balances>
-              "Alice" |-> 0
-              "Bobby" |-> 0
-              Flap |-> 0
-              GemJoin "MKR" |-> 0
-              Vow |-> 0
+              "Alice" |-> wad ( 0 )
+              "Bobby" |-> wad ( 0 )
+              Flap |-> wad ( 0 )
+              GemJoin "MKR" |-> wad ( 0 )
+              Vow |-> wad ( 0 )
             </gem-balances>
           </gem> <gem>
             <gem-id>
@@ -207,9 +207,9 @@
               .Set
             </gem-wards>
             <gem-balances>
-              "Alice" |-> 10
-              "Bobby" |-> 9
-              GemJoin "gold" |-> 21
+              "Alice" |-> wad ( 10 )
+              "Bobby" |-> wad ( 9 )
+              GemJoin "gold" |-> wad ( 21 )
             </gem-balances>
           </gem>
         </gems>
@@ -257,7 +257,7 @@
             0
           </jug-vow>
           <jug-base>
-            0
+            ray ( 0 )
           </jug-base>
         </jug>
         <pot>
@@ -265,17 +265,17 @@
             SetItem ( End )
           </pot-wards>
           <pot-pies>
-            "Alice" |-> 0
-            "Bobby" |-> 0
+            "Alice" |-> wad ( 0 )
+            "Bobby" |-> wad ( 0 )
           </pot-pies>
           <pot-pie>
-            0
+            wad ( 0 )
           </pot-pie>
           <pot-dsr>
-            1
+            ray ( 1 )
           </pot-dsr>
           <pot-chi>
-            1
+            ray ( 1 )
           </pot-chi>
           <pot-vow>
             Vow
@@ -292,10 +292,10 @@
             .Set
           </spot-wards>
           <spot-ilks>
-            "gold" |-> SpotIlk ( 3000000000 , 1 )
+            "gold" |-> SpotIlk ( wad ( 3000000000 ) , ray ( 1 ) )
           </spot-ilks>
           <spot-par>
-            1
+            ray ( 1 )
           </spot-par>
           <spot-live>
             true
@@ -323,43 +323,43 @@
             Vow |-> SetItem ( Flap )
           </vat-can>
           <vat-ilks>
-            "gold" |-> Ilk ( 20 , 1 , 3000000000 , 1000000000000 , 0 )
+            "gold" |-> Ilk ( wad ( 20 ) , ray ( 1 ) , ray ( 3000000000 ) , rad ( 1000000000000 ) , rad ( 0 ) )
           </vat-ilks>
           <vat-urns>
-            { "gold" , "Alice" } |-> Urn ( 10 , 10 )
-            { "gold" , "Bobby" } |-> Urn ( 10 , 10 )
-            { "gold" , End } |-> Urn ( 0 , 0 )
+            { "gold" , "Alice" } |-> Urn ( wad ( 10 ) , wad ( 10 ) )
+            { "gold" , "Bobby" } |-> Urn ( wad ( 10 ) , wad ( 10 ) )
+            { "gold" , End } |-> Urn ( wad ( 0 ) , wad ( 0 ) )
           </vat-urns>
           <vat-gem>
-            { "gold" , "Alice" } |-> 0
-            { "gold" , "Bobby" } |-> 1
-            { "gold" , End } |-> 0
-            { "gold" , Flip "gold" } |-> 0
+            { "gold" , "Alice" } |-> wad ( 0 )
+            { "gold" , "Bobby" } |-> wad ( 1 )
+            { "gold" , End } |-> wad ( 0 )
+            { "gold" , Flip "gold" } |-> wad ( 0 )
           </vat-gem>
           <vat-dai>
-            "Alice" |-> 10
-            "Bobby" |-> 10
-            End |-> 0
-            Flap |-> 0
-            Pot |-> 0
-            Vow |-> 0
+            "Alice" |-> rad ( 10 )
+            "Bobby" |-> rad ( 10 )
+            End |-> rad ( 0 )
+            Flap |-> rad ( 0 )
+            Pot |-> rad ( 0 )
+            Vow |-> rad ( 0 )
           </vat-dai>
           <vat-sin>
-            "Alice" |-> 0
-            "Bobby" |-> 0
-            End |-> 0
-            Flap |-> 0
-            Pot |-> 0
-            Vow |-> 0
+            "Alice" |-> rad ( 0 )
+            "Bobby" |-> rad ( 0 )
+            End |-> rad ( 0 )
+            Flap |-> rad ( 0 )
+            Pot |-> rad ( 0 )
+            Vow |-> rad ( 0 )
           </vat-sin>
           <vat-debt>
-            20
+            rad ( 20 )
           </vat-debt>
           <vat-vice>
-            0
+            rad ( 0 )
           </vat-vice>
           <vat-Line>
-            1000000000000
+            rad ( 1000000000000 )
           </vat-Line>
           <vat-live>
             false
@@ -374,25 +374,25 @@
             .Map
           </vow-sins>
           <vow-sin>
-            0
+            rad ( 0 )
           </vow-sin>
           <vow-ash>
-            0
+            rad ( 0 )
           </vow-ash>
           <vow-wait>
             0
           </vow-wait>
           <vow-dump>
-            30
+            wad ( 30 )
           </vow-dump>
           <vow-sump>
-            50
+            rad ( 50 )
           </vow-sump>
           <vow-bump>
-            1000000000
+            rad ( 1000000000 )
           </vow-bump>
           <vow-hump>
-            0
+            rad ( 0 )
           </vow-hump>
           <vow-live>
             false
@@ -402,890 +402,890 @@
     </kmcd>
     <processed-events>
       ListItem ( LogNote ( ADMIN , Vat . rely Pot ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . rely End ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . rely Spot ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Pot . rely End ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vow . rely Pot ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vow . rely End ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Cat . rely End ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Flap . rely Vow ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Flop . rely Vow ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser Vow ) )
-      ListItem ( Measure ( 0 , Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , Vow |-> 0 , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , Vow |-> rad ( 0 ) , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser Pot ) )
-      ListItem ( Measure ( 0 , Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , Pot |-> 0
-      Vow |-> 0 , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser Flap ) )
-      ListItem ( Measure ( 0 , Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , GemJoin "MKR" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , GemJoin "MKR" |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , GemJoin "MKR" |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Vow ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Flap ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Pot . file vow-file Vow ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( Vow , Vat . hope Flap ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vat . file Line 1000000000000 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vow . file bump 1000000000 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vow . file hump 0 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vow . file sump 50 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vow . file dump 30 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vat . file Line rad ( 1000000000000 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vow . file bump rad ( 1000000000 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vow . file hump rad ( 0 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vow . file sump rad ( 50 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vow . file dump wad ( 30 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Flop . file tau 3600 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , GemJoin "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . rely GemJoin "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" Flip "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Spot . init "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 3000000000 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Spot . file mat "gold" 1 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Spot . file par 1 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" wad ( 3000000000 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Spot . file mat "gold" ray ( 1 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Spot . file par ray ( 1 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Flip "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Flip "gold" . rely End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . initGap "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initIlk "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ANYONE , Vat . file spot "gold" 3000000000 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vat . file line "gold" rad ( 1000000000000 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ANYONE , Vat . file spot "gold" ray ( 3000000000 ) ) )
       ListItem ( LogNote ( ANYONE , Spot . poke "gold" ) )
-      ListItem ( Poke ( "gold" , 3000000000 , 3000000000 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Poke ( "gold" , wad ( 3000000000 ) , ray ( 3000000000 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Alice" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Bobby" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Alice" 20 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Bobby" 20 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Alice" wad ( 20 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Bobby" wad ( 20 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Alice" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Bobby" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Pot . initUser "Alice" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Pot . initUser "Bobby" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser "Alice" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Alice" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Alice" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser "Bobby" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Bobby" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Bobby" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Alice" , Vat . hope Pot ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Alice" , Vat . hope Flip "gold" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Alice" , Vat . hope End ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Alice" , Vat . hope Flop ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope Pot ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope Flip "gold" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope End ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope Flop ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( "Alice" , Vat . slip "gold" "Alice" 10 ) )
-      ListItem ( LogNote ( "Alice" , Gem "gold" . transferFrom "Alice" GemJoin "gold" 10 ) )
-      ListItem ( LogNote ( "Alice" , GemJoin "gold" . join "Alice" 10 ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 10 ) )
-      ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 10 ) )
-      ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 10 ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( "Alice" , Vat . frob "gold" "Alice" "Alice" "Alice" 10 10 ) )
-      ListItem ( Measure ( 10 , "Alice" |-> 10
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 10 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( "Alice" , Vat . slip "gold" "Alice" wad ( 10 ) ) )
+      ListItem ( LogNote ( "Alice" , Gem "gold" . transferFrom "Alice" GemJoin "gold" wad ( 10 ) ) )
+      ListItem ( LogNote ( "Alice" , GemJoin "gold" . join "Alice" wad ( 10 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" wad ( 10 ) ) )
+      ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" wad ( 10 ) ) )
+      ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" wad ( 10 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( "Alice" , Vat . frob "gold" "Alice" "Alice" "Alice" wad ( 10 ) wad ( 10 ) ) )
+      ListItem ( Measure ( rad ( 10 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 10 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" wad ( 10 ) wad ( 10 ) ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 1 ) )
-      ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 1 ) )
-      ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 1 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" wad ( 1 ) ) )
+      ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" wad ( 1 ) ) )
+      ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" wad ( 1 ) ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . cage ) )
       ListItem ( LogNote ( ADMIN , Cat . cage ) )
-      ListItem ( LogNote ( Vow , Vat . move Flap Vow 0 ) )
-      ListItem ( LogNote ( End , Flap . cage 0 ) )
+      ListItem ( LogNote ( Vow , Vat . move Flap Vow rad ( 0 ) ) )
+      ListItem ( LogNote ( End , Flap . cage rad ( 0 ) ) )
       ListItem ( LogNote ( End , Flop . cage ) )
-      ListItem ( LogNote ( End , Vat . heal 0 ) )
+      ListItem ( LogNote ( End , Vat . heal rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vow . cage ) )
       ListItem ( LogNote ( ADMIN , Pot . cage ) )
       ListItem ( LogNote ( ADMIN , End . cage ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . cage "gold" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( TimeStep ( 3600 , 3600 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . thaw ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 20 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 20 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . flow "gold" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 20 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( Exception ( Flip "gold" . kick End "Bobby" 1001000000000 1 1000000000000 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 20 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( Exception ( Flip "gold" . kick End "Bobby" rad ( 1001000000000 ) wad ( 1 ) rad ( 1000000000000 ) ) )
       ListItem ( Exception ( End . skip "gold" 1 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 20 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 20 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
     </processed-events>
     <properties>
       "Debt Constant After Thaw" |-> debtConstantAfterThaw
       "Flap Dai Consistency" |-> flapDaiConsistencyEnd
       "Flap MKR Consistency" |-> flapMkrConsistency
-      "Flop Block Check" |-> flopBlockCheck ( 0 , 0 )
+      "Flop Block Check" |-> flopBlockCheck ( rad ( 0 ) , 0 )
       "Pot Interest Accumulation After End" |-> potEndInterestEnd
-      "PotChi PotPie VatPot" |-> potChiPieDai ( 0 , 0 )
+      "PotChi PotPie VatPot" |-> potChiPieDai ( rad ( 0 ) , wad ( 0 ) )
       "Total Backed Debt Consistency" |-> totalBackedDebtConsistency
-      "Total Bound on Debt" |-> totalDebtBoundedEnd ( 20 )
+      "Total Bound on Debt" |-> totalDebtBoundedEnd ( rad ( 20 ) )
       "Unauthorized Flap Kick" |-> unAuthFlapKick
       "Unauthorized Flip Kick" |-> unAuthFlipKick
       "Zero-Time Pot Interest Accumulation" |-> zeroTimePotInterestEnd

--- a/tests/attacks/lucash-flip-end.random.mcd.expected
+++ b/tests/attacks/lucash-flip-end.random.mcd.expected
@@ -50,7 +50,7 @@
             .Set
           </dai-wards>
           <dai-totalSupply>
-            0
+            wad ( 0 )
           </dai-totalSupply>
           <dai-account-id>
             0
@@ -83,27 +83,27 @@
               0
             </end-wait>
             <end-debt>
-              20
+              rad ( 20 )
             </end-debt>
             <end-tag>
-              "gold" |-> 1 /Rat 3000000000
+              "gold" |-> ray ( 1 /Rat 3000000000 )
             </end-tag>
             <end-gap>
-              "gold" |-> 0
+              "gold" |-> wad ( 0 )
             </end-gap>
             <end-art>
-              "gold" |-> 20
+              "gold" |-> wad ( 20 )
             </end-art>
             <end-fix>
-              "gold" |-> 1 /Rat 3000000000
+              "gold" |-> ray ( 1 /Rat 3000000000 )
             </end-fix>
             <end-bag>
-              "Alice" |-> 0
-              "Bobby" |-> 0
+              "Alice" |-> wad ( 0 )
+              "Bobby" |-> wad ( 0 )
             </end-bag>
             <end-out>
-              { "gold" , "Alice" } |-> 0
-              { "gold" , "Bobby" } |-> 0
+              { "gold" , "Alice" } |-> wad ( 0 )
+              { "gold" , "Bobby" } |-> wad ( 0 )
             </end-out>
           </end>
         </end-state>
@@ -121,7 +121,7 @@
             false
           </flap-live>
           <flap-beg>
-            21 /Rat 20
+            wad ( 21 /Rat 20 )
           </flap-beg>
           <flap-ttl>
             10800
@@ -142,7 +142,7 @@
               .Map
             </flip-bids>
             <flip-beg>
-              21 /Rat 20
+              wad ( 21 /Rat 20 )
             </flip-beg>
             <flip-ttl>
               10800
@@ -169,10 +169,10 @@
             false
           </flop-live>
           <flop-beg>
-            21 /Rat 20
+            wad ( 21 /Rat 20 )
           </flop-beg>
           <flop-pad>
-            3 /Rat 2
+            wad ( 3 /Rat 2 )
           </flop-pad>
           <flop-ttl>
             10800
@@ -193,11 +193,11 @@
               .Set
             </gem-wards>
             <gem-balances>
-              "Alice" |-> 0
-              "Bobby" |-> 0
-              Flap |-> 0
-              GemJoin "MKR" |-> 0
-              Vow |-> 0
+              "Alice" |-> wad ( 0 )
+              "Bobby" |-> wad ( 0 )
+              Flap |-> wad ( 0 )
+              GemJoin "MKR" |-> wad ( 0 )
+              Vow |-> wad ( 0 )
             </gem-balances>
           </gem> <gem>
             <gem-id>
@@ -207,9 +207,9 @@
               .Set
             </gem-wards>
             <gem-balances>
-              "Alice" |-> 10
-              "Bobby" |-> 795 /Rat 128
-              GemJoin "gold" |-> 3045 /Rat 128
+              "Alice" |-> wad ( 10 )
+              "Bobby" |-> wad ( 795 /Rat 128 )
+              GemJoin "gold" |-> wad ( 3045 /Rat 128 )
             </gem-balances>
           </gem>
         </gems>
@@ -257,7 +257,7 @@
             0
           </jug-vow>
           <jug-base>
-            0
+            ray ( 0 )
           </jug-base>
         </jug>
         <pot>
@@ -265,17 +265,17 @@
             SetItem ( End )
           </pot-wards>
           <pot-pies>
-            "Alice" |-> 0
-            "Bobby" |-> 0
+            "Alice" |-> wad ( 0 )
+            "Bobby" |-> wad ( 0 )
           </pot-pies>
           <pot-pie>
-            0
+            wad ( 0 )
           </pot-pie>
           <pot-dsr>
-            1
+            ray ( 1 )
           </pot-dsr>
           <pot-chi>
-            1
+            ray ( 1 )
           </pot-chi>
           <pot-vow>
             Vow
@@ -292,10 +292,10 @@
             .Set
           </spot-wards>
           <spot-ilks>
-            "gold" |-> SpotIlk ( 3000000000 , 1 )
+            "gold" |-> SpotIlk ( wad ( 3000000000 ) , ray ( 1 ) )
           </spot-ilks>
           <spot-par>
-            1
+            ray ( 1 )
           </spot-par>
           <spot-live>
             true
@@ -323,43 +323,43 @@
             Vow |-> SetItem ( Flap )
           </vat-can>
           <vat-ilks>
-            "gold" |-> Ilk ( 20 , 1 , 3000000000 , 1000000000000 , 0 )
+            "gold" |-> Ilk ( wad ( 20 ) , ray ( 1 ) , ray ( 3000000000 ) , rad ( 1000000000000 ) , rad ( 0 ) )
           </vat-ilks>
           <vat-urns>
-            { "gold" , "Alice" } |-> Urn ( 10 , 10 )
-            { "gold" , "Bobby" } |-> Urn ( 10 , 10 )
-            { "gold" , End } |-> Urn ( 0 , 0 )
+            { "gold" , "Alice" } |-> Urn ( wad ( 10 ) , wad ( 10 ) )
+            { "gold" , "Bobby" } |-> Urn ( wad ( 10 ) , wad ( 10 ) )
+            { "gold" , End } |-> Urn ( wad ( 0 ) , wad ( 0 ) )
           </vat-urns>
           <vat-gem>
-            { "gold" , "Alice" } |-> 0
-            { "gold" , "Bobby" } |-> 485 /Rat 128
-            { "gold" , End } |-> 0
-            { "gold" , Flip "gold" } |-> 0
+            { "gold" , "Alice" } |-> wad ( 0 )
+            { "gold" , "Bobby" } |-> wad ( 485 /Rat 128 )
+            { "gold" , End } |-> wad ( 0 )
+            { "gold" , Flip "gold" } |-> wad ( 0 )
           </vat-gem>
           <vat-dai>
-            "Alice" |-> 10
-            "Bobby" |-> 10
-            End |-> 0
-            Flap |-> 0
-            Pot |-> 0
-            Vow |-> 0
+            "Alice" |-> rad ( 10 )
+            "Bobby" |-> rad ( 10 )
+            End |-> rad ( 0 )
+            Flap |-> rad ( 0 )
+            Pot |-> rad ( 0 )
+            Vow |-> rad ( 0 )
           </vat-dai>
           <vat-sin>
-            "Alice" |-> 0
-            "Bobby" |-> 0
-            End |-> 0
-            Flap |-> 0
-            Pot |-> 0
-            Vow |-> 0
+            "Alice" |-> rad ( 0 )
+            "Bobby" |-> rad ( 0 )
+            End |-> rad ( 0 )
+            Flap |-> rad ( 0 )
+            Pot |-> rad ( 0 )
+            Vow |-> rad ( 0 )
           </vat-sin>
           <vat-debt>
-            20
+            rad ( 20 )
           </vat-debt>
           <vat-vice>
-            0
+            rad ( 0 )
           </vat-vice>
           <vat-Line>
-            1000000000000
+            rad ( 1000000000000 )
           </vat-Line>
           <vat-live>
             false
@@ -374,25 +374,25 @@
             .Map
           </vow-sins>
           <vow-sin>
-            0
+            rad ( 0 )
           </vow-sin>
           <vow-ash>
-            0
+            rad ( 0 )
           </vow-ash>
           <vow-wait>
             0
           </vow-wait>
           <vow-dump>
-            30
+            wad ( 30 )
           </vow-dump>
           <vow-sump>
-            50
+            rad ( 50 )
           </vow-sump>
           <vow-bump>
-            1000000000
+            rad ( 1000000000 )
           </vow-bump>
           <vow-hump>
-            0
+            rad ( 0 )
           </vow-hump>
           <vow-live>
             false
@@ -402,897 +402,897 @@
     </kmcd>
     <processed-events>
       ListItem ( LogNote ( ADMIN , Vat . rely Pot ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . rely End ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . rely Spot ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Pot . rely End ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vow . rely Pot ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vow . rely End ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Cat . rely End ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Flap . rely Vow ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Flop . rely Vow ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser Vow ) )
-      ListItem ( Measure ( 0 , Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , Vow |-> 0 , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , Vow |-> rad ( 0 ) , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser Pot ) )
-      ListItem ( Measure ( 0 , Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , Pot |-> 0
-      Vow |-> 0 , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser Flap ) )
-      ListItem ( Measure ( 0 , Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , GemJoin "MKR" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , GemJoin "MKR" |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , GemJoin "MKR" |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Vow ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Flap ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Pot . file vow-file Vow ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( Vow , Vat . hope Flap ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vat . file Line 1000000000000 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vow . file bump 1000000000 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vow . file hump 0 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vow . file sump 50 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vow . file dump 30 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vat . file Line rad ( 1000000000000 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vow . file bump rad ( 1000000000 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vow . file hump rad ( 0 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vow . file sump rad ( 50 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vow . file dump wad ( 30 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Flop . file tau 3600 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , GemJoin "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . rely GemJoin "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" Flip "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Spot . init "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 3000000000 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Spot . file mat "gold" 1 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Spot . file par 1 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" wad ( 3000000000 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Spot . file mat "gold" ray ( 1 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Spot . file par ray ( 1 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Flip "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Flip "gold" . rely End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . initGap "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initIlk "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ANYONE , Vat . file spot "gold" 3000000000 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vat . file line "gold" rad ( 1000000000000 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ANYONE , Vat . file spot "gold" ray ( 3000000000 ) ) )
       ListItem ( LogNote ( ANYONE , Spot . poke "gold" ) )
-      ListItem ( Poke ( "gold" , 3000000000 , 3000000000 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Poke ( "gold" , wad ( 3000000000 ) , ray ( 3000000000 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Alice" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Bobby" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Alice" 20 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Bobby" 20 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Alice" wad ( 20 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Bobby" wad ( 20 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Alice" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Bobby" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Pot . initUser "Alice" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Pot . initUser "Bobby" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser "Alice" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Alice" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Alice" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser "Bobby" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Bobby" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Bobby" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Alice" , Vat . hope Pot ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Alice" , Vat . hope Flip "gold" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Alice" , Vat . hope End ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Alice" , Vat . hope Flop ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope Pot ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope Flip "gold" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope End ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope Flop ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( "Alice" , Vat . slip "gold" "Alice" 10 ) )
-      ListItem ( LogNote ( "Alice" , Gem "gold" . transferFrom "Alice" GemJoin "gold" 10 ) )
-      ListItem ( LogNote ( "Alice" , GemJoin "gold" . join "Alice" 10 ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 10 ) )
-      ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 10 ) )
-      ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 10 ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( "Alice" , Vat . frob "gold" "Alice" "Alice" "Alice" 10 10 ) )
-      ListItem ( Measure ( 10 , "Alice" |-> 10
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 10 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( "Alice" , Vat . slip "gold" "Alice" wad ( 10 ) ) )
+      ListItem ( LogNote ( "Alice" , Gem "gold" . transferFrom "Alice" GemJoin "gold" wad ( 10 ) ) )
+      ListItem ( LogNote ( "Alice" , GemJoin "gold" . join "Alice" wad ( 10 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" wad ( 10 ) ) )
+      ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" wad ( 10 ) ) )
+      ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" wad ( 10 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( "Alice" , Vat . frob "gold" "Alice" "Alice" "Alice" wad ( 10 ) wad ( 10 ) ) )
+      ListItem ( Measure ( rad ( 10 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 10 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" wad ( 10 ) wad ( 10 ) ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( GenStep ( b"ca" , transact "Bobby" GemJoin "gold" . join "Bobby" 485 /Rat 128 ) )
-      ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 485 /Rat 128 ) )
-      ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 485 /Rat 128 ) )
-      ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 485 /Rat 128 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( GenStep ( b"ca" , transact "Bobby" GemJoin "gold" . join "Bobby" wad ( 485 /Rat 128 ) ) )
+      ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" wad ( 485 /Rat 128 ) ) )
+      ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" wad ( 485 /Rat 128 ) ) )
+      ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" wad ( 485 /Rat 128 ) ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( GenStep ( b"c" , transact ADMIN End . cage ) )
       ListItem ( LogNote ( ADMIN , Vat . cage ) )
       ListItem ( LogNote ( ADMIN , Cat . cage ) )
-      ListItem ( LogNote ( Vow , Vat . move Flap Vow 0 ) )
-      ListItem ( LogNote ( End , Flap . cage 0 ) )
+      ListItem ( LogNote ( Vow , Vat . move Flap Vow rad ( 0 ) ) )
+      ListItem ( LogNote ( End , Flap . cage rad ( 0 ) ) )
       ListItem ( LogNote ( End , Flop . cage ) )
-      ListItem ( LogNote ( End , Vat . heal 0 ) )
+      ListItem ( LogNote ( End , Vat . heal rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vow . cage ) )
       ListItem ( LogNote ( ADMIN , Pot . cage ) )
       ListItem ( LogNote ( ADMIN , End . cage ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( GenStep ( b"ca" , transact ANYONE End . cage "gold" ) )
       ListItem ( LogNote ( ANYONE , End . cage "gold" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( GenStep ( b"ca" , TimeStep 2 ) )
       ListItem ( TimeStep ( 2 , 2 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( GenStep ( b"c" , transact ANYONE End . thaw ) )
       ListItem ( LogNote ( ANYONE , End . thaw ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 20 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 20 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( GenStep ( b"ca" , transact ANYONE End . flow "gold" ) )
       ListItem ( LogNote ( ANYONE , End . flow "gold" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 20 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( GenStep ( b"caa" , transact "Bobby" Flip "gold" . kick End Flap 1000 47045 /Rat 32768 12125 /Rat 32 ) )
-      ListItem ( Exception ( Flip "gold" . kick End Flap 1000 47045 /Rat 32768 12125 /Rat 32 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 20 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( GenStep ( b"caa" , transact "Bobby" Flip "gold" . kick End Flap rad ( 1000 ) wad ( 47045 /Rat 32768 ) rad ( 12125 /Rat 32 ) ) )
+      ListItem ( Exception ( Flip "gold" . kick End Flap rad ( 1000 ) wad ( 47045 /Rat 32768 ) rad ( 12125 /Rat 32 ) ) )
       ListItem ( GenStepFailed ( b"c" , GenEndSkip "gold" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 20 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 20 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
     </processed-events>
     <properties>
       "Debt Constant After Thaw" |-> debtConstantAfterThaw
       "Flap Dai Consistency" |-> flapDaiConsistencyEnd
       "Flap MKR Consistency" |-> flapMkrConsistency
-      "Flop Block Check" |-> flopBlockCheck ( 0 , 0 )
+      "Flop Block Check" |-> flopBlockCheck ( rad ( 0 ) , 0 )
       "Pot Interest Accumulation After End" |-> potEndInterestEnd
-      "PotChi PotPie VatPot" |-> potChiPieDai ( 0 , 0 )
+      "PotChi PotPie VatPot" |-> potChiPieDai ( rad ( 0 ) , wad ( 0 ) )
       "Total Backed Debt Consistency" |-> totalBackedDebtConsistency
-      "Total Bound on Debt" |-> totalDebtBoundedEnd ( 20 )
+      "Total Bound on Debt" |-> totalDebtBoundedEnd ( rad ( 20 ) )
       "Unauthorized Flap Kick" |-> unAuthFlapKick
       "Unauthorized Flip Kick" |-> unAuthFlipKick
       "Zero-Time Pot Interest Accumulation" |-> zeroTimePotInterestEnd

--- a/tests/attacks/lucash-pot-end.mcd.expected
+++ b/tests/attacks/lucash-pot-end.mcd.expected
@@ -50,7 +50,7 @@
             .Set
           </dai-wards>
           <dai-totalSupply>
-            0
+            wad ( 0 )
           </dai-totalSupply>
           <dai-account-id>
             0
@@ -83,27 +83,27 @@
               0
             </end-wait>
             <end-debt>
-              20
+              rad ( 20 )
             </end-debt>
             <end-tag>
-              "gold" |-> 1 /Rat 3000000000
+              "gold" |-> ray ( 1 /Rat 3000000000 )
             </end-tag>
             <end-gap>
-              "gold" |-> 0
+              "gold" |-> wad ( 0 )
             </end-gap>
             <end-art>
-              "gold" |-> 20
+              "gold" |-> wad ( 20 )
             </end-art>
             <end-fix>
-              "gold" |-> 1 /Rat 3000000000
+              "gold" |-> ray ( 1 /Rat 3000000000 )
             </end-fix>
             <end-bag>
-              "Alice" |-> 0
-              "Bobby" |-> 0
+              "Alice" |-> wad ( 0 )
+              "Bobby" |-> wad ( 0 )
             </end-bag>
             <end-out>
-              { "gold" , "Alice" } |-> 0
-              { "gold" , "Bobby" } |-> 0
+              { "gold" , "Alice" } |-> wad ( 0 )
+              { "gold" , "Bobby" } |-> wad ( 0 )
             </end-out>
           </end>
         </end-state>
@@ -121,7 +121,7 @@
             false
           </flap-live>
           <flap-beg>
-            21 /Rat 20
+            wad ( 21 /Rat 20 )
           </flap-beg>
           <flap-ttl>
             10800
@@ -142,7 +142,7 @@
               .Map
             </flip-bids>
             <flip-beg>
-              21 /Rat 20
+              wad ( 21 /Rat 20 )
             </flip-beg>
             <flip-ttl>
               10800
@@ -169,10 +169,10 @@
             false
           </flop-live>
           <flop-beg>
-            21 /Rat 20
+            wad ( 21 /Rat 20 )
           </flop-beg>
           <flop-pad>
-            3 /Rat 2
+            wad ( 3 /Rat 2 )
           </flop-pad>
           <flop-ttl>
             10800
@@ -193,11 +193,11 @@
               .Set
             </gem-wards>
             <gem-balances>
-              "Alice" |-> 0
-              "Bobby" |-> 0
-              Flap |-> 0
-              GemJoin "MKR" |-> 0
-              Vow |-> 0
+              "Alice" |-> wad ( 0 )
+              "Bobby" |-> wad ( 0 )
+              Flap |-> wad ( 0 )
+              GemJoin "MKR" |-> wad ( 0 )
+              Vow |-> wad ( 0 )
             </gem-balances>
           </gem> <gem>
             <gem-id>
@@ -207,9 +207,9 @@
               .Set
             </gem-wards>
             <gem-balances>
-              "Alice" |-> 10
-              "Bobby" |-> 10
-              GemJoin "gold" |-> 20
+              "Alice" |-> wad ( 10 )
+              "Bobby" |-> wad ( 10 )
+              GemJoin "gold" |-> wad ( 20 )
             </gem-balances>
           </gem>
         </gems>
@@ -257,7 +257,7 @@
             0
           </jug-vow>
           <jug-base>
-            0
+            ray ( 0 )
           </jug-base>
         </jug>
         <pot>
@@ -265,17 +265,17 @@
             SetItem ( End )
           </pot-wards>
           <pot-pies>
-            "Alice" |-> 0
-            "Bobby" |-> 0
+            "Alice" |-> wad ( 0 )
+            "Bobby" |-> wad ( 0 )
           </pot-pies>
           <pot-pie>
-            0
+            wad ( 0 )
           </pot-pie>
           <pot-dsr>
-            1
+            ray ( 1 )
           </pot-dsr>
           <pot-chi>
-            1
+            ray ( 1 )
           </pot-chi>
           <pot-vow>
             Vow
@@ -292,10 +292,10 @@
             .Set
           </spot-wards>
           <spot-ilks>
-            "gold" |-> SpotIlk ( 3000000000 , 1 )
+            "gold" |-> SpotIlk ( wad ( 3000000000 ) , ray ( 1 ) )
           </spot-ilks>
           <spot-par>
-            1
+            ray ( 1 )
           </spot-par>
           <spot-live>
             true
@@ -323,43 +323,43 @@
             Vow |-> SetItem ( Flap )
           </vat-can>
           <vat-ilks>
-            "gold" |-> Ilk ( 0 , 1 , 3000000000 , 1000000000000 , 0 )
+            "gold" |-> Ilk ( wad ( 0 ) , ray ( 1 ) , ray ( 3000000000 ) , rad ( 1000000000000 ) , rad ( 0 ) )
           </vat-ilks>
           <vat-urns>
-            { "gold" , "Alice" } |-> Urn ( 2999999999 /Rat 300000000 , 0 )
-            { "gold" , "Bobby" } |-> Urn ( 2999999999 /Rat 300000000 , 0 )
-            { "gold" , End } |-> Urn ( 0 , 0 )
+            { "gold" , "Alice" } |-> Urn ( wad ( 2999999999 /Rat 300000000 ) , wad ( 0 ) )
+            { "gold" , "Bobby" } |-> Urn ( wad ( 2999999999 /Rat 300000000 ) , wad ( 0 ) )
+            { "gold" , End } |-> Urn ( wad ( 0 ) , wad ( 0 ) )
           </vat-urns>
           <vat-gem>
-            { "gold" , "Alice" } |-> 0
-            { "gold" , "Bobby" } |-> 0
-            { "gold" , End } |-> 1 /Rat 150000000
-            { "gold" , Flip "gold" } |-> 0
+            { "gold" , "Alice" } |-> wad ( 0 )
+            { "gold" , "Bobby" } |-> wad ( 0 )
+            { "gold" , End } |-> wad ( 1 /Rat 150000000 )
+            { "gold" , Flip "gold" } |-> wad ( 0 )
           </vat-gem>
           <vat-dai>
-            "Alice" |-> 10
-            "Bobby" |-> 10
-            End |-> 0
-            Flap |-> 0
-            Pot |-> 0
-            Vow |-> 0
+            "Alice" |-> rad ( 10 )
+            "Bobby" |-> rad ( 10 )
+            End |-> rad ( 0 )
+            Flap |-> rad ( 0 )
+            Pot |-> rad ( 0 )
+            Vow |-> rad ( 0 )
           </vat-dai>
           <vat-sin>
-            "Alice" |-> 0
-            "Bobby" |-> 0
-            End |-> 0
-            Flap |-> 0
-            Pot |-> 0
-            Vow |-> 20
+            "Alice" |-> rad ( 0 )
+            "Bobby" |-> rad ( 0 )
+            End |-> rad ( 0 )
+            Flap |-> rad ( 0 )
+            Pot |-> rad ( 0 )
+            Vow |-> rad ( 20 )
           </vat-sin>
           <vat-debt>
-            20
+            rad ( 20 )
           </vat-debt>
           <vat-vice>
-            20
+            rad ( 20 )
           </vat-vice>
           <vat-Line>
-            1000000000000
+            rad ( 1000000000000 )
           </vat-Line>
           <vat-live>
             false
@@ -374,25 +374,25 @@
             .Map
           </vow-sins>
           <vow-sin>
-            0
+            rad ( 0 )
           </vow-sin>
           <vow-ash>
-            0
+            rad ( 0 )
           </vow-ash>
           <vow-wait>
             0
           </vow-wait>
           <vow-dump>
-            30
+            wad ( 30 )
           </vow-dump>
           <vow-sump>
-            50
+            rad ( 50 )
           </vow-sump>
           <vow-bump>
-            1000000000
+            rad ( 1000000000 )
           </vow-bump>
           <vow-hump>
-            0
+            rad ( 0 )
           </vow-hump>
           <vow-live>
             false
@@ -402,956 +402,956 @@
     </kmcd>
     <processed-events>
       ListItem ( LogNote ( ADMIN , Vat . rely Pot ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . rely End ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . rely Spot ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Pot . rely End ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vow . rely Pot ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vow . rely End ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Cat . rely End ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Flap . rely Vow ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Flop . rely Vow ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser Vow ) )
-      ListItem ( Measure ( 0 , Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , Vow |-> 0 , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , Vow |-> rad ( 0 ) , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser Pot ) )
-      ListItem ( Measure ( 0 , Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , Pot |-> 0
-      Vow |-> 0 , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser Flap ) )
-      ListItem ( Measure ( 0 , Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , GemJoin "MKR" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , GemJoin "MKR" |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , GemJoin "MKR" |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Vow ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Flap ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Pot . file vow-file Vow ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( Vow , Vat . hope Flap ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vat . file Line 1000000000000 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vow . file bump 1000000000 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vow . file hump 0 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vow . file sump 50 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vow . file dump 30 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vat . file Line rad ( 1000000000000 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vow . file bump rad ( 1000000000 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vow . file hump rad ( 0 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vow . file sump rad ( 50 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vow . file dump wad ( 30 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Flop . file tau 3600 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , GemJoin "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . rely GemJoin "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" Flip "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Spot . init "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 3000000000 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Spot . file mat "gold" 1 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Spot . file par 1 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" wad ( 3000000000 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Spot . file mat "gold" ray ( 1 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Spot . file par ray ( 1 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Flip "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Flip "gold" . rely End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . initGap "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initIlk "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ANYONE , Vat . file spot "gold" 3000000000 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vat . file line "gold" rad ( 1000000000000 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ANYONE , Vat . file spot "gold" ray ( 3000000000 ) ) )
       ListItem ( LogNote ( ANYONE , Spot . poke "gold" ) )
-      ListItem ( Poke ( "gold" , 3000000000 , 3000000000 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Poke ( "gold" , wad ( 3000000000 ) , ray ( 3000000000 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Alice" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Bobby" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Alice" 20 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Bobby" 20 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Alice" wad ( 20 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Bobby" wad ( 20 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Alice" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Bobby" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Pot . initUser "Alice" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Pot . initUser "Bobby" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser "Alice" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Alice" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Alice" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser "Bobby" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Bobby" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Bobby" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Alice" , Vat . hope Pot ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Alice" , Vat . hope Flip "gold" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Alice" , Vat . hope End ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Alice" , Vat . hope Flop ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope Pot ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope Flip "gold" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope End ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope Flop ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( "Alice" , Vat . slip "gold" "Alice" 10 ) )
-      ListItem ( LogNote ( "Alice" , Gem "gold" . transferFrom "Alice" GemJoin "gold" 10 ) )
-      ListItem ( LogNote ( "Alice" , GemJoin "gold" . join "Alice" 10 ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 10 ) )
-      ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 10 ) )
-      ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 10 ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( "Alice" , Vat . frob "gold" "Alice" "Alice" "Alice" 10 10 ) )
-      ListItem ( Measure ( 10 , "Alice" |-> 10
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 10 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( "Alice" , Vat . slip "gold" "Alice" wad ( 10 ) ) )
+      ListItem ( LogNote ( "Alice" , Gem "gold" . transferFrom "Alice" GemJoin "gold" wad ( 10 ) ) )
+      ListItem ( LogNote ( "Alice" , GemJoin "gold" . join "Alice" wad ( 10 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" wad ( 10 ) ) )
+      ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" wad ( 10 ) ) )
+      ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" wad ( 10 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( "Alice" , Vat . frob "gold" "Alice" "Alice" "Alice" wad ( 10 ) wad ( 10 ) ) )
+      ListItem ( Measure ( rad ( 10 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 10 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" wad ( 10 ) wad ( 10 ) ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . cage ) )
       ListItem ( LogNote ( ADMIN , Cat . cage ) )
-      ListItem ( LogNote ( Vow , Vat . move Flap Vow 0 ) )
-      ListItem ( LogNote ( End , Flap . cage 0 ) )
+      ListItem ( LogNote ( Vow , Vat . move Flap Vow rad ( 0 ) ) )
+      ListItem ( LogNote ( End , Flap . cage rad ( 0 ) ) )
       ListItem ( LogNote ( End , Flop . cage ) )
-      ListItem ( LogNote ( End , Vat . heal 0 ) )
+      ListItem ( LogNote ( End , Vat . heal rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vow . cage ) )
       ListItem ( LogNote ( ADMIN , Pot . cage ) )
       ListItem ( LogNote ( ADMIN , End . cage ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . cage "gold" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vat . grab "gold" "Alice" End Vow -1 /Rat 300000000 -10 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vat . grab "gold" "Alice" End Vow wad ( -1 /Rat 300000000 ) wad ( -10 ) ) )
       ListItem ( LogNote ( ADMIN , End . skim "gold" "Alice" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 10 , 10 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vat . grab "gold" "Bobby" End Vow -1 /Rat 300000000 -10 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 10 ) , rad ( 10 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vat . grab "gold" "Bobby" End Vow wad ( -1 /Rat 300000000 ) wad ( -10 ) ) )
       ListItem ( LogNote ( ADMIN , End . skim "gold" "Bobby" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 20 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . thaw ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 20 , 20 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 20 ) , rad ( 20 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . flow "gold" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 20 , 20 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( "Alice" , Vat . move "Alice" Pot 10 ) )
-      ListItem ( LogNote ( "Alice" , Pot . join 10 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 10
-      Vow |-> 0 , 1 , 10 , 0 , 20 , 20 , 0 , "Alice" |-> 0
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 10
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( Exception ( Pot . file dsr 2 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 20 ) , rad ( 20 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( "Alice" , Vat . move "Alice" Pot rad ( 10 ) ) )
+      ListItem ( LogNote ( "Alice" , Pot . join wad ( 10 ) ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 10 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 10 ) , rad ( 0 ) , rad ( 20 ) , rad ( 20 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 10 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( Exception ( Pot . file dsr ray ( 2 ) ) )
       ListItem ( TimeStep ( 1 , 1 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 10
-      Vow |-> 0 , 1 , 10 , 0 , 20 , 20 , 0 , "Alice" |-> 0
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 10
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( "Alice" , Vat . suck Vow Pot 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 10 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 10 ) , rad ( 0 ) , rad ( 20 ) , rad ( 20 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 10 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( "Alice" , Vat . suck Vow Pot rad ( 0 ) ) )
       ListItem ( LogNote ( "Alice" , Pot . drip ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 10
-      Vow |-> 0 , 1 , 10 , 0 , 20 , 20 , 0 , "Alice" |-> 0
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 10
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( "Alice" , Vat . move Pot "Alice" 10 ) )
-      ListItem ( LogNote ( "Alice" , Pot . exit 10 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 20 , 20 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 20 , 20 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 10 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 10 ) , rad ( 0 ) , rad ( 20 ) , rad ( 20 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 10 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( "Alice" , Vat . move Pot "Alice" rad ( 10 ) ) )
+      ListItem ( LogNote ( "Alice" , Pot . exit wad ( 10 ) ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 20 ) , rad ( 20 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 20 ) , rad ( 20 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
     </processed-events>
     <properties>
       "Debt Constant After Thaw" |-> debtConstantAfterThaw
       "Flap Dai Consistency" |-> flapDaiConsistencyEnd
       "Flap MKR Consistency" |-> flapMkrConsistency
-      "Flop Block Check" |-> flopBlockCheck ( 0 , 0 )
+      "Flop Block Check" |-> flopBlockCheck ( rad ( 0 ) , 0 )
       "Pot Interest Accumulation After End" |-> potEndInterestEnd
-      "PotChi PotPie VatPot" |-> potChiPieDai ( 0 , 0 )
+      "PotChi PotPie VatPot" |-> potChiPieDai ( rad ( 0 ) , wad ( 0 ) )
       "Total Backed Debt Consistency" |-> totalBackedDebtConsistency
-      "Total Bound on Debt" |-> totalDebtBoundedEnd ( 20 )
+      "Total Bound on Debt" |-> totalDebtBoundedEnd ( rad ( 20 ) )
       "Unauthorized Flap Kick" |-> unAuthFlapKick
       "Unauthorized Flip Kick" |-> unAuthFlipKick
       "Zero-Time Pot Interest Accumulation" |-> zeroTimePotInterest

--- a/tests/attacks/lucash-pot-end.random.mcd.expected
+++ b/tests/attacks/lucash-pot-end.random.mcd.expected
@@ -50,7 +50,7 @@
             .Set
           </dai-wards>
           <dai-totalSupply>
-            0
+            wad ( 0 )
           </dai-totalSupply>
           <dai-account-id>
             0
@@ -83,27 +83,27 @@
               0
             </end-wait>
             <end-debt>
-              20
+              rad ( 20 )
             </end-debt>
             <end-tag>
-              "gold" |-> 1 /Rat 3000000000
+              "gold" |-> ray ( 1 /Rat 3000000000 )
             </end-tag>
             <end-gap>
-              "gold" |-> 0
+              "gold" |-> wad ( 0 )
             </end-gap>
             <end-art>
-              "gold" |-> 20
+              "gold" |-> wad ( 20 )
             </end-art>
             <end-fix>
-              "gold" |-> 1 /Rat 3000000000
+              "gold" |-> ray ( 1 /Rat 3000000000 )
             </end-fix>
             <end-bag>
-              "Alice" |-> 0
-              "Bobby" |-> 0
+              "Alice" |-> wad ( 0 )
+              "Bobby" |-> wad ( 0 )
             </end-bag>
             <end-out>
-              { "gold" , "Alice" } |-> 0
-              { "gold" , "Bobby" } |-> 0
+              { "gold" , "Alice" } |-> wad ( 0 )
+              { "gold" , "Bobby" } |-> wad ( 0 )
             </end-out>
           </end>
         </end-state>
@@ -121,7 +121,7 @@
             false
           </flap-live>
           <flap-beg>
-            21 /Rat 20
+            wad ( 21 /Rat 20 )
           </flap-beg>
           <flap-ttl>
             10800
@@ -142,7 +142,7 @@
               .Map
             </flip-bids>
             <flip-beg>
-              21 /Rat 20
+              wad ( 21 /Rat 20 )
             </flip-beg>
             <flip-ttl>
               10800
@@ -169,10 +169,10 @@
             false
           </flop-live>
           <flop-beg>
-            21 /Rat 20
+            wad ( 21 /Rat 20 )
           </flop-beg>
           <flop-pad>
-            3 /Rat 2
+            wad ( 3 /Rat 2 )
           </flop-pad>
           <flop-ttl>
             10800
@@ -193,11 +193,11 @@
               .Set
             </gem-wards>
             <gem-balances>
-              "Alice" |-> 0
-              "Bobby" |-> 0
-              Flap |-> 0
-              GemJoin "MKR" |-> 0
-              Vow |-> 0
+              "Alice" |-> wad ( 0 )
+              "Bobby" |-> wad ( 0 )
+              Flap |-> wad ( 0 )
+              GemJoin "MKR" |-> wad ( 0 )
+              Vow |-> wad ( 0 )
             </gem-balances>
           </gem> <gem>
             <gem-id>
@@ -207,9 +207,9 @@
               .Set
             </gem-wards>
             <gem-balances>
-              "Alice" |-> 10
-              "Bobby" |-> 10
-              GemJoin "gold" |-> 20
+              "Alice" |-> wad ( 10 )
+              "Bobby" |-> wad ( 10 )
+              GemJoin "gold" |-> wad ( 20 )
             </gem-balances>
           </gem>
         </gems>
@@ -257,7 +257,7 @@
             0
           </jug-vow>
           <jug-base>
-            0
+            ray ( 0 )
           </jug-base>
         </jug>
         <pot>
@@ -265,17 +265,17 @@
             SetItem ( End )
           </pot-wards>
           <pot-pies>
-            "Alice" |-> 0
-            "Bobby" |-> 0
+            "Alice" |-> wad ( 0 )
+            "Bobby" |-> wad ( 0 )
           </pot-pies>
           <pot-pie>
-            0
+            wad ( 0 )
           </pot-pie>
           <pot-dsr>
-            1
+            ray ( 1 )
           </pot-dsr>
           <pot-chi>
-            1
+            ray ( 1 )
           </pot-chi>
           <pot-vow>
             Vow
@@ -292,10 +292,10 @@
             .Set
           </spot-wards>
           <spot-ilks>
-            "gold" |-> SpotIlk ( 3000000000 , 1 )
+            "gold" |-> SpotIlk ( wad ( 3000000000 ) , ray ( 1 ) )
           </spot-ilks>
           <spot-par>
-            1
+            ray ( 1 )
           </spot-par>
           <spot-live>
             true
@@ -323,43 +323,43 @@
             Vow |-> SetItem ( Flap )
           </vat-can>
           <vat-ilks>
-            "gold" |-> Ilk ( 0 , 1 , 3000000000 , 1000000000000 , 0 )
+            "gold" |-> Ilk ( wad ( 0 ) , ray ( 1 ) , ray ( 3000000000 ) , rad ( 1000000000000 ) , rad ( 0 ) )
           </vat-ilks>
           <vat-urns>
-            { "gold" , "Alice" } |-> Urn ( 2999999999 /Rat 300000000 , 0 )
-            { "gold" , "Bobby" } |-> Urn ( 2999999999 /Rat 300000000 , 0 )
-            { "gold" , End } |-> Urn ( 0 , 0 )
+            { "gold" , "Alice" } |-> Urn ( wad ( 2999999999 /Rat 300000000 ) , wad ( 0 ) )
+            { "gold" , "Bobby" } |-> Urn ( wad ( 2999999999 /Rat 300000000 ) , wad ( 0 ) )
+            { "gold" , End } |-> Urn ( wad ( 0 ) , wad ( 0 ) )
           </vat-urns>
           <vat-gem>
-            { "gold" , "Alice" } |-> 0
-            { "gold" , "Bobby" } |-> 0
-            { "gold" , End } |-> 1 /Rat 150000000
-            { "gold" , Flip "gold" } |-> 0
+            { "gold" , "Alice" } |-> wad ( 0 )
+            { "gold" , "Bobby" } |-> wad ( 0 )
+            { "gold" , End } |-> wad ( 1 /Rat 150000000 )
+            { "gold" , Flip "gold" } |-> wad ( 0 )
           </vat-gem>
           <vat-dai>
-            "Alice" |-> 10
-            "Bobby" |-> 10
-            End |-> 0
-            Flap |-> 0
-            Pot |-> 0
-            Vow |-> 0
+            "Alice" |-> rad ( 10 )
+            "Bobby" |-> rad ( 10 )
+            End |-> rad ( 0 )
+            Flap |-> rad ( 0 )
+            Pot |-> rad ( 0 )
+            Vow |-> rad ( 0 )
           </vat-dai>
           <vat-sin>
-            "Alice" |-> 0
-            "Bobby" |-> 0
-            End |-> 0
-            Flap |-> 0
-            Pot |-> 0
-            Vow |-> 20
+            "Alice" |-> rad ( 0 )
+            "Bobby" |-> rad ( 0 )
+            End |-> rad ( 0 )
+            Flap |-> rad ( 0 )
+            Pot |-> rad ( 0 )
+            Vow |-> rad ( 20 )
           </vat-sin>
           <vat-debt>
-            20
+            rad ( 20 )
           </vat-debt>
           <vat-vice>
-            20
+            rad ( 20 )
           </vat-vice>
           <vat-Line>
-            1000000000000
+            rad ( 1000000000000 )
           </vat-Line>
           <vat-live>
             false
@@ -374,25 +374,25 @@
             .Map
           </vow-sins>
           <vow-sin>
-            0
+            rad ( 0 )
           </vow-sin>
           <vow-ash>
-            0
+            rad ( 0 )
           </vow-ash>
           <vow-wait>
             0
           </vow-wait>
           <vow-dump>
-            30
+            wad ( 30 )
           </vow-dump>
           <vow-sump>
-            50
+            rad ( 50 )
           </vow-sump>
           <vow-bump>
-            1000000000
+            rad ( 1000000000 )
           </vow-bump>
           <vow-hump>
-            0
+            rad ( 0 )
           </vow-hump>
           <vow-live>
             false
@@ -402,967 +402,967 @@
     </kmcd>
     <processed-events>
       ListItem ( LogNote ( ADMIN , Vat . rely Pot ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . rely End ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . rely Spot ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Pot . rely End ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vow . rely Pot ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vow . rely End ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Cat . rely End ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Flap . rely Vow ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Flop . rely Vow ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser Vow ) )
-      ListItem ( Measure ( 0 , Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , Vow |-> 0 , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , Vow |-> rad ( 0 ) , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser Pot ) )
-      ListItem ( Measure ( 0 , Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , Pot |-> 0
-      Vow |-> 0 , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser Flap ) )
-      ListItem ( Measure ( 0 , Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , GemJoin "MKR" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , GemJoin "MKR" |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , GemJoin "MKR" |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Vow ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Flap ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Pot . file vow-file Vow ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( Vow , Vat . hope Flap ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vat . file Line 1000000000000 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vow . file bump 1000000000 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vow . file hump 0 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vow . file sump 50 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vow . file dump 30 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vat . file Line rad ( 1000000000000 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vow . file bump rad ( 1000000000 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vow . file hump rad ( 0 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vow . file sump rad ( 50 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vow . file dump wad ( 30 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Flop . file tau 3600 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , GemJoin "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . rely GemJoin "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" Flip "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Spot . init "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 3000000000 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Spot . file mat "gold" 1 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Spot . file par 1 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" wad ( 3000000000 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Spot . file mat "gold" ray ( 1 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Spot . file par ray ( 1 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Flip "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Flip "gold" . rely End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . initGap "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initIlk "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ANYONE , Vat . file spot "gold" 3000000000 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vat . file line "gold" rad ( 1000000000000 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ANYONE , Vat . file spot "gold" ray ( 3000000000 ) ) )
       ListItem ( LogNote ( ANYONE , Spot . poke "gold" ) )
-      ListItem ( Poke ( "gold" , 3000000000 , 3000000000 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Poke ( "gold" , wad ( 3000000000 ) , ray ( 3000000000 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Alice" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Bobby" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Alice" 20 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Bobby" 20 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Alice" wad ( 20 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Bobby" wad ( 20 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Alice" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Bobby" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Pot . initUser "Alice" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Pot . initUser "Bobby" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser "Alice" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Alice" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Alice" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser "Bobby" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Bobby" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Bobby" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Alice" , Vat . hope Pot ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Alice" , Vat . hope Flip "gold" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Alice" , Vat . hope End ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Alice" , Vat . hope Flop ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope Pot ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope Flip "gold" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope End ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope Flop ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( "Alice" , Vat . slip "gold" "Alice" 10 ) )
-      ListItem ( LogNote ( "Alice" , Gem "gold" . transferFrom "Alice" GemJoin "gold" 10 ) )
-      ListItem ( LogNote ( "Alice" , GemJoin "gold" . join "Alice" 10 ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 10 ) )
-      ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 10 ) )
-      ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 10 ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( "Alice" , Vat . frob "gold" "Alice" "Alice" "Alice" 10 10 ) )
-      ListItem ( Measure ( 10 , "Alice" |-> 10
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 10 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( "Alice" , Vat . slip "gold" "Alice" wad ( 10 ) ) )
+      ListItem ( LogNote ( "Alice" , Gem "gold" . transferFrom "Alice" GemJoin "gold" wad ( 10 ) ) )
+      ListItem ( LogNote ( "Alice" , GemJoin "gold" . join "Alice" wad ( 10 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" wad ( 10 ) ) )
+      ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" wad ( 10 ) ) )
+      ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" wad ( 10 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( "Alice" , Vat . frob "gold" "Alice" "Alice" "Alice" wad ( 10 ) wad ( 10 ) ) )
+      ListItem ( Measure ( rad ( 10 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 10 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" wad ( 10 ) wad ( 10 ) ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( GenStep ( b"d" , transact ADMIN End . cage ) )
       ListItem ( LogNote ( ADMIN , Vat . cage ) )
       ListItem ( LogNote ( ADMIN , Cat . cage ) )
-      ListItem ( LogNote ( Vow , Vat . move Flap Vow 0 ) )
-      ListItem ( LogNote ( End , Flap . cage 0 ) )
+      ListItem ( LogNote ( Vow , Vat . move Flap Vow rad ( 0 ) ) )
+      ListItem ( LogNote ( End , Flap . cage rad ( 0 ) ) )
       ListItem ( LogNote ( End , Flop . cage ) )
-      ListItem ( LogNote ( End , Vat . heal 0 ) )
+      ListItem ( LogNote ( End , Vat . heal rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vow . cage ) )
       ListItem ( LogNote ( ADMIN , Pot . cage ) )
       ListItem ( LogNote ( ADMIN , End . cage ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( GenStep ( b"da" , transact ANYONE End . cage "gold" ) )
       ListItem ( LogNote ( ANYONE , End . cage "gold" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( GenStep ( b"d" , transact ANYONE End . skim "gold" "Alice" ) )
-      ListItem ( LogNote ( ANYONE , Vat . grab "gold" "Alice" End Vow -1 /Rat 300000000 -10 ) )
+      ListItem ( LogNote ( ANYONE , Vat . grab "gold" "Alice" End Vow wad ( -1 /Rat 300000000 ) wad ( -10 ) ) )
       ListItem ( LogNote ( ANYONE , End . skim "gold" "Alice" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 10 , 10 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 10 ) , rad ( 10 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( GenStep ( b"d" , transact ANYONE End . skim "gold" "Bobby" ) )
-      ListItem ( LogNote ( ANYONE , Vat . grab "gold" "Bobby" End Vow -1 /Rat 300000000 -10 ) )
+      ListItem ( LogNote ( ANYONE , Vat . grab "gold" "Bobby" End Vow wad ( -1 /Rat 300000000 ) wad ( -10 ) ) )
       ListItem ( LogNote ( ANYONE , End . skim "gold" "Bobby" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 20 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( GenStep ( b"d" , transact ANYONE End . thaw ) )
       ListItem ( LogNote ( ANYONE , End . thaw ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 20 , 20 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 20 ) , rad ( 20 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( GenStep ( b"da" , transact ANYONE End . flow "gold" ) )
       ListItem ( LogNote ( ANYONE , End . flow "gold" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 20 , 20 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( GenStep ( b"da" , transact "Alice" Pot . join 485 /Rat 128 ) )
-      ListItem ( LogNote ( "Alice" , Vat . move "Alice" Pot 485 /Rat 128 ) )
-      ListItem ( LogNote ( "Alice" , Pot . join 485 /Rat 128 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 485 /Rat 128
-      Vow |-> 0 , 1 , 485 /Rat 128 , 0 , 20 , 20 , 0 , "Alice" |-> 795 /Rat 128
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 485 /Rat 128
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( GenStep ( b"da" , transact ADMIN Pot . file dsr 1377 /Rat 1280 ) )
-      ListItem ( Exception ( Pot . file dsr 1377 /Rat 1280 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 20 ) , rad ( 20 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( GenStep ( b"da" , transact "Alice" Pot . join wad ( 485 /Rat 128 ) ) )
+      ListItem ( LogNote ( "Alice" , Vat . move "Alice" Pot rad ( 485 /Rat 128 ) ) )
+      ListItem ( LogNote ( "Alice" , Pot . join wad ( 485 /Rat 128 ) ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 485 /Rat 128 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 485 /Rat 128 ) , rad ( 0 ) , rad ( 20 ) , rad ( 20 ) , rad ( 0 ) , "Alice" |-> rad ( 795 /Rat 128 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 485 /Rat 128 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( GenStep ( b"da" , transact ADMIN Pot . file dsr ray ( 1377 /Rat 1280 ) ) )
+      ListItem ( Exception ( Pot . file dsr ray ( 1377 /Rat 1280 ) ) )
       ListItem ( GenStep ( b"da" , TimeStep 2 ) )
       ListItem ( TimeStep ( 2 , 2 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 485 /Rat 128
-      Vow |-> 0 , 1 , 485 /Rat 128 , 0 , 20 , 20 , 0 , "Alice" |-> 795 /Rat 128
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 485 /Rat 128
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 485 /Rat 128 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 485 /Rat 128 ) , rad ( 0 ) , rad ( 20 ) , rad ( 20 ) , rad ( 0 ) , "Alice" |-> rad ( 795 /Rat 128 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 485 /Rat 128 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( GenStep ( b"d" , transact ANYONE Pot . drip ) )
-      ListItem ( LogNote ( ANYONE , Vat . suck Vow Pot 0 ) )
+      ListItem ( LogNote ( ANYONE , Vat . suck Vow Pot rad ( 0 ) ) )
       ListItem ( LogNote ( ANYONE , Pot . drip ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 485 /Rat 128
-      Vow |-> 0 , 1 , 485 /Rat 128 , 0 , 20 , 20 , 0 , "Alice" |-> 795 /Rat 128
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 485 /Rat 128
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( GenStep ( b"d" , transact "Alice" Pot . exit 485 /Rat 128 ) )
-      ListItem ( LogNote ( "Alice" , Vat . move Pot "Alice" 485 /Rat 128 ) )
-      ListItem ( LogNote ( "Alice" , Pot . exit 485 /Rat 128 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 20 , 20 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 20 , 20 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 485 /Rat 128 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 485 /Rat 128 ) , rad ( 0 ) , rad ( 20 ) , rad ( 20 ) , rad ( 0 ) , "Alice" |-> rad ( 795 /Rat 128 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 485 /Rat 128 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( GenStep ( b"d" , transact "Alice" Pot . exit wad ( 485 /Rat 128 ) ) )
+      ListItem ( LogNote ( "Alice" , Vat . move Pot "Alice" rad ( 485 /Rat 128 ) ) )
+      ListItem ( LogNote ( "Alice" , Pot . exit wad ( 485 /Rat 128 ) ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 20 ) , rad ( 20 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 20 ) , rad ( 20 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
     </processed-events>
     <properties>
       "Debt Constant After Thaw" |-> debtConstantAfterThaw
       "Flap Dai Consistency" |-> flapDaiConsistencyEnd
       "Flap MKR Consistency" |-> flapMkrConsistency
-      "Flop Block Check" |-> flopBlockCheck ( 0 , 0 )
+      "Flop Block Check" |-> flopBlockCheck ( rad ( 0 ) , 0 )
       "Pot Interest Accumulation After End" |-> potEndInterestEnd
-      "PotChi PotPie VatPot" |-> potChiPieDai ( 0 , 0 )
+      "PotChi PotPie VatPot" |-> potChiPieDai ( rad ( 0 ) , wad ( 0 ) )
       "Total Backed Debt Consistency" |-> totalBackedDebtConsistency
-      "Total Bound on Debt" |-> totalDebtBoundedEnd ( 20 )
+      "Total Bound on Debt" |-> totalDebtBoundedEnd ( rad ( 20 ) )
       "Unauthorized Flap Kick" |-> unAuthFlapKick
       "Unauthorized Flip Kick" |-> unAuthFlipKick
       "Zero-Time Pot Interest Accumulation" |-> zeroTimePotInterest

--- a/tests/attacks/lucash-pot.mcd.expected
+++ b/tests/attacks/lucash-pot.mcd.expected
@@ -50,7 +50,7 @@
             .Set
           </dai-wards>
           <dai-totalSupply>
-            0
+            wad ( 0 )
           </dai-totalSupply>
           <dai-account-id>
             0
@@ -83,13 +83,13 @@
               0
             </end-wait>
             <end-debt>
-              0
+              rad ( 0 )
             </end-debt>
             <end-tag>
               .Map
             </end-tag>
             <end-gap>
-              "gold" |-> 0
+              "gold" |-> wad ( 0 )
             </end-gap>
             <end-art>
               .Map
@@ -98,12 +98,12 @@
               .Map
             </end-fix>
             <end-bag>
-              "Alice" |-> 0
-              "Bobby" |-> 0
+              "Alice" |-> wad ( 0 )
+              "Bobby" |-> wad ( 0 )
             </end-bag>
             <end-out>
-              { "gold" , "Alice" } |-> 0
-              { "gold" , "Bobby" } |-> 0
+              { "gold" , "Alice" } |-> wad ( 0 )
+              { "gold" , "Bobby" } |-> wad ( 0 )
             </end-out>
           </end>
         </end-state>
@@ -121,7 +121,7 @@
             true
           </flap-live>
           <flap-beg>
-            21 /Rat 20
+            wad ( 21 /Rat 20 )
           </flap-beg>
           <flap-ttl>
             10800
@@ -142,7 +142,7 @@
               .Map
             </flip-bids>
             <flip-beg>
-              21 /Rat 20
+              wad ( 21 /Rat 20 )
             </flip-beg>
             <flip-ttl>
               10800
@@ -169,10 +169,10 @@
             true
           </flop-live>
           <flop-beg>
-            21 /Rat 20
+            wad ( 21 /Rat 20 )
           </flop-beg>
           <flop-pad>
-            3 /Rat 2
+            wad ( 3 /Rat 2 )
           </flop-pad>
           <flop-ttl>
             10800
@@ -193,11 +193,11 @@
               .Set
             </gem-wards>
             <gem-balances>
-              "Alice" |-> 0
-              "Bobby" |-> 0
-              Flap |-> 0
-              GemJoin "MKR" |-> 0
-              Vow |-> 0
+              "Alice" |-> wad ( 0 )
+              "Bobby" |-> wad ( 0 )
+              Flap |-> wad ( 0 )
+              GemJoin "MKR" |-> wad ( 0 )
+              Vow |-> wad ( 0 )
             </gem-balances>
           </gem> <gem>
             <gem-id>
@@ -207,9 +207,9 @@
               .Set
             </gem-wards>
             <gem-balances>
-              "Alice" |-> 10
-              "Bobby" |-> 10
-              GemJoin "gold" |-> 20
+              "Alice" |-> wad ( 10 )
+              "Bobby" |-> wad ( 10 )
+              GemJoin "gold" |-> wad ( 20 )
             </gem-balances>
           </gem>
         </gems>
@@ -257,7 +257,7 @@
             0
           </jug-vow>
           <jug-base>
-            0
+            ray ( 0 )
           </jug-base>
         </jug>
         <pot>
@@ -265,17 +265,17 @@
             SetItem ( End )
           </pot-wards>
           <pot-pies>
-            "Alice" |-> 0
-            "Bobby" |-> 0
+            "Alice" |-> wad ( 0 )
+            "Bobby" |-> wad ( 0 )
           </pot-pies>
           <pot-pie>
-            0
+            wad ( 0 )
           </pot-pie>
           <pot-dsr>
-            5
+            ray ( 5 )
           </pot-dsr>
           <pot-chi>
-            5
+            ray ( 5 )
           </pot-chi>
           <pot-vow>
             Vow
@@ -292,10 +292,10 @@
             .Set
           </spot-wards>
           <spot-ilks>
-            "gold" |-> SpotIlk ( 3000000000 , 1 )
+            "gold" |-> SpotIlk ( wad ( 3000000000 ) , ray ( 1 ) )
           </spot-ilks>
           <spot-par>
-            1
+            ray ( 1 )
           </spot-par>
           <spot-live>
             true
@@ -323,43 +323,43 @@
             Vow |-> SetItem ( Flap )
           </vat-can>
           <vat-ilks>
-            "gold" |-> Ilk ( 20 , 1 , 3000000000 , 1000000000000 , 0 )
+            "gold" |-> Ilk ( wad ( 20 ) , ray ( 1 ) , ray ( 3000000000 ) , rad ( 1000000000000 ) , rad ( 0 ) )
           </vat-ilks>
           <vat-urns>
-            { "gold" , "Alice" } |-> Urn ( 10 , 10 )
-            { "gold" , "Bobby" } |-> Urn ( 10 , 10 )
-            { "gold" , End } |-> Urn ( 0 , 0 )
+            { "gold" , "Alice" } |-> Urn ( wad ( 10 ) , wad ( 10 ) )
+            { "gold" , "Bobby" } |-> Urn ( wad ( 10 ) , wad ( 10 ) )
+            { "gold" , End } |-> Urn ( wad ( 0 ) , wad ( 0 ) )
           </vat-urns>
           <vat-gem>
-            { "gold" , "Alice" } |-> 0
-            { "gold" , "Bobby" } |-> 0
-            { "gold" , End } |-> 0
-            { "gold" , Flip "gold" } |-> 0
+            { "gold" , "Alice" } |-> wad ( 0 )
+            { "gold" , "Bobby" } |-> wad ( 0 )
+            { "gold" , End } |-> wad ( 0 )
+            { "gold" , Flip "gold" } |-> wad ( 0 )
           </vat-gem>
           <vat-dai>
-            "Alice" |-> 10
-            "Bobby" |-> 10
-            End |-> 0
-            Flap |-> 0
-            Pot |-> 0
-            Vow |-> 0
+            "Alice" |-> rad ( 10 )
+            "Bobby" |-> rad ( 10 )
+            End |-> rad ( 0 )
+            Flap |-> rad ( 0 )
+            Pot |-> rad ( 0 )
+            Vow |-> rad ( 0 )
           </vat-dai>
           <vat-sin>
-            "Alice" |-> 0
-            "Bobby" |-> 0
-            End |-> 0
-            Flap |-> 0
-            Pot |-> 0
-            Vow |-> 0
+            "Alice" |-> rad ( 0 )
+            "Bobby" |-> rad ( 0 )
+            End |-> rad ( 0 )
+            Flap |-> rad ( 0 )
+            Pot |-> rad ( 0 )
+            Vow |-> rad ( 0 )
           </vat-sin>
           <vat-debt>
-            20
+            rad ( 20 )
           </vat-debt>
           <vat-vice>
-            0
+            rad ( 0 )
           </vat-vice>
           <vat-Line>
-            1000000000000
+            rad ( 1000000000000 )
           </vat-Line>
           <vat-live>
             true
@@ -374,25 +374,25 @@
             .Map
           </vow-sins>
           <vow-sin>
-            0
+            rad ( 0 )
           </vow-sin>
           <vow-ash>
-            0
+            rad ( 0 )
           </vow-ash>
           <vow-wait>
             0
           </vow-wait>
           <vow-dump>
-            30
+            wad ( 30 )
           </vow-dump>
           <vow-sump>
-            50
+            rad ( 50 )
           </vow-sump>
           <vow-bump>
-            1000000000
+            rad ( 1000000000 )
           </vow-bump>
           <vow-hump>
-            0
+            rad ( 0 )
           </vow-hump>
           <vow-live>
             true
@@ -402,833 +402,833 @@
     </kmcd>
     <processed-events>
       ListItem ( LogNote ( ADMIN , Vat . rely Pot ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . rely End ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . rely Spot ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Pot . rely End ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vow . rely Pot ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vow . rely End ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Cat . rely End ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Flap . rely Vow ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Flop . rely Vow ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser Vow ) )
-      ListItem ( Measure ( 0 , Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , Vow |-> 0 , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , Vow |-> rad ( 0 ) , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser Pot ) )
-      ListItem ( Measure ( 0 , Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , Pot |-> 0
-      Vow |-> 0 , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser Flap ) )
-      ListItem ( Measure ( 0 , Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , GemJoin "MKR" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , GemJoin "MKR" |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , GemJoin "MKR" |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Vow ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Flap ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Pot . file vow-file Vow ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( Vow , Vat . hope Flap ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vat . file Line 1000000000000 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vow . file bump 1000000000 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vow . file hump 0 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vow . file sump 50 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vow . file dump 30 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vat . file Line rad ( 1000000000000 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vow . file bump rad ( 1000000000 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vow . file hump rad ( 0 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vow . file sump rad ( 50 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vow . file dump wad ( 30 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Flop . file tau 3600 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , GemJoin "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . rely GemJoin "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" Flip "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Spot . init "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 3000000000 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Spot . file mat "gold" 1 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Spot . file par 1 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" wad ( 3000000000 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Spot . file mat "gold" ray ( 1 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Spot . file par ray ( 1 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Flip "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Flip "gold" . rely End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . initGap "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initIlk "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ANYONE , Vat . file spot "gold" 3000000000 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vat . file line "gold" rad ( 1000000000000 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ANYONE , Vat . file spot "gold" ray ( 3000000000 ) ) )
       ListItem ( LogNote ( ANYONE , Spot . poke "gold" ) )
-      ListItem ( Poke ( "gold" , 3000000000 , 3000000000 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Poke ( "gold" , wad ( 3000000000 ) , ray ( 3000000000 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Alice" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Bobby" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Alice" 20 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Bobby" 20 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Alice" wad ( 20 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Bobby" wad ( 20 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Alice" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Bobby" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Pot . initUser "Alice" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Pot . initUser "Bobby" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser "Alice" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Alice" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Alice" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser "Bobby" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Bobby" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Bobby" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Alice" , Vat . hope Pot ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Alice" , Vat . hope Flip "gold" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Alice" , Vat . hope End ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Alice" , Vat . hope Flop ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope Pot ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope Flip "gold" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope End ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope Flop ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( "Alice" , Vat . slip "gold" "Alice" 10 ) )
-      ListItem ( LogNote ( "Alice" , Gem "gold" . transferFrom "Alice" GemJoin "gold" 10 ) )
-      ListItem ( LogNote ( "Alice" , GemJoin "gold" . join "Alice" 10 ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 10 ) )
-      ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 10 ) )
-      ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 10 ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( "Alice" , Vat . frob "gold" "Alice" "Alice" "Alice" 10 10 ) )
-      ListItem ( Measure ( 10 , "Alice" |-> 10
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 10 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( "Alice" , Vat . slip "gold" "Alice" wad ( 10 ) ) )
+      ListItem ( LogNote ( "Alice" , Gem "gold" . transferFrom "Alice" GemJoin "gold" wad ( 10 ) ) )
+      ListItem ( LogNote ( "Alice" , GemJoin "gold" . join "Alice" wad ( 10 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" wad ( 10 ) ) )
+      ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" wad ( 10 ) ) )
+      ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" wad ( 10 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( "Alice" , Vat . frob "gold" "Alice" "Alice" "Alice" wad ( 10 ) wad ( 10 ) ) )
+      ListItem ( Measure ( rad ( 10 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 10 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" wad ( 10 ) wad ( 10 ) ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Pot . file dsr 5 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Pot . file dsr ray ( 5 ) ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( TimeStep ( 1 , 1 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( Exception ( Pot . join 10 ) )
-      ListItem ( LogNote ( "Alice" , Vat . suck Vow Pot 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( Exception ( Pot . join wad ( 10 ) ) )
+      ListItem ( LogNote ( "Alice" , Vat . suck Vow Pot rad ( 0 ) ) )
       ListItem ( LogNote ( "Alice" , Pot . drip ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 5 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( Exception ( Pot . exit 10 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 5 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 5 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( Exception ( Pot . exit wad ( 10 ) ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 5 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
     </processed-events>
     <properties>
       "Debt Constant After Thaw" |-> debtConstantAfterThaw
       "Flap Dai Consistency" |-> flapDaiConsistency
       "Flap MKR Consistency" |-> flapMkrConsistency
-      "Flop Block Check" |-> flopBlockCheck ( 0 , 0 )
+      "Flop Block Check" |-> flopBlockCheck ( rad ( 0 ) , 0 )
       "Pot Interest Accumulation After End" |-> potEndInterest
-      "PotChi PotPie VatPot" |-> potChiPieDai ( 0 , 0 )
+      "PotChi PotPie VatPot" |-> potChiPieDai ( rad ( 0 ) , wad ( 0 ) )
       "Total Backed Debt Consistency" |-> totalBackedDebtConsistency
-      "Total Bound on Debt" |-> totalDebtBoundedRun ( 20 , 5 )
+      "Total Bound on Debt" |-> totalDebtBoundedRun ( rad ( 20 ) , ray ( 5 ) )
       "Unauthorized Flap Kick" |-> unAuthFlapKick
       "Unauthorized Flip Kick" |-> unAuthFlipKick
       "Zero-Time Pot Interest Accumulation" |-> zeroTimePotInterest

--- a/tests/attacks/lucash-pot.random.mcd.expected
+++ b/tests/attacks/lucash-pot.random.mcd.expected
@@ -50,7 +50,7 @@
             .Set
           </dai-wards>
           <dai-totalSupply>
-            0
+            wad ( 0 )
           </dai-totalSupply>
           <dai-account-id>
             0
@@ -83,13 +83,13 @@
               0
             </end-wait>
             <end-debt>
-              0
+              rad ( 0 )
             </end-debt>
             <end-tag>
               .Map
             </end-tag>
             <end-gap>
-              "gold" |-> 0
+              "gold" |-> wad ( 0 )
             </end-gap>
             <end-art>
               .Map
@@ -98,12 +98,12 @@
               .Map
             </end-fix>
             <end-bag>
-              "Alice" |-> 0
-              "Bobby" |-> 0
+              "Alice" |-> wad ( 0 )
+              "Bobby" |-> wad ( 0 )
             </end-bag>
             <end-out>
-              { "gold" , "Alice" } |-> 0
-              { "gold" , "Bobby" } |-> 0
+              { "gold" , "Alice" } |-> wad ( 0 )
+              { "gold" , "Bobby" } |-> wad ( 0 )
             </end-out>
           </end>
         </end-state>
@@ -121,7 +121,7 @@
             true
           </flap-live>
           <flap-beg>
-            21 /Rat 20
+            wad ( 21 /Rat 20 )
           </flap-beg>
           <flap-ttl>
             10800
@@ -142,7 +142,7 @@
               .Map
             </flip-bids>
             <flip-beg>
-              21 /Rat 20
+              wad ( 21 /Rat 20 )
             </flip-beg>
             <flip-ttl>
               10800
@@ -169,10 +169,10 @@
             true
           </flop-live>
           <flop-beg>
-            21 /Rat 20
+            wad ( 21 /Rat 20 )
           </flop-beg>
           <flop-pad>
-            3 /Rat 2
+            wad ( 3 /Rat 2 )
           </flop-pad>
           <flop-ttl>
             10800
@@ -193,11 +193,11 @@
               .Set
             </gem-wards>
             <gem-balances>
-              "Alice" |-> 0
-              "Bobby" |-> 0
-              Flap |-> 0
-              GemJoin "MKR" |-> 0
-              Vow |-> 0
+              "Alice" |-> wad ( 0 )
+              "Bobby" |-> wad ( 0 )
+              Flap |-> wad ( 0 )
+              GemJoin "MKR" |-> wad ( 0 )
+              Vow |-> wad ( 0 )
             </gem-balances>
           </gem> <gem>
             <gem-id>
@@ -207,9 +207,9 @@
               .Set
             </gem-wards>
             <gem-balances>
-              "Alice" |-> 10
-              "Bobby" |-> 10
-              GemJoin "gold" |-> 20
+              "Alice" |-> wad ( 10 )
+              "Bobby" |-> wad ( 10 )
+              GemJoin "gold" |-> wad ( 20 )
             </gem-balances>
           </gem>
         </gems>
@@ -257,7 +257,7 @@
             0
           </jug-vow>
           <jug-base>
-            0
+            ray ( 0 )
           </jug-base>
         </jug>
         <pot>
@@ -265,17 +265,17 @@
             SetItem ( End )
           </pot-wards>
           <pot-pies>
-            "Alice" |-> 0
-            "Bobby" |-> 0
+            "Alice" |-> wad ( 0 )
+            "Bobby" |-> wad ( 0 )
           </pot-pies>
           <pot-pie>
-            0
+            wad ( 0 )
           </pot-pie>
           <pot-dsr>
-            1377 /Rat 1280
+            ray ( 1377 /Rat 1280 )
           </pot-dsr>
           <pot-chi>
-            1896129 /Rat 1638400
+            ray ( 1896129 /Rat 1638400 )
           </pot-chi>
           <pot-vow>
             Vow
@@ -292,10 +292,10 @@
             .Set
           </spot-wards>
           <spot-ilks>
-            "gold" |-> SpotIlk ( 3000000000 , 1 )
+            "gold" |-> SpotIlk ( wad ( 3000000000 ) , ray ( 1 ) )
           </spot-ilks>
           <spot-par>
-            1
+            ray ( 1 )
           </spot-par>
           <spot-live>
             true
@@ -323,43 +323,43 @@
             Vow |-> SetItem ( Flap )
           </vat-can>
           <vat-ilks>
-            "gold" |-> Ilk ( 20 , 1 , 3000000000 , 1000000000000 , 0 )
+            "gold" |-> Ilk ( wad ( 20 ) , ray ( 1 ) , ray ( 3000000000 ) , rad ( 1000000000000 ) , rad ( 0 ) )
           </vat-ilks>
           <vat-urns>
-            { "gold" , "Alice" } |-> Urn ( 10 , 10 )
-            { "gold" , "Bobby" } |-> Urn ( 10 , 10 )
-            { "gold" , End } |-> Urn ( 0 , 0 )
+            { "gold" , "Alice" } |-> Urn ( wad ( 10 ) , wad ( 10 ) )
+            { "gold" , "Bobby" } |-> Urn ( wad ( 10 ) , wad ( 10 ) )
+            { "gold" , End } |-> Urn ( wad ( 0 ) , wad ( 0 ) )
           </vat-urns>
           <vat-gem>
-            { "gold" , "Alice" } |-> 0
-            { "gold" , "Bobby" } |-> 0
-            { "gold" , End } |-> 0
-            { "gold" , Flip "gold" } |-> 0
+            { "gold" , "Alice" } |-> wad ( 0 )
+            { "gold" , "Bobby" } |-> wad ( 0 )
+            { "gold" , End } |-> wad ( 0 )
+            { "gold" , Flip "gold" } |-> wad ( 0 )
           </vat-gem>
           <vat-dai>
-            "Alice" |-> 10
-            "Bobby" |-> 10
-            End |-> 0
-            Flap |-> 0
-            Pot |-> 0
-            Vow |-> 0
+            "Alice" |-> rad ( 10 )
+            "Bobby" |-> rad ( 10 )
+            End |-> rad ( 0 )
+            Flap |-> rad ( 0 )
+            Pot |-> rad ( 0 )
+            Vow |-> rad ( 0 )
           </vat-dai>
           <vat-sin>
-            "Alice" |-> 0
-            "Bobby" |-> 0
-            End |-> 0
-            Flap |-> 0
-            Pot |-> 0
-            Vow |-> 0
+            "Alice" |-> rad ( 0 )
+            "Bobby" |-> rad ( 0 )
+            End |-> rad ( 0 )
+            Flap |-> rad ( 0 )
+            Pot |-> rad ( 0 )
+            Vow |-> rad ( 0 )
           </vat-sin>
           <vat-debt>
-            20
+            rad ( 20 )
           </vat-debt>
           <vat-vice>
-            0
+            rad ( 0 )
           </vat-vice>
           <vat-Line>
-            1000000000000
+            rad ( 1000000000000 )
           </vat-Line>
           <vat-live>
             true
@@ -374,25 +374,25 @@
             .Map
           </vow-sins>
           <vow-sin>
-            0
+            rad ( 0 )
           </vow-sin>
           <vow-ash>
-            0
+            rad ( 0 )
           </vow-ash>
           <vow-wait>
             0
           </vow-wait>
           <vow-dump>
-            30
+            wad ( 30 )
           </vow-dump>
           <vow-sump>
-            50
+            rad ( 50 )
           </vow-sump>
           <vow-bump>
-            1000000000
+            rad ( 1000000000 )
           </vow-bump>
           <vow-hump>
-            0
+            rad ( 0 )
           </vow-hump>
           <vow-live>
             true
@@ -402,854 +402,854 @@
     </kmcd>
     <processed-events>
       ListItem ( LogNote ( ADMIN , Vat . rely Pot ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . rely End ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . rely Spot ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Pot . rely End ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vow . rely Pot ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vow . rely End ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Cat . rely End ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Flap . rely Vow ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Flop . rely Vow ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser Vow ) )
-      ListItem ( Measure ( 0 , Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , Vow |-> 0 , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , Vow |-> rad ( 0 ) , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser Pot ) )
-      ListItem ( Measure ( 0 , Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , Pot |-> 0
-      Vow |-> 0 , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser Flap ) )
-      ListItem ( Measure ( 0 , Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , GemJoin "MKR" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , GemJoin "MKR" |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , GemJoin "MKR" |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Vow ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Flap ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Pot . file vow-file Vow ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( Vow , Vat . hope Flap ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vat . file Line 1000000000000 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vow . file bump 1000000000 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vow . file hump 0 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vow . file sump 50 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vow . file dump 30 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vat . file Line rad ( 1000000000000 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vow . file bump rad ( 1000000000 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vow . file hump rad ( 0 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vow . file sump rad ( 50 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vow . file dump wad ( 30 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Flop . file tau 3600 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , GemJoin "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . rely GemJoin "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" Flip "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Spot . init "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 3000000000 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Spot . file mat "gold" 1 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Spot . file par 1 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" wad ( 3000000000 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Spot . file mat "gold" ray ( 1 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Spot . file par ray ( 1 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Flip "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Flip "gold" . rely End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . initGap "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initIlk "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ANYONE , Vat . file spot "gold" 3000000000 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vat . file line "gold" rad ( 1000000000000 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ANYONE , Vat . file spot "gold" ray ( 3000000000 ) ) )
       ListItem ( LogNote ( ANYONE , Spot . poke "gold" ) )
-      ListItem ( Poke ( "gold" , 3000000000 , 3000000000 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Poke ( "gold" , wad ( 3000000000 ) , ray ( 3000000000 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Alice" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Bobby" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Alice" 20 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Bobby" 20 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Alice" wad ( 20 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Bobby" wad ( 20 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Alice" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Bobby" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Pot . initUser "Alice" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Pot . initUser "Bobby" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser "Alice" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Alice" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Alice" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser "Bobby" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Bobby" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Bobby" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Alice" , Vat . hope Pot ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Alice" , Vat . hope Flip "gold" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Alice" , Vat . hope End ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Alice" , Vat . hope Flop ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope Pot ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope Flip "gold" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope End ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope Flop ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( "Alice" , Vat . slip "gold" "Alice" 10 ) )
-      ListItem ( LogNote ( "Alice" , Gem "gold" . transferFrom "Alice" GemJoin "gold" 10 ) )
-      ListItem ( LogNote ( "Alice" , GemJoin "gold" . join "Alice" 10 ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 10 ) )
-      ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 10 ) )
-      ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 10 ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( "Alice" , Vat . frob "gold" "Alice" "Alice" "Alice" 10 10 ) )
-      ListItem ( Measure ( 10 , "Alice" |-> 10
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 10 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( "Alice" , Vat . slip "gold" "Alice" wad ( 10 ) ) )
+      ListItem ( LogNote ( "Alice" , Gem "gold" . transferFrom "Alice" GemJoin "gold" wad ( 10 ) ) )
+      ListItem ( LogNote ( "Alice" , GemJoin "gold" . join "Alice" wad ( 10 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" wad ( 10 ) ) )
+      ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" wad ( 10 ) ) )
+      ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" wad ( 10 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( "Alice" , Vat . frob "gold" "Alice" "Alice" "Alice" wad ( 10 ) wad ( 10 ) ) )
+      ListItem ( Measure ( rad ( 10 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 10 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" wad ( 10 ) wad ( 10 ) ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( GenStep ( b"aa" , transact ADMIN Pot . file dsr 1377 /Rat 1280 ) )
-      ListItem ( LogNote ( ADMIN , Pot . file dsr 1377 /Rat 1280 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( GenStep ( b"aa" , transact ADMIN Pot . file dsr ray ( 1377 /Rat 1280 ) ) )
+      ListItem ( LogNote ( ADMIN , Pot . file dsr ray ( 1377 /Rat 1280 ) ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( GenStep ( b"aa" , TimeStep 2 ) )
       ListItem ( TimeStep ( 2 , 2 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( GenStep ( b"aa" , transact "Alice" Pot . join 485 /Rat 128 ) )
-      ListItem ( Exception ( Pot . join 485 /Rat 128 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( GenStep ( b"aa" , transact "Alice" Pot . join wad ( 485 /Rat 128 ) ) )
+      ListItem ( Exception ( Pot . join wad ( 485 /Rat 128 ) ) )
       ListItem ( GenStep ( b"a" , transact ANYONE Pot . drip ) )
-      ListItem ( LogNote ( ANYONE , Vat . suck Vow Pot 0 ) )
+      ListItem ( LogNote ( ANYONE , Vat . suck Vow Pot rad ( 0 ) ) )
       ListItem ( LogNote ( ANYONE , Pot . drip ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1896129 /Rat 1638400 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( GenStep ( b"a" , transact "Alice" Pot . exit 0 ) )
-      ListItem ( LogNote ( "Alice" , Vat . move Pot "Alice" 0 ) )
-      ListItem ( LogNote ( "Alice" , Pot . exit 0 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1896129 /Rat 1638400 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1896129 /Rat 1638400 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1896129 /Rat 1638400 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( GenStep ( b"a" , transact "Alice" Pot . exit wad ( 0 ) ) )
+      ListItem ( LogNote ( "Alice" , Vat . move Pot "Alice" rad ( 0 ) ) )
+      ListItem ( LogNote ( "Alice" , Pot . exit wad ( 0 ) ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1896129 /Rat 1638400 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1896129 /Rat 1638400 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
     </processed-events>
     <properties>
       "Debt Constant After Thaw" |-> debtConstantAfterThaw
       "Flap Dai Consistency" |-> flapDaiConsistency
       "Flap MKR Consistency" |-> flapMkrConsistency
-      "Flop Block Check" |-> flopBlockCheck ( 0 , 0 )
+      "Flop Block Check" |-> flopBlockCheck ( rad ( 0 ) , 0 )
       "Pot Interest Accumulation After End" |-> potEndInterest
-      "PotChi PotPie VatPot" |-> potChiPieDai ( 0 , 0 )
+      "PotChi PotPie VatPot" |-> potChiPieDai ( rad ( 0 ) , wad ( 0 ) )
       "Total Backed Debt Consistency" |-> totalBackedDebtConsistency
-      "Total Bound on Debt" |-> totalDebtBoundedRun ( 20 , 1377 /Rat 1280 )
+      "Total Bound on Debt" |-> totalDebtBoundedRun ( rad ( 20 ) , ray ( 1377 /Rat 1280 ) )
       "Unauthorized Flap Kick" |-> unAuthFlapKick
       "Unauthorized Flip Kick" |-> unAuthFlipKick
       "Zero-Time Pot Interest Accumulation" |-> zeroTimePotInterest

--- a/tests/fixes/debtBoundDSR.mcd.expected
+++ b/tests/fixes/debtBoundDSR.mcd.expected
@@ -41,7 +41,7 @@
                 .Set
               </dai-wards>
               <dai-totalSupply>
-                0
+                wad ( 0 )
               </dai-totalSupply>
               <dai-account-id>
                 0
@@ -74,13 +74,13 @@
                   0
                 </end-wait>
                 <end-debt>
-                  0
+                  rad ( 0 )
                 </end-debt>
                 <end-tag>
                   .Map
                 </end-tag>
                 <end-gap>
-                  "gold" |-> 0
+                  "gold" |-> wad ( 0 )
                 </end-gap>
                 <end-art>
                   .Map
@@ -89,12 +89,12 @@
                   .Map
                 </end-fix>
                 <end-bag>
-                  "Alice" |-> 0
-                  "Bobby" |-> 0
+                  "Alice" |-> wad ( 0 )
+                  "Bobby" |-> wad ( 0 )
                 </end-bag>
                 <end-out>
-                  { "gold" , "Alice" } |-> 0
-                  { "gold" , "Bobby" } |-> 0
+                  { "gold" , "Alice" } |-> wad ( 0 )
+                  { "gold" , "Bobby" } |-> wad ( 0 )
                 </end-out>
               </end>
             </end-state>
@@ -112,7 +112,7 @@
                 true
               </flap-live>
               <flap-beg>
-                21 /Rat 20
+                wad ( 21 /Rat 20 )
               </flap-beg>
               <flap-ttl>
                 10800
@@ -133,7 +133,7 @@
                   .Map
                 </flip-bids>
                 <flip-beg>
-                  21 /Rat 20
+                  wad ( 21 /Rat 20 )
                 </flip-beg>
                 <flip-ttl>
                   10800
@@ -160,10 +160,10 @@
                 true
               </flop-live>
               <flop-beg>
-                21 /Rat 20
+                wad ( 21 /Rat 20 )
               </flop-beg>
               <flop-pad>
-                3 /Rat 2
+                wad ( 3 /Rat 2 )
               </flop-pad>
               <flop-ttl>
                 10800
@@ -184,11 +184,11 @@
                   .Set
                 </gem-wards>
                 <gem-balances>
-                  "Alice" |-> 0
-                  "Bobby" |-> 0
-                  Flap |-> 0
-                  GemJoin "MKR" |-> 0
-                  Vow |-> 0
+                  "Alice" |-> wad ( 0 )
+                  "Bobby" |-> wad ( 0 )
+                  Flap |-> wad ( 0 )
+                  GemJoin "MKR" |-> wad ( 0 )
+                  Vow |-> wad ( 0 )
                 </gem-balances>
               </gem> <gem>
                 <gem-id>
@@ -198,9 +198,9 @@
                   .Set
                 </gem-wards>
                 <gem-balances>
-                  "Alice" |-> 10
-                  "Bobby" |-> 10
-                  GemJoin "gold" |-> 20
+                  "Alice" |-> wad ( 10 )
+                  "Bobby" |-> wad ( 10 )
+                  GemJoin "gold" |-> wad ( 20 )
                 </gem-balances>
               </gem>
             </gems>
@@ -248,7 +248,7 @@
                 0
               </jug-vow>
               <jug-base>
-                0
+                ray ( 0 )
               </jug-base>
             </jug>
             <pot>
@@ -256,17 +256,17 @@
                 SetItem ( End )
               </pot-wards>
               <pot-pies>
-                "Alice" |-> 0
-                "Bobby" |-> 0
+                "Alice" |-> wad ( 0 )
+                "Bobby" |-> wad ( 0 )
               </pot-pies>
               <pot-pie>
-                0
+                wad ( 0 )
               </pot-pie>
               <pot-dsr>
-                9 /Rat 8
+                ray ( 9 /Rat 8 )
               </pot-dsr>
               <pot-chi>
-                1
+                ray ( 1 )
               </pot-chi>
               <pot-vow>
                 Vow
@@ -283,10 +283,10 @@
                 .Set
               </spot-wards>
               <spot-ilks>
-                "gold" |-> SpotIlk ( 3000000000 , 1 )
+                "gold" |-> SpotIlk ( wad ( 3000000000 ) , ray ( 1 ) )
               </spot-ilks>
               <spot-par>
-                1
+                ray ( 1 )
               </spot-par>
               <spot-live>
                 true
@@ -314,43 +314,43 @@
                 Vow |-> SetItem ( Flap )
               </vat-can>
               <vat-ilks>
-                "gold" |-> Ilk ( 20 , 1 , 3000000000 , 1000000000000 , 0 )
+                "gold" |-> Ilk ( wad ( 20 ) , ray ( 1 ) , ray ( 3000000000 ) , rad ( 1000000000000 ) , rad ( 0 ) )
               </vat-ilks>
               <vat-urns>
-                { "gold" , "Alice" } |-> Urn ( 10 , 10 )
-                { "gold" , "Bobby" } |-> Urn ( 10 , 10 )
-                { "gold" , End } |-> Urn ( 0 , 0 )
+                { "gold" , "Alice" } |-> Urn ( wad ( 10 ) , wad ( 10 ) )
+                { "gold" , "Bobby" } |-> Urn ( wad ( 10 ) , wad ( 10 ) )
+                { "gold" , End } |-> Urn ( wad ( 0 ) , wad ( 0 ) )
               </vat-urns>
               <vat-gem>
-                { "gold" , "Alice" } |-> 0
-                { "gold" , "Bobby" } |-> 0
-                { "gold" , End } |-> 0
-                { "gold" , Flip "gold" } |-> 0
+                { "gold" , "Alice" } |-> wad ( 0 )
+                { "gold" , "Bobby" } |-> wad ( 0 )
+                { "gold" , End } |-> wad ( 0 )
+                { "gold" , Flip "gold" } |-> wad ( 0 )
               </vat-gem>
               <vat-dai>
-                "Alice" |-> 10
-                "Bobby" |-> 295 /Rat 128
-                End |-> 0
-                Flap |-> 0
-                Pot |-> 985 /Rat 128
-                Vow |-> 0
+                "Alice" |-> rad ( 10 )
+                "Bobby" |-> rad ( 295 /Rat 128 )
+                End |-> rad ( 0 )
+                Flap |-> rad ( 0 )
+                Pot |-> rad ( 985 /Rat 128 )
+                Vow |-> rad ( 0 )
               </vat-dai>
               <vat-sin>
-                "Alice" |-> 0
-                "Bobby" |-> 0
-                End |-> 0
-                Flap |-> 0
-                Pot |-> 0
-                Vow |-> 0
+                "Alice" |-> rad ( 0 )
+                "Bobby" |-> rad ( 0 )
+                End |-> rad ( 0 )
+                Flap |-> rad ( 0 )
+                Pot |-> rad ( 0 )
+                Vow |-> rad ( 0 )
               </vat-sin>
               <vat-debt>
-                20
+                rad ( 20 )
               </vat-debt>
               <vat-vice>
-                0
+                rad ( 0 )
               </vat-vice>
               <vat-Line>
-                1000000000000
+                rad ( 1000000000000 )
               </vat-Line>
               <vat-live>
                 true
@@ -365,25 +365,25 @@
                 .Map
               </vow-sins>
               <vow-sin>
-                0
+                rad ( 0 )
               </vow-sin>
               <vow-ash>
-                0
+                rad ( 0 )
               </vow-ash>
               <vow-wait>
                 0
               </vow-wait>
               <vow-dump>
-                30
+                wad ( 30 )
               </vow-dump>
               <vow-sump>
-                50
+                rad ( 50 )
               </vow-sump>
               <vow-bump>
-                1000000000
+                rad ( 1000000000 )
               </vow-bump>
               <vow-hump>
-                0
+                rad ( 0 )
               </vow-hump>
               <vow-live>
                 true
@@ -418,7 +418,7 @@
             .Set
           </dai-wards>
           <dai-totalSupply>
-            0
+            wad ( 0 )
           </dai-totalSupply>
           <dai-account-id>
             0
@@ -451,13 +451,13 @@
               0
             </end-wait>
             <end-debt>
-              0
+              rad ( 0 )
             </end-debt>
             <end-tag>
               .Map
             </end-tag>
             <end-gap>
-              "gold" |-> 0
+              "gold" |-> wad ( 0 )
             </end-gap>
             <end-art>
               .Map
@@ -466,12 +466,12 @@
               .Map
             </end-fix>
             <end-bag>
-              "Alice" |-> 0
-              "Bobby" |-> 0
+              "Alice" |-> wad ( 0 )
+              "Bobby" |-> wad ( 0 )
             </end-bag>
             <end-out>
-              { "gold" , "Alice" } |-> 0
-              { "gold" , "Bobby" } |-> 0
+              { "gold" , "Alice" } |-> wad ( 0 )
+              { "gold" , "Bobby" } |-> wad ( 0 )
             </end-out>
           </end>
         </end-state>
@@ -489,7 +489,7 @@
             false
           </flap-live>
           <flap-beg>
-            21 /Rat 20
+            wad ( 21 /Rat 20 )
           </flap-beg>
           <flap-ttl>
             10800
@@ -510,7 +510,7 @@
               .Map
             </flip-bids>
             <flip-beg>
-              21 /Rat 20
+              wad ( 21 /Rat 20 )
             </flip-beg>
             <flip-ttl>
               10800
@@ -537,10 +537,10 @@
             false
           </flop-live>
           <flop-beg>
-            21 /Rat 20
+            wad ( 21 /Rat 20 )
           </flop-beg>
           <flop-pad>
-            3 /Rat 2
+            wad ( 3 /Rat 2 )
           </flop-pad>
           <flop-ttl>
             10800
@@ -561,11 +561,11 @@
               .Set
             </gem-wards>
             <gem-balances>
-              "Alice" |-> 0
-              "Bobby" |-> 0
-              Flap |-> 0
-              GemJoin "MKR" |-> 0
-              Vow |-> 0
+              "Alice" |-> wad ( 0 )
+              "Bobby" |-> wad ( 0 )
+              Flap |-> wad ( 0 )
+              GemJoin "MKR" |-> wad ( 0 )
+              Vow |-> wad ( 0 )
             </gem-balances>
           </gem> <gem>
             <gem-id>
@@ -575,9 +575,9 @@
               .Set
             </gem-wards>
             <gem-balances>
-              "Alice" |-> 10
-              "Bobby" |-> 10
-              GemJoin "gold" |-> 20
+              "Alice" |-> wad ( 10 )
+              "Bobby" |-> wad ( 10 )
+              GemJoin "gold" |-> wad ( 20 )
             </gem-balances>
           </gem>
         </gems>
@@ -625,7 +625,7 @@
             0
           </jug-vow>
           <jug-base>
-            0
+            ray ( 0 )
           </jug-base>
         </jug>
         <pot>
@@ -633,17 +633,17 @@
             SetItem ( End )
           </pot-wards>
           <pot-pies>
-            "Alice" |-> 0
-            "Bobby" |-> 0
+            "Alice" |-> wad ( 0 )
+            "Bobby" |-> wad ( 0 )
           </pot-pies>
           <pot-pie>
-            0
+            wad ( 0 )
           </pot-pie>
           <pot-dsr>
-            1
+            ray ( 1 )
           </pot-dsr>
           <pot-chi>
-            1
+            ray ( 1 )
           </pot-chi>
           <pot-vow>
             Vow
@@ -660,10 +660,10 @@
             .Set
           </spot-wards>
           <spot-ilks>
-            "gold" |-> SpotIlk ( 3000000000 , 1 )
+            "gold" |-> SpotIlk ( wad ( 3000000000 ) , ray ( 1 ) )
           </spot-ilks>
           <spot-par>
-            1
+            ray ( 1 )
           </spot-par>
           <spot-live>
             true
@@ -691,43 +691,43 @@
             Vow |-> SetItem ( Flap )
           </vat-can>
           <vat-ilks>
-            "gold" |-> Ilk ( 20 , 1 , 3000000000 , 1000000000000 , 0 )
+            "gold" |-> Ilk ( wad ( 20 ) , ray ( 1 ) , ray ( 3000000000 ) , rad ( 1000000000000 ) , rad ( 0 ) )
           </vat-ilks>
           <vat-urns>
-            { "gold" , "Alice" } |-> Urn ( 10 , 10 )
-            { "gold" , "Bobby" } |-> Urn ( 10 , 10 )
-            { "gold" , End } |-> Urn ( 0 , 0 )
+            { "gold" , "Alice" } |-> Urn ( wad ( 10 ) , wad ( 10 ) )
+            { "gold" , "Bobby" } |-> Urn ( wad ( 10 ) , wad ( 10 ) )
+            { "gold" , End } |-> Urn ( wad ( 0 ) , wad ( 0 ) )
           </vat-urns>
           <vat-gem>
-            { "gold" , "Alice" } |-> 0
-            { "gold" , "Bobby" } |-> 0
-            { "gold" , End } |-> 0
-            { "gold" , Flip "gold" } |-> 0
+            { "gold" , "Alice" } |-> wad ( 0 )
+            { "gold" , "Bobby" } |-> wad ( 0 )
+            { "gold" , End } |-> wad ( 0 )
+            { "gold" , Flip "gold" } |-> wad ( 0 )
           </vat-gem>
           <vat-dai>
-            "Alice" |-> 10
-            "Bobby" |-> 295 /Rat 128
-            End |-> 0
-            Flap |-> 0
-            Pot |-> 985 /Rat 128
-            Vow |-> 0
+            "Alice" |-> rad ( 10 )
+            "Bobby" |-> rad ( 295 /Rat 128 )
+            End |-> rad ( 0 )
+            Flap |-> rad ( 0 )
+            Pot |-> rad ( 985 /Rat 128 )
+            Vow |-> rad ( 0 )
           </vat-dai>
           <vat-sin>
-            "Alice" |-> 0
-            "Bobby" |-> 0
-            End |-> 0
-            Flap |-> 0
-            Pot |-> 0
-            Vow |-> 0
+            "Alice" |-> rad ( 0 )
+            "Bobby" |-> rad ( 0 )
+            End |-> rad ( 0 )
+            Flap |-> rad ( 0 )
+            Pot |-> rad ( 0 )
+            Vow |-> rad ( 0 )
           </vat-sin>
           <vat-debt>
-            20
+            rad ( 20 )
           </vat-debt>
           <vat-vice>
-            0
+            rad ( 0 )
           </vat-vice>
           <vat-Line>
-            1000000000000
+            rad ( 1000000000000 )
           </vat-Line>
           <vat-live>
             false
@@ -742,25 +742,25 @@
             .Map
           </vow-sins>
           <vow-sin>
-            0
+            rad ( 0 )
           </vow-sin>
           <vow-ash>
-            0
+            rad ( 0 )
           </vow-ash>
           <vow-wait>
             0
           </vow-wait>
           <vow-dump>
-            30
+            wad ( 30 )
           </vow-dump>
           <vow-sump>
-            50
+            rad ( 50 )
           </vow-sump>
           <vow-bump>
-            1000000000
+            rad ( 1000000000 )
           </vow-bump>
           <vow-hump>
-            0
+            rad ( 0 )
           </vow-hump>
           <vow-live>
             false
@@ -770,839 +770,839 @@
     </kmcd>
     <processed-events>
       ListItem ( LogNote ( ADMIN , Vat . rely Pot ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . rely End ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . rely Spot ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Pot . rely End ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vow . rely Pot ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vow . rely End ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Cat . rely End ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Flap . rely Vow ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Flop . rely Vow ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser Vow ) )
-      ListItem ( Measure ( 0 , Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , Vow |-> 0 , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , Vow |-> rad ( 0 ) , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser Pot ) )
-      ListItem ( Measure ( 0 , Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , Pot |-> 0
-      Vow |-> 0 , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser Flap ) )
-      ListItem ( Measure ( 0 , Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , GemJoin "MKR" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , GemJoin "MKR" |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , GemJoin "MKR" |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Vow ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Flap ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Pot . file vow-file Vow ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( Vow , Vat . hope Flap ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vat . file Line 1000000000000 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vow . file bump 1000000000 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vow . file hump 0 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vow . file sump 50 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vow . file dump 30 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vat . file Line rad ( 1000000000000 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vow . file bump rad ( 1000000000 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vow . file hump rad ( 0 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vow . file sump rad ( 50 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vow . file dump wad ( 30 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Flop . file tau 3600 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , GemJoin "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . rely GemJoin "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" Flip "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Spot . init "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 3000000000 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Spot . file mat "gold" 1 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Spot . file par 1 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" wad ( 3000000000 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Spot . file mat "gold" ray ( 1 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Spot . file par ray ( 1 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Flip "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Flip "gold" . rely End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . initGap "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initIlk "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ANYONE , Vat . file spot "gold" 3000000000 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vat . file line "gold" rad ( 1000000000000 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ANYONE , Vat . file spot "gold" ray ( 3000000000 ) ) )
       ListItem ( LogNote ( ANYONE , Spot . poke "gold" ) )
-      ListItem ( Poke ( "gold" , 3000000000 , 3000000000 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Poke ( "gold" , wad ( 3000000000 ) , ray ( 3000000000 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Alice" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Bobby" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Alice" 20 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Bobby" 20 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Alice" wad ( 20 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Bobby" wad ( 20 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Alice" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Bobby" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Pot . initUser "Alice" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Pot . initUser "Bobby" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser "Alice" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Alice" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Alice" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser "Bobby" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Bobby" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Bobby" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Alice" , Vat . hope Pot ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Alice" , Vat . hope Flip "gold" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Alice" , Vat . hope End ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Alice" , Vat . hope Flop ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope Pot ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope Flip "gold" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope End ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope Flop ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( "Alice" , Vat . slip "gold" "Alice" 10 ) )
-      ListItem ( LogNote ( "Alice" , Gem "gold" . transferFrom "Alice" GemJoin "gold" 10 ) )
-      ListItem ( LogNote ( "Alice" , GemJoin "gold" . join "Alice" 10 ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 10 ) )
-      ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 10 ) )
-      ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 10 ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( "Alice" , Vat . frob "gold" "Alice" "Alice" "Alice" 10 10 ) )
-      ListItem ( Measure ( 10 , "Alice" |-> 10
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 10 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( "Alice" , Vat . slip "gold" "Alice" wad ( 10 ) ) )
+      ListItem ( LogNote ( "Alice" , Gem "gold" . transferFrom "Alice" GemJoin "gold" wad ( 10 ) ) )
+      ListItem ( LogNote ( "Alice" , GemJoin "gold" . join "Alice" wad ( 10 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" wad ( 10 ) ) )
+      ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" wad ( 10 ) ) )
+      ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" wad ( 10 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( "Alice" , Vat . frob "gold" "Alice" "Alice" "Alice" wad ( 10 ) wad ( 10 ) ) )
+      ListItem ( Measure ( rad ( 10 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 10 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" wad ( 10 ) wad ( 10 ) ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( "Bobby" , Vat . move "Bobby" Pot 985 /Rat 128 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 295 /Rat 128
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 985 /Rat 128
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 295 /Rat 128
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 985 /Rat 128
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Pot . file dsr 9 /Rat 8 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 295 /Rat 128
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 985 /Rat 128
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 295 /Rat 128
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 985 /Rat 128
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( "Bobby" , Vat . move "Bobby" Pot rad ( 985 /Rat 128 ) ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 295 /Rat 128 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 985 /Rat 128 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 295 /Rat 128 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 985 /Rat 128 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Pot . file dsr ray ( 9 /Rat 8 ) ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 295 /Rat 128 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 985 /Rat 128 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 295 /Rat 128 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 985 /Rat 128 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( TimeStep ( 1 , 1 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 295 /Rat 128
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 985 /Rat 128
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 295 /Rat 128
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 985 /Rat 128
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 295 /Rat 128 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 985 /Rat 128 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 295 /Rat 128 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 985 /Rat 128 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . cage ) )
       ListItem ( LogNote ( ADMIN , Cat . cage ) )
-      ListItem ( LogNote ( Vow , Vat . move Flap Vow 0 ) )
-      ListItem ( LogNote ( End , Flap . cage 0 ) )
+      ListItem ( LogNote ( Vow , Vat . move Flap Vow rad ( 0 ) ) )
+      ListItem ( LogNote ( End , Flap . cage rad ( 0 ) ) )
       ListItem ( LogNote ( End , Flop . cage ) )
-      ListItem ( LogNote ( End , Vat . heal 0 ) )
+      ListItem ( LogNote ( End , Vat . heal rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vow . cage ) )
       ListItem ( LogNote ( ADMIN , Pot . cage ) )
       ListItem ( LogNote ( ADMIN , End . cage ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 295 /Rat 128
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 985 /Rat 128
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 295 /Rat 128
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 985 /Rat 128
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 295 /Rat 128 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 985 /Rat 128 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 295 /Rat 128 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 985 /Rat 128 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
     </processed-events>
     <properties>
       "Debt Constant After Thaw" |-> debtConstantAfterThaw
       "Flap Dai Consistency" |-> flapDaiConsistencyEnd
       "Flap MKR Consistency" |-> flapMkrConsistency
-      "Flop Block Check" |-> flopBlockCheck ( 0 , 0 )
+      "Flop Block Check" |-> flopBlockCheck ( rad ( 0 ) , 0 )
       "Pot Interest Accumulation After End" |-> potEndInterestEnd
-      "PotChi PotPie VatPot" |-> potChiPieDai ( 985 /Rat 128 , 0 )
+      "PotChi PotPie VatPot" |-> potChiPieDai ( rad ( 985 /Rat 128 ) , wad ( 0 ) )
       "Total Backed Debt Consistency" |-> totalBackedDebtConsistency
-      "Total Bound on Debt" |-> Violated ( totalDebtBoundedEnd ( 21465 /Rat 1024 ) )
+      "Total Bound on Debt" |-> Violated ( totalDebtBoundedEnd ( rad ( 21465 /Rat 1024 ) ) )
       "Unauthorized Flap Kick" |-> unAuthFlapKick
       "Unauthorized Flip Kick" |-> unAuthFlipKick
       "Zero-Time Pot Interest Accumulation" |-> zeroTimePotInterestEnd

--- a/tests/fixes/potChiPieDai.mcd.expected
+++ b/tests/fixes/potChiPieDai.mcd.expected
@@ -50,7 +50,7 @@
             .Set
           </dai-wards>
           <dai-totalSupply>
-            0
+            wad ( 0 )
           </dai-totalSupply>
           <dai-account-id>
             0
@@ -83,13 +83,13 @@
               0
             </end-wait>
             <end-debt>
-              0
+              rad ( 0 )
             </end-debt>
             <end-tag>
               .Map
             </end-tag>
             <end-gap>
-              "gold" |-> 0
+              "gold" |-> wad ( 0 )
             </end-gap>
             <end-art>
               .Map
@@ -98,12 +98,12 @@
               .Map
             </end-fix>
             <end-bag>
-              "Alice" |-> 0
-              "Bobby" |-> 0
+              "Alice" |-> wad ( 0 )
+              "Bobby" |-> wad ( 0 )
             </end-bag>
             <end-out>
-              { "gold" , "Alice" } |-> 0
-              { "gold" , "Bobby" } |-> 0
+              { "gold" , "Alice" } |-> wad ( 0 )
+              { "gold" , "Bobby" } |-> wad ( 0 )
             </end-out>
           </end>
         </end-state>
@@ -121,7 +121,7 @@
             true
           </flap-live>
           <flap-beg>
-            21 /Rat 20
+            wad ( 21 /Rat 20 )
           </flap-beg>
           <flap-ttl>
             10800
@@ -142,7 +142,7 @@
               .Map
             </flip-bids>
             <flip-beg>
-              21 /Rat 20
+              wad ( 21 /Rat 20 )
             </flip-beg>
             <flip-ttl>
               10800
@@ -169,10 +169,10 @@
             true
           </flop-live>
           <flop-beg>
-            21 /Rat 20
+            wad ( 21 /Rat 20 )
           </flop-beg>
           <flop-pad>
-            3 /Rat 2
+            wad ( 3 /Rat 2 )
           </flop-pad>
           <flop-ttl>
             10800
@@ -193,11 +193,11 @@
               .Set
             </gem-wards>
             <gem-balances>
-              "Alice" |-> 0
-              "Bobby" |-> 0
-              Flap |-> 0
-              GemJoin "MKR" |-> 0
-              Vow |-> 0
+              "Alice" |-> wad ( 0 )
+              "Bobby" |-> wad ( 0 )
+              Flap |-> wad ( 0 )
+              GemJoin "MKR" |-> wad ( 0 )
+              Vow |-> wad ( 0 )
             </gem-balances>
           </gem> <gem>
             <gem-id>
@@ -207,9 +207,9 @@
               .Set
             </gem-wards>
             <gem-balances>
-              "Alice" |-> 10
-              "Bobby" |-> 10
-              GemJoin "gold" |-> 20
+              "Alice" |-> wad ( 10 )
+              "Bobby" |-> wad ( 10 )
+              GemJoin "gold" |-> wad ( 20 )
             </gem-balances>
           </gem>
         </gems>
@@ -257,7 +257,7 @@
             0
           </jug-vow>
           <jug-base>
-            0
+            ray ( 0 )
           </jug-base>
         </jug>
         <pot>
@@ -265,17 +265,17 @@
             SetItem ( End )
           </pot-wards>
           <pot-pies>
-            "Alice" |-> 0
-            "Bobby" |-> 0
+            "Alice" |-> wad ( 0 )
+            "Bobby" |-> wad ( 0 )
           </pot-pies>
           <pot-pie>
-            0
+            wad ( 0 )
           </pot-pie>
           <pot-dsr>
-            23 /Rat 20
+            ray ( 23 /Rat 20 )
           </pot-dsr>
           <pot-chi>
-            1
+            ray ( 1 )
           </pot-chi>
           <pot-vow>
             Vow
@@ -292,10 +292,10 @@
             .Set
           </spot-wards>
           <spot-ilks>
-            "gold" |-> SpotIlk ( 3000000000 , 1 )
+            "gold" |-> SpotIlk ( wad ( 3000000000 ) , ray ( 1 ) )
           </spot-ilks>
           <spot-par>
-            1
+            ray ( 1 )
           </spot-par>
           <spot-live>
             true
@@ -323,43 +323,43 @@
             Vow |-> SetItem ( Flap )
           </vat-can>
           <vat-ilks>
-            "gold" |-> Ilk ( 20 , 1 , 3000000000 , 1000000000000 , 0 )
+            "gold" |-> Ilk ( wad ( 20 ) , ray ( 1 ) , ray ( 3000000000 ) , rad ( 1000000000000 ) , rad ( 0 ) )
           </vat-ilks>
           <vat-urns>
-            { "gold" , "Alice" } |-> Urn ( 10 , 10 )
-            { "gold" , "Bobby" } |-> Urn ( 10 , 10 )
-            { "gold" , End } |-> Urn ( 0 , 0 )
+            { "gold" , "Alice" } |-> Urn ( wad ( 10 ) , wad ( 10 ) )
+            { "gold" , "Bobby" } |-> Urn ( wad ( 10 ) , wad ( 10 ) )
+            { "gold" , End } |-> Urn ( wad ( 0 ) , wad ( 0 ) )
           </vat-urns>
           <vat-gem>
-            { "gold" , "Alice" } |-> 0
-            { "gold" , "Bobby" } |-> 0
-            { "gold" , End } |-> 0
-            { "gold" , Flip "gold" } |-> 0
+            { "gold" , "Alice" } |-> wad ( 0 )
+            { "gold" , "Bobby" } |-> wad ( 0 )
+            { "gold" , End } |-> wad ( 0 )
+            { "gold" , Flip "gold" } |-> wad ( 0 )
           </vat-gem>
           <vat-dai>
-            "Alice" |-> 10
-            "Bobby" |-> 145 /Rat 64
-            End |-> 0
-            Flap |-> 0
-            Pot |-> 495 /Rat 64
-            Vow |-> 0
+            "Alice" |-> rad ( 10 )
+            "Bobby" |-> rad ( 145 /Rat 64 )
+            End |-> rad ( 0 )
+            Flap |-> rad ( 0 )
+            Pot |-> rad ( 495 /Rat 64 )
+            Vow |-> rad ( 0 )
           </vat-dai>
           <vat-sin>
-            "Alice" |-> 0
-            "Bobby" |-> 0
-            End |-> 0
-            Flap |-> 0
-            Pot |-> 0
-            Vow |-> 0
+            "Alice" |-> rad ( 0 )
+            "Bobby" |-> rad ( 0 )
+            End |-> rad ( 0 )
+            Flap |-> rad ( 0 )
+            Pot |-> rad ( 0 )
+            Vow |-> rad ( 0 )
           </vat-sin>
           <vat-debt>
-            20
+            rad ( 20 )
           </vat-debt>
           <vat-vice>
-            0
+            rad ( 0 )
           </vat-vice>
           <vat-Line>
-            1000000000000
+            rad ( 1000000000000 )
           </vat-Line>
           <vat-live>
             true
@@ -374,25 +374,25 @@
             .Map
           </vow-sins>
           <vow-sin>
-            0
+            rad ( 0 )
           </vow-sin>
           <vow-ash>
-            0
+            rad ( 0 )
           </vow-ash>
           <vow-wait>
             0
           </vow-wait>
           <vow-dump>
-            30
+            wad ( 30 )
           </vow-dump>
           <vow-sump>
-            50
+            rad ( 50 )
           </vow-sump>
           <vow-bump>
-            1000000000
+            rad ( 1000000000 )
           </vow-bump>
           <vow-hump>
-            0
+            rad ( 0 )
           </vow-hump>
           <vow-live>
             true
@@ -402,830 +402,830 @@
     </kmcd>
     <processed-events>
       ListItem ( LogNote ( ADMIN , Vat . rely Pot ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . rely End ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . rely Spot ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Pot . rely End ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vow . rely Pot ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vow . rely End ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Cat . rely End ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Flap . rely Vow ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Flop . rely Vow ) )
-      ListItem ( Measure ( 0 , .Map , 1 , 0 , 0 , 0 , 0 , 0 , .Map , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , .Map , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , .Map , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser Vow ) )
-      ListItem ( Measure ( 0 , Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , Vow |-> 0 , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , Vow |-> rad ( 0 ) , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser Pot ) )
-      ListItem ( Measure ( 0 , Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , Pot |-> 0
-      Vow |-> 0 , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser Flap ) )
-      ListItem ( Measure ( 0 , Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , .Map , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , .Map , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , GemJoin "MKR" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , GemJoin "MKR" |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , GemJoin "MKR" |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Vow ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser Flap ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Pot . file vow-file Vow ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( Vow , Vat . hope Flap ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vat . file Line 1000000000000 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vow . file bump 1000000000 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vow . file hump 0 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vow . file sump 50 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vow . file dump 30 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vat . file Line rad ( 1000000000000 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vow . file bump rad ( 1000000000 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vow . file hump rad ( 0 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vow . file sump rad ( 50 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vow . file dump wad ( 30 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Flop . file tau 3600 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , GemJoin "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . rely GemJoin "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" Flip "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Spot . init "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" 3000000000 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Spot . file mat "gold" 1 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Spot . file par 1 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Spot . setPrice "gold" wad ( 3000000000 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Spot . file mat "gold" ray ( 1 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Spot . file par ray ( 1 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Flip "gold" . init ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Flip "gold" . rely End ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . initGap "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initIlk "gold" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Vat . file line "gold" 1000000000000 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ANYONE , Vat . file spot "gold" 3000000000 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Vat . file line "gold" rad ( 1000000000000 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ANYONE , Vat . file spot "gold" ray ( 3000000000 ) ) )
       ListItem ( LogNote ( ANYONE , Spot . poke "gold" ) )
-      ListItem ( Poke ( "gold" , 3000000000 , 3000000000 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Poke ( "gold" , wad ( 3000000000 ) , ray ( 3000000000 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Alice" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "gold" . initUser "Bobby" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Alice" 20 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Bobby" 20 ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Alice" wad ( 20 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Gem "gold" . mint "Bobby" wad ( 20 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Alice" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Gem "MKR" . initUser "Bobby" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Pot . initUser "Alice" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Pot . initUser "Bobby" ) )
-      ListItem ( Measure ( 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser "Alice" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Alice" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Alice" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initUser "Bobby" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initGem "gold" "Bobby" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , Vat . initCDP "gold" "Bobby" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Alice" , Vat . hope Pot ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Alice" , Vat . hope Flip "gold" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Alice" , Vat . hope End ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Alice" , Vat . hope Flop ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope Pot ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope Flip "gold" ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope End ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( "Bobby" , Vat . hope Flop ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( "Alice" , Vat . slip "gold" "Alice" 10 ) )
-      ListItem ( LogNote ( "Alice" , Gem "gold" . transferFrom "Alice" GemJoin "gold" 10 ) )
-      ListItem ( LogNote ( "Alice" , GemJoin "gold" . join "Alice" 10 ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" 10 ) )
-      ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" 10 ) )
-      ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" 10 ) )
-      ListItem ( Measure ( 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 0 , 0 , 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( "Alice" , Vat . frob "gold" "Alice" "Alice" "Alice" 10 10 ) )
-      ListItem ( Measure ( 10 , "Alice" |-> 10
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 10 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 0
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" 10 10 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( "Alice" , Vat . slip "gold" "Alice" wad ( 10 ) ) )
+      ListItem ( LogNote ( "Alice" , Gem "gold" . transferFrom "Alice" GemJoin "gold" wad ( 10 ) ) )
+      ListItem ( LogNote ( "Alice" , GemJoin "gold" . join "Alice" wad ( 10 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( "Bobby" , Vat . slip "gold" "Bobby" wad ( 10 ) ) )
+      ListItem ( LogNote ( "Bobby" , Gem "gold" . transferFrom "Bobby" GemJoin "gold" wad ( 10 ) ) )
+      ListItem ( LogNote ( "Bobby" , GemJoin "gold" . join "Bobby" wad ( 10 ) ) )
+      ListItem ( Measure ( rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 0 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( "Alice" , Vat . frob "gold" "Alice" "Alice" "Alice" wad ( 10 ) wad ( 10 ) ) )
+      ListItem ( Measure ( rad ( 10 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 10 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 0 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( "Bobby" , Vat . frob "gold" "Bobby" "Bobby" "Bobby" wad ( 10 ) wad ( 10 ) ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . initBag "Alice" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . initBag "Bobby" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . initOut "gold" "Alice" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( LogNote ( ADMIN , End . initOut "gold" "Bobby" ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( ADMIN , Pot . file dsr 23 /Rat 20 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( ADMIN , Pot . file dsr ray ( 23 /Rat 20 ) ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
       ListItem ( TimeStep ( 1 , 1 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 10
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 0
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( LogNote ( "Bobby" , Vat . move "Bobby" Pot 495 /Rat 64 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 145 /Rat 64
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 495 /Rat 64
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 145 /Rat 64
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 495 /Rat 64
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
-      ListItem ( Measure ( 20 , "Alice" |-> 10
-      "Bobby" |-> 145 /Rat 64
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 495 /Rat 64
-      Vow |-> 0 , 1 , 0 , 20 , 0 , 0 , 0 , "Alice" |-> 10
-      "Bobby" |-> 145 /Rat 64
-      End |-> 0
-      Flap |-> 0
-      Pot |-> 495 /Rat 64
-      Vow |-> 0 , 0 , "Alice" |-> 0
-      "Bobby" |-> 0
-      Flap |-> 0
-      GemJoin "MKR" |-> 0
-      Vow |-> 0 , 0 ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 10 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 0 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( LogNote ( "Bobby" , Vat . move "Bobby" Pot rad ( 495 /Rat 64 ) ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 145 /Rat 64 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 495 /Rat 64 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 145 /Rat 64 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 495 /Rat 64 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
+      ListItem ( Measure ( rad ( 20 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 145 /Rat 64 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 495 /Rat 64 )
+      Vow |-> rad ( 0 ) , ray ( 1 ) , wad ( 0 ) , rad ( 20 ) , rad ( 0 ) , rad ( 0 ) , rad ( 0 ) , "Alice" |-> rad ( 10 )
+      "Bobby" |-> rad ( 145 /Rat 64 )
+      End |-> rad ( 0 )
+      Flap |-> rad ( 0 )
+      Pot |-> rad ( 495 /Rat 64 )
+      Vow |-> rad ( 0 ) , wad ( 0 ) , "Alice" |-> wad ( 0 )
+      "Bobby" |-> wad ( 0 )
+      Flap |-> wad ( 0 )
+      GemJoin "MKR" |-> wad ( 0 )
+      Vow |-> wad ( 0 ) , rad ( 0 ) ) )
     </processed-events>
     <properties>
       "Debt Constant After Thaw" |-> debtConstantAfterThaw
       "Flap Dai Consistency" |-> flapDaiConsistency
       "Flap MKR Consistency" |-> flapMkrConsistency
-      "Flop Block Check" |-> flopBlockCheck ( 0 , 0 )
+      "Flop Block Check" |-> flopBlockCheck ( rad ( 0 ) , 0 )
       "Pot Interest Accumulation After End" |-> potEndInterest
-      "PotChi PotPie VatPot" |-> potChiPieDai ( 495 /Rat 64 , 0 )
+      "PotChi PotPie VatPot" |-> potChiPieDai ( rad ( 495 /Rat 64 ) , wad ( 0 ) )
       "Total Backed Debt Consistency" |-> totalBackedDebtConsistency
-      "Total Bound on Debt" |-> totalDebtBoundedRun ( 20 , 23 /Rat 20 )
+      "Total Bound on Debt" |-> totalDebtBoundedRun ( rad ( 20 ) , ray ( 23 /Rat 20 ) )
       "Unauthorized Flap Kick" |-> unAuthFlapKick
       "Unauthorized Flip Kick" |-> unAuthFlipKick
       "Zero-Time Pot Interest Accumulation" |-> zeroTimePotInterestEnd

--- a/vat.md
+++ b/vat.md
@@ -396,9 +396,7 @@ This is quite permissive, and would allow the account to drain all your locked c
 
     syntax VatStep ::= "frob" String Address Address Address Wad Wad
  // ----------------------------------------------------------------
-    rule <k> Vat . frob ILKID ADDRU ADDRV ADDRW DINK DART => .
-         ...
-         </k>
+    rule <k> Vat . frob ILKID ADDRU ADDRV ADDRW DINK DART => . ... </k>
          <vat-live> true </vat-live>
          <vat-debt> DEBT => DEBT +Rad (DART *Rate RATE) </vat-debt>
          <vat-urns> ... { ILKID , ADDRU } |-> Urn ( INK => INK +Wad DINK , URNART => URNART +Wad DART ) ... </vat-urns>


### PR DESCRIPTION
Blocked on #173 

This makes the types stronger for each of `Wad/Ray/Rad`, by making them wrapped rationals instead of just sort synonyms for rationals.

The benefit here is that we get sort-checking now for each operation we use.