### PR TITLE
circle-ci template

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,20 +1,18 @@
 version: 2
 jobs:
-  dependencies:
+  build:
     docker:
-      - image: circleci/node:lts
+      - image: runtimeverificationinc/kframework-k:ubuntu-bionic-master
     steps:
       - checkout
+      - attach_workspace:
+          at: .build
       - run:
-          name: Install dependencies
-          command: |
-            make deps
-      - persist_to_workspace:
-          root: .
-          paths: .build/*
+          name: Build Definition
+          command: make build -j8
   test:
     docker:
-      - image: circleci/node:lts
+      - image: runtimeverificationinc/kframework-k:ubuntu-bionic-master
     steps:
       - checkout
       - attach_workspace:
@@ -27,7 +25,7 @@ jobs:
             make test-random
   gh-pages-deploy:
     docker:
-      - image: node:12.13
+      - image: runtimeverificationinc/kframework-k:ubuntu-bionic-master
     steps:
       - checkout
       - attach_workspace:
@@ -52,10 +50,10 @@ workflows:
   version: 2
   mainflow:
     jobs:
-      - dependencies
+      - build
       - test:
           requires:
-            - dependencies
+            - build
       - gh-pages-deploy:
           requires:
             - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,64 @@
+version: 2
+jobs:
+  dependencies:
+    docker:
+      - image: circleci/node:lts
+    steps:
+      - checkout
+      - run:
+          name: Install dependencies
+          command: |
+            make deps
+      - persist_to_workspace:
+          root: .
+          paths: .build/*
+  test:
+    docker:
+      - image: circleci/node:lts
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .build
+      - run:
+          name: Run tests
+          command: |
+            make test-execution
+            make test-python-generator
+            make test-random
+  gh-pages-deploy:
+    docker:
+      - image: node:12.13
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .build
+      - add_ssh_keys:
+          fingerprints:
+            - "be:c8:cd:8e:00:2b:23:d7:62:e4:8b:41:59:35:59:14"
+      - run:
+          name: gh-pages
+          command: |
+            git config user.email "mkr-mcd-spec@makerdao.com"
+            git config user.name "CircleCI"
+            git checkout -B 'gh-pages'
+            rm -rf .build .gitignore deps .gitmodules Dockerfile Jenkinsfile Makefile kmcd mcd-pyk.py
+            git add ./
+            git commit -m 'gh-pages: remove unrelated content'
+            git fetch origin gh-pages
+            git merge --strategy ours FETCH_HEAD
+            git push origin gh-pages
+
+workflows:
+  version: 2
+  mainflow:
+    jobs:
+      - dependencies
+      - test:
+          requires:
+            - dependencies
+      - gh-pages-deploy:
+          requires:
+            - test
+          filters:
+            branches:
+              only: master

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![CircleCI](https://circleci.com/gh/makerdao/mkr-mcd-spec.svg?style=svg)](https://circleci.com/gh/makerdao/mkr-mcd-spec)
+
 KMCD - Multi-Collateral Dai (MCD) KSpecification
 ====================================================
 


### PR DESCRIPTION
Like we discussed last week, this is the general template. It should work pretty much out of the box with the images mentioned in https://github.com/makerdao/mkr-mcd-spec/issues/22#issuecomment-623546597 slotting in in each stage.

The key defined in `gh-pages-deploy` is wrong, so that step will fail. Will add a working one once we iron out the deps and test details