### PR TITLE
Use K Dockerhub images on CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,49 +1,21 @@
-FROM runtimeverificationinc/ubuntu:bionic
+ARG K_COMMIT
+FROM runtimeverificationinc/kframework-k:ubuntu-bionic-${K_COMMIT}
 
 RUN    apt-get update        \
     && apt-get upgrade --yes \
     && apt-get install --yes \
-        autoconf             \
-        bison                \
-        clang++-8            \
-        clang-8              \
         cmake                \
-        curl                 \
-        flex                 \
-        gcc                  \
-        git                  \
-        libboost-test-dev    \
-        libgmp-dev           \
-        libjemalloc-dev      \
-        libmpfr-dev          \
         libprocps-dev        \
-        libprotobuf-dev      \
-        libsecp256k1-dev     \
-        libtool              \
-        libyaml-dev          \
-        libz3-dev            \
-        lld-8                \
-        llvm-8               \
-        llvm-8-tools         \
-        make                 \
-        maven                \
-        openjdk-11-jdk       \
         pandoc               \
         pkg-config           \
-        protobuf-compiler    \
-        python3              \
-        z3                   \
-        zlib1g-dev
+        python3
 
-ADD deps/k/haskell-backend/src/main/native/haskell-backend/scripts/install-stack.sh /.install-stack/
-RUN /.install-stack/install-stack.sh
+ARG USER_ID=1000
+ARG GROUP_ID=1000
+RUN groupadd -g $GROUP_ID user && useradd -m -u $USER_ID -s /bin/sh -g user user
 
 USER user:user
-
-ADD --chown=user:user deps/k/haskell-backend/src/main/native/haskell-backend/stack.yaml /home/user/.tmp-haskell/
-ADD --chown=user:user deps/k/haskell-backend/src/main/native/haskell-backend/kore/package.yaml /home/user/.tmp-haskell/kore/
-RUN    cd /home/user/.tmp-haskell  \
-    && stack build --only-snapshot
+WORKDIR /home/user
 
 RUN    git config --global user.email "admin@runtimeverification.com" \
     && git config --global user.name  "RV Jenkins"                    \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,12 +12,6 @@ pipeline {
       steps { script { currentBuild.displayName = "PR ${env.CHANGE_ID}: ${env.CHANGE_TITLE}" } }
     }
     stage('Build and Test') {
-      agent {
-        dockerfile {
-          additionalBuildArgs '--build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g)'
-          reuseNode true
-        }
-      }
       stages {
         stage('Dependencies') { steps { sh 'make deps K_BUILD_TYPE=Release' } }
         stage('Build')        { steps { sh 'make build -j4'                 } }
@@ -31,12 +25,6 @@ pipeline {
       }
     }
     stage('Deploy') {
-      agent {
-        dockerfile {
-          additionalBuildArgs '--build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g)'
-          reuseNode true
-        }
-      }
       when {
         branch 'master'
         beforeAgent true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,8 +13,7 @@ pipeline {
     }
     stage('Build and Test') {
       stages {
-        stage('Dependencies') { steps { sh 'make deps K_BUILD_TYPE=Release' } }
-        stage('Build')        { steps { sh 'make build -j4'                 } }
+        stage('Build') { steps { sh 'make build -j4' } }
         stage('Test') {
           parallel {
             stage('Run Simulation Tests')              { steps { sh 'make test-execution -j8'    } }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,9 +16,9 @@ pipeline {
         stage('Build') { steps { sh 'make build -j4' } }
         stage('Test') {
           parallel {
-            stage('Run Simulation Tests')              { steps { sh 'make test-execution -j8'    } }
-            stage('Python Generator (Lucash Attacks)') { steps { sh 'make test-python-generator' } }
-            stage('Python Generator')                  { steps { sh 'make test-random'           } }
+            stage('Run Simulation Tests') { steps { sh 'make test-execution -j8'    } }
+            stage('Python Runner')        { steps { sh 'make test-python-generator' } }
+            stage('Random Generation')    { steps { sh 'make test-random'           } }
           }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,10 @@
 pipeline {
-  agent { label 'docker' }
+  agent {
+    dockerfile {
+      label 'docker'
+      additionalBuildArgs '--build-arg K_COMMIT=$(cd deps/k && git rev-parse --short=7 HEAD) --build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g)'
+    }
+  }
   options { ansiColor('xterm') }
   stages {
     stage('Init title') {

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,6 @@ PANDOC_TANGLE_SUBMODULE:=$(DEPS_DIR)/pandoc-tangle
 K_RELEASE := $(K_SUBMODULE)/k-distribution/target/release/k
 K_BIN     := $(K_RELEASE)/bin
 K_LIB     := $(K_RELEASE)/lib
-export K_RELEASE
 
 K_BUILD_TYPE := FastBuild
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ K_BUILD_TYPE := FastBuild
 PATH:=$(K_BIN):$(PATH)
 export PATH
 
-PYTHONPATH:=$(K_LIB)
+PYTHONPATH:=$(K_LIB):/usr/lib/kframework/lib
 export PYTHONPATH
 
 TANGLER:=$(PANDOC_TANGLE_SUBMODULE)/tangle.lua

--- a/Makefile
+++ b/Makefile
@@ -101,20 +101,20 @@ $(haskell_dir)/%.k: %.md
 # LLVM Backend
 
 $(llvm_kompiled): $(llvm_files)
-	$(K_BIN)/kompile --debug --main-module $(MAIN_MODULE) --backend llvm              \
-	                 --syntax-module $(SYNTAX_MODULE) $(llvm_dir)/$(MAIN_DEFN_FILE).k \
-	                 --directory $(llvm_dir) -I $(llvm_dir)                           \
-	                 --emit-json                                                      \
-	                 $(LLVM_KOMPILE_OPTS)
+	kompile --debug --main-module $(MAIN_MODULE) --backend llvm              \
+	        --syntax-module $(SYNTAX_MODULE) $(llvm_dir)/$(MAIN_DEFN_FILE).k \
+	        --directory $(llvm_dir) -I $(llvm_dir)                           \
+	        --emit-json                                                      \
+	        $(LLVM_KOMPILE_OPTS)
 
 # Haskell Backend
 
 $(haskell_kompiled): $(haskell_files)
-	$(K_BIN)/kompile --debug --main-module $(MAIN_MODULE) --backend haskell              \
-	                 --syntax-module $(SYNTAX_MODULE) $(haskell_dir)/$(MAIN_DEFN_FILE).k \
-	                 --directory $(haskell_dir) -I $(haskell_dir)                        \
-	                 --emit-json                                                         \
-	                 $(KOMPILE_OPTS)
+	kompile --debug --main-module $(MAIN_MODULE) --backend haskell              \
+	        --syntax-module $(SYNTAX_MODULE) $(haskell_dir)/$(MAIN_DEFN_FILE).k \
+	        --directory $(haskell_dir) -I $(haskell_dir)                        \
+	        --emit-json                                                         \
+	        $(KOMPILE_OPTS)
 
 # Test
 # ----

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ export TANGLER
 export LUA_PATH
 
 .PHONY: all clean                                             \
-        deps deps-k deps-tangle deps-media                    \
+        deps deps-k deps-media                                \
         defn defn-llvm defn-haskell                           \
         build build-llvm build-haskell                        \
         test test-execution test-python-generator test-random
@@ -37,21 +37,13 @@ all: build
 clean:
 	rm -rf $(BUILD_DIR)
 
-clean-submodules:
-	rm -rf $(DEPS_DIR)/k/submodule.timestamp $(DEPS_DIR)/k/mvn.timestamp $(DEPS_DIR)/pandoc-tangle/submodule.timestamp tests/eth2.0-specs/submodule.timestamp
-
 # Dependencies
 # ------------
 
-deps: deps-k deps-tangle
+deps: deps-k
 deps-k: $(K_SUBMODULE)/mvn.timestamp
-deps-tangle: $(PANDOC_TANGLE_SUBMODULE)/submodule.timestamp
 
-%/submodule.timestamp:
-	git submodule update --init --recursive -- $*
-	touch $@
-
-$(K_SUBMODULE)/mvn.timestamp: $(K_SUBMODULE)/submodule.timestamp
+$(K_SUBMODULE)/mvn.timestamp:
 	cd $(K_SUBMODULE) && mvn package -DskipTests -Dproject.build.type=$(K_BUILD_TYPE)
 	touch $(K_SUBMODULE)/mvn.timestamp
 

--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ $(haskell_kompiled): $(haskell_files)
 
 KMCD_RANDOMSEED := ""
 
-test: test-execution test-python-generator
+test: test-execution test-python-generator test-random
 
 execution_tests_random := $(wildcard tests/*/*.random.mcd)
 execution_tests := $(wildcard tests/*/*.mcd)


### PR DESCRIPTION
~Not ready for merge.~

@daimesava and @kmbarry1 this is ready for review now. It makes it so that we use the K dockerhub image on CI jobs, for the purpose of skipping the K build step.

If CircleCI is able to take advantage of Dockerhub images, then this may be helpful there too.