### PR TITLE
Clean separation of representation of Wad/Ray/Rad

### DIFF
--- a/cat.md
+++ b/cat.md
@@ -101,11 +101,11 @@ The parameters controlled by governance are:
 
     rule <k> Cat . file chop ILKID CHOP => . ... </k>
          <cat-ilks> ... ILKID |-> Ilk ( ... chop: (_ => CHOP) ) ... </cat-ilks>
-      requires CHOP >=Ray 0Ray
+      requires CHOP >=Ray ray(0)
 
     rule <k> Cat . file lump ILKID LUMP => . ... </k>
          <cat-ilks> ... ILKID |-> Ilk ( ... lump: (_ => LUMP) ) ... </cat-ilks>
-      requires LUMP >=Wad 0Wad
+      requires LUMP >=Wad wad(0)
 ```
 
 **NOTE**: `flip` is not fileable since we are assuming a unique liquidator for each ilk.
@@ -122,9 +122,9 @@ Cat Semantics
           => #fun(LOT
           => #fun(ART
           => #fun(TAB
-          => call Vat . grab ILK URN THIS VOWADDR (0Wad -Wad LOT) (0Wad -Wad ART)
+          => call Vat . grab ILK URN THIS VOWADDR (wad(0) -Wad LOT) (wad(0) -Wad ART)
           ~> call Vow . fess TAB
-          ~> call Flip ILK . kick URN VOWADDR rmul(TAB, CHOP) LOT 0Rad
+          ~> call Flip ILK . kick URN VOWADDR rmul(TAB, CHOP) LOT rad(0)
           ~> emitBite ILK URN LOT ART TAB)
           (ART *Rate RATE))
           (minWad(URNART, (LOT *Wad URNART) /Wad INK)))

--- a/dai.md
+++ b/dai.md
@@ -13,12 +13,12 @@ module DAI
 
     configuration
       <dai>
-        <dai-wards>       .Set </dai-wards>
-        <dai-totalSupply> 0Wad </dai-totalSupply>
-        <dai-account-id>  0    </dai-account-id>
-        <dai-balance>     .Map </dai-balance>     // mapping (address => uint)                      Address |-> Wad
-        <dai-allowance>   .Map </dai-allowance>   // mapping (address => mapping (address => uint))
-        <dai-nonce>       .Map </dai-nonce>       // mapping (address => uint)                      Address |-> Wad
+        <dai-wards>       .Set   </dai-wards>
+        <dai-totalSupply> wad(0) </dai-totalSupply>
+        <dai-account-id>  0      </dai-account-id>
+        <dai-balance>     .Map   </dai-balance>     // mapping (address => uint)                      Address |-> Wad
+        <dai-allowance>   .Map   </dai-allowance>   // mapping (address => mapping (address => uint))
+        <dai-nonce>       .Map   </dai-nonce>       // mapping (address => uint)                      Address |-> Wad
       </dai>
 ```
 
@@ -79,7 +79,7 @@ The Dai token is a mintable/burnable ERC20 token.
          <msg-sender> ACCOUNT_SRC </msg-sender>
          <dai-balance> ... ACCOUNT_SRC |-> BALANCE_SRC ... </dai-balance>
          <frame-events> ... (.List => ListItem(Transfer(ACCOUNT_SRC, ACCOUNT_SRC, AMOUNT))) </frame-events>
-      requires AMOUNT >=Wad 0Wad
+      requires AMOUNT >=Wad wad(0)
        andBool BALANCE_SRC >=Wad AMOUNT
 
     rule <k> Dai . transfer ACCOUNT_DST AMOUNT => . ... </k>
@@ -91,7 +91,7 @@ The Dai token is a mintable/burnable ERC20 token.
            ...
          </dai-balance>
          <frame-events> ... (.List => ListItem(Transfer(ACCOUNT_SRC, ACCOUNT_DST, AMOUNT))) </frame-events>
-      requires AMOUNT >=Wad 0Wad
+      requires AMOUNT >=Wad wad(0)
        andBool ACCOUNT_SRC =/=K ACCOUNT_DST
        andBool BALANCE_SRC >=Wad AMOUNT
 
@@ -100,7 +100,7 @@ The Dai token is a mintable/burnable ERC20 token.
     rule <k> Dai . transferFrom ACCOUNT_SRC ACCOUNT_SRC AMOUNT => . ... </k>
          <dai-balance> ... ACCOUNT_SRC |-> BALANCE_SRC ... </dai-balance>
          <frame-events> ... (.List => ListItem(Transfer(ACCOUNT_SRC, ACCOUNT_SRC, AMOUNT))) </frame-events>
-      requires AMOUNT >=Wad 0Wad
+      requires AMOUNT >=Wad wad(0)
        andBool BALANCE_SRC >=Wad AMOUNT
 
     rule <k> Dai . transferFrom ACCOUNT_SRC ACCOUNT_DST AMOUNT => . ... </k>
@@ -112,7 +112,7 @@ The Dai token is a mintable/burnable ERC20 token.
            ...
          </dai-balance>
          <frame-events> ... (.List => ListItem(Transfer(ACCOUNT_SRC, ACCOUNT_DST, AMOUNT))) </frame-events>
-      requires AMOUNT >=Wad 0Wad
+      requires AMOUNT >=Wad wad(0)
        andBool ACCOUNT_SRC =/=K ACCOUNT_DST
        andBool BALANCE_SRC >=Wad AMOUNT
        andBool ALLOWANCE_SRC_DST >=Wad AMOUNT
@@ -126,7 +126,7 @@ The Dai token is a mintable/burnable ERC20 token.
            ...
          </dai-balance>
          <frame-events> ... (.List => ListItem(Transfer(ACCOUNT_SRC, ACCOUNT_DST, AMOUNT))) </frame-events>
-      requires AMOUNT >=Wad 0Wad
+      requires AMOUNT >=Wad wad(0)
        andBool ACCOUNT_SRC =/=K ACCOUNT_DST
        andBool BALANCE_SRC >=Wad AMOUNT
 
@@ -136,7 +136,7 @@ The Dai token is a mintable/burnable ERC20 token.
          <dai-totalSupply> DAI_SUPPLY => DAI_SUPPLY +Wad AMOUNT </dai-totalSupply>
          <dai-balance> ... ACCOUNT_DST |-> (BALANCE_DST => BALANCE_DST +Wad AMOUNT) ... </dai-balance>
          <frame-events> ... (.List => ListItem(Transfer(0, ACCOUNT_DST, AMOUNT))) </frame-events>
-      requires AMOUNT >=Wad 0Wad
+      requires AMOUNT >=Wad wad(0)
 
     syntax DaiStep ::= "burn" Address Wad
  // -------------------------------------
@@ -144,7 +144,7 @@ The Dai token is a mintable/burnable ERC20 token.
          <dai-totalSupply> DAI_SUPPLY => DAI_SUPPLY -Wad AMOUNT </dai-totalSupply>
          <dai-balance> ... ACCOUNT_SRC |-> (AMOUNT_SRC => AMOUNT_SRC -Wad AMOUNT) ... </dai-balance>
          <frame-events> ... (.List => ListItem(Transfer(ACCOUNT_SRC, 0, AMOUNT))) </frame-events>
-      requires AMOUNT >=Wad 0Wad
+      requires AMOUNT >=Wad wad(0)
 
     syntax DaiStep ::= "approve" Address Wad
  // ----------------------------------------
@@ -152,24 +152,24 @@ The Dai token is a mintable/burnable ERC20 token.
          <msg-sender> ACCOUNT_SRC </msg-sender>
          <dai-allowance> ... { ACCOUNT_SRC -> ACCOUNT_DST } |-> (_ => AMOUNT) ... </dai-allowance>
          <frame-events> ... (.List => ListItem(Approval(ACCOUNT_SRC, ACCOUNT_DST, AMOUNT))) </frame-events>
-      requires AMOUNT >=Wad 0Wad
+      requires AMOUNT >=Wad wad(0)
 
     syntax DaiStep ::= "push" Address Wad
  // -------------------------------------
     rule <k> Dai . push ACCOUNT_DST AMOUNT => Dai . transferFrom ACCOUNT_SRC ACCOUNT_DST AMOUNT ... </k>
          <msg-sender> ACCOUNT_SRC </msg-sender>
-      requires AMOUNT >=Wad 0Wad
+      requires AMOUNT >=Wad wad(0)
 
     syntax DaiStep ::= "pull" Address Wad
  // -------------------------------------
     rule <k> Dai . pull ACCOUNT_SRC AMOUNT => Dai . transferFrom ACCOUNT_SRC ACCOUNT_DST AMOUNT ... </k>
          <msg-sender> ACCOUNT_DST </msg-sender>
-      requires AMOUNT >=Wad 0Wad
+      requires AMOUNT >=Wad wad(0)
 
     syntax DaiStep ::= "move" Address Address Wad
  // ---------------------------------------------
     rule <k> Dai . move ACCOUNT_SRC ACCOUNT_DST AMOUNT => Dai . transferFrom ACCOUNT_SRC ACCOUNT_DST AMOUNT ... </k>
-      requires AMOUNT >=Wad 0Wad
+      requires AMOUNT >=Wad wad(0)
 ```
 
 **TODO**: `permit` logic, seems to be a time-locked allowance.

--- a/end.md
+++ b/end.md
@@ -25,17 +25,17 @@ End Configuration
       <end-state>
         <endPhase> false </endPhase>
         <end>
-          <end-wards> .Set </end-wards>
-          <end-live>  true </end-live>
-          <end-when>  0    </end-when>
-          <end-wait>  0    </end-wait>
-          <end-debt>  0Rad </end-debt>
-          <end-tag>   .Map </end-tag>  // mapping (bytes32 => uint256)                      String  |-> Ray
-          <end-gap>   .Map </end-gap>  // mapping (bytes32 => uint256)                      String  |-> Wad
-          <end-art>   .Map </end-art>  // mapping (bytes32 => uint256)                      String  |-> Wad
-          <end-fix>   .Map </end-fix>  // mapping (bytes32 => uint256)                      String  |-> Ray
-          <end-bag>   .Map </end-bag>  // mapping (address => uint256)                      Address |-> Wad
-          <end-out>   .Map </end-out>  // mapping (bytes32 => mapping (address => uint256)) CDPID   |-> Wad
+          <end-wards> .Set   </end-wards>
+          <end-live>  true   </end-live>
+          <end-when>  0      </end-when>
+          <end-wait>  0      </end-wait>
+          <end-debt>  rad(0) </end-debt>
+          <end-tag>   .Map   </end-tag>  // mapping (bytes32 => uint256)                      String  |-> Ray
+          <end-gap>   .Map   </end-gap>  // mapping (bytes32 => uint256)                      String  |-> Wad
+          <end-art>   .Map   </end-art>  // mapping (bytes32 => uint256)                      String  |-> Wad
+          <end-fix>   .Map   </end-fix>  // mapping (bytes32 => uint256)                      String  |-> Ray
+          <end-bag>   .Map   </end-bag>  // mapping (address => uint256)                      Address |-> Wad
+          <end-out>   .Map   </end-out>  // mapping (bytes32 => mapping (address => uint256)) CDPID   |-> Wad
         </end>
       </end-state>
 ```
@@ -101,15 +101,15 @@ Because data isn't explicitely initialized to 0 in KMCD, we need explicit initia
                          | "initOut" String Address
  // -----------------------------------------------
     rule <k> End . initGap ILKID => . ... </k>
-         <end-gap> GAPS => GAPS [ ILKID <- 0Wad ] </end-gap>
+         <end-gap> GAPS => GAPS [ ILKID <- wad(0) ] </end-gap>
       requires notBool ILKID in_keys(GAPS)
 
     rule <k> End . initBag ADDR => . ... </k>
-         <end-bag> BAGS => BAGS [ ADDR <- 0Wad ] </end-bag>
+         <end-bag> BAGS => BAGS [ ADDR <- wad(0) ] </end-bag>
       requires notBool ADDR in_keys(BAGS)
 
     rule <k> End . initOut ILKID ADDR => . ... </k>
-         <end-out> OUTS => OUTS [ { ILKID , ADDR } <- 0Wad ] </end-out>
+         <end-out> OUTS => OUTS [ { ILKID , ADDR } <- wad(0) ] </end-out>
       requires notBool { ILKID , ADDR } in_keys(OUTS)
 ```
 
@@ -160,14 +160,14 @@ End Semantics
            <flip-bids> ... ID |-> FlipBid(... bid: BID, lot: LOT, usr: USR, tab: TAB) ... </flip-bids>
            ...
          </flip>
-      requires TAG =/=Ray 0Ray
-       andBool LOT >=Wad 0Wad
-       andBool TAB /Rate RATE >=Wad 0Wad
+      requires TAG =/=Ray ray(0)
+       andBool LOT >=Wad wad(0)
+       andBool TAB /Rate RATE >=Wad wad(0)
 
     syntax EndStep ::= "skim" String Address
  // ----------------------------------------
     rule <k> End . skim ILK ADDR
-          => call Vat . grab ILK ADDR THIS Vow (0Wad -Wad minWad(INK, rmul(rmul(ART, RATE), TAG))) (0Wad -Wad ART)
+          => call Vat . grab ILK ADDR THIS Vow (wad(0) -Wad minWad(INK, rmul(rmul(ART, RATE), TAG))) (wad(0) -Wad ART)
          ...
          </k>
          <this> THIS </this>
@@ -175,28 +175,28 @@ End Semantics
          <end-gap> ... ILK |-> (GAP => GAP +Wad (rmul(rmul(ART, RATE), TAG) -Wad minWad(INK, rmul(rmul(ART, RATE), TAG)))) ... </end-gap>
          <vat-ilks> ... ILK |-> Ilk(... rate: RATE)::VatIlk ... </vat-ilks>
          <vat-urns> ... {ILK, ADDR} |-> Urn(... ink: INK, art: ART) ... </vat-urns>
-      requires TAG =/=Ray 0Ray
+      requires TAG =/=Ray ray(0)
 
     syntax EndStep ::= "free" String
  // --------------------------------
     rule <k> End . free ILK
-          => call Vat . grab ILK MSGSENDER MSGSENDER Vow (0Wad -Wad INK) 0Wad
+          => call Vat . grab ILK MSGSENDER MSGSENDER Vow (wad(0) -Wad INK) wad(0)
          ...
          </k>
          <msg-sender> MSGSENDER </msg-sender>
          <end-live> false </end-live>
          <vat-urns> ... {ILK, MSGSENDER} |-> Urn(... ink: INK, art: ART) ... </vat-urns>
-      requires ART ==Wad 0Wad
+      requires ART ==Wad wad(0)
 
     syntax EndStep ::= "thaw"
  // -------------------------
     rule <k> End . thaw => . ... </k>
          <current-time> NOW </current-time>
          <end-live> false </end-live>
-         <end-debt> 0Rad => DEBT </end-debt>
+         <end-debt> rad(0) => DEBT </end-debt>
          <end-when> WHEN </end-when>
          <end-wait> WAIT </end-wait>
-         <vat-dai> ... Vow |-> 0Rad ... </vat-dai>
+         <vat-dai> ... Vow |-> rad(0) ... </vat-dai>
          <vat-debt> DEBT </vat-debt>
       requires NOW >=Int WHEN +Int WAIT
 
@@ -209,7 +209,7 @@ End Semantics
          <end-gap> ... ILK |-> GAP ... </end-gap>
          <end-art> ... ILK |-> ART ... </end-art>
          <vat-ilks> ... ILK |-> Ilk(... rate: RATE)::VatIlk ... </vat-ilks>
-      requires DEBT =/=Rad 0Rad
+      requires DEBT =/=Rad rad(0)
        andBool rmul(rmul(ART, RATE), TAG) >=Wad GAP
        andBool notBool ILK in_keys(FIX)
 
@@ -222,8 +222,8 @@ End Semantics
          <msg-sender> MSGSENDER </msg-sender>
          <end-debt> DEBT </end-debt>
          <end-bag> ... MSGSENDER |-> (BAG => BAG +Wad AMOUNT) ... </end-bag>
-      requires AMOUNT >=Wad 0Wad
-       andBool DEBT =/=Rad 0Rad
+      requires AMOUNT >=Wad wad(0)
+       andBool DEBT =/=Rad rad(0)
 
     syntax EndStep ::= "cash" String Wad
  // ------------------------------------
@@ -236,8 +236,8 @@ End Semantics
          <end-fix> ... ILK |-> FIX ... </end-fix>
          <end-out> ... {ILK, MSGSENDER} |-> (OUT => OUT +Wad AMOUNT) ... </end-out>
          <end-bag> ... MSGSENDER |-> BAG ... </end-bag>
-      requires AMOUNT >=Wad 0Wad
-       andBool FIX =/=Ray 0Ray
+      requires AMOUNT >=Wad wad(0)
+       andBool FIX =/=Ray ray(0)
        andBool OUT +Wad AMOUNT <=Wad BAG
 ```
 

--- a/flap.md
+++ b/flap.md
@@ -89,7 +89,7 @@ The parameters controlled by governance are:
  // -----------------------------
     rule <k> Flap . file beg BEG => . ... </k>
          <flap-beg> _ => BEG </flap-beg>
-      requires BEG >=Wad 0Wad
+      requires BEG >=Wad wad(0)
 
     rule <k> Flap . file ttl TTL => . ... </k>
          <flap-ttl> _ => TTL </flap-ttl>
@@ -130,8 +130,8 @@ Flap Semantics
          <flap-live> true </flap-live>
          <flap-tau> TAU </flap-tau>
          <frame-events> ... (.List => ListItem(FlapKick(MSGSENDER, KICKS +Int 1, LOT, BID))) </frame-events>
-      requires LOT >=Rad 0Rad
-       andBool BID >=Wad 0Wad
+      requires LOT >=Rad rad(0)
+       andBool BID >=Wad wad(0)
 ```
 
 - tick(uint id)
@@ -165,8 +165,8 @@ Flap Semantics
          <flap-live> true </flap-live>
          <flap-ttl> TTL </flap-ttl>
          <flap-beg> BEG </flap-beg>
-      requires LOT >=Rad 0Rad
-       andBool BID >=Wad 0Wad
+      requires LOT >=Rad rad(0)
+       andBool BID >=Wad wad(0)
        andBool (TIC >Int NOW orBool TIC ==Int 0)
        andBool END  >Int NOW
        andBool LOT ==Rad LOT'
@@ -203,7 +203,7 @@ Flap Semantics
          <msg-sender> MSGSENDER </msg-sender>
          <this> THIS </this>
          <flap-live> _ => false </flap-live>
-      requires RAD >=Rad 0Rad
+      requires RAD >=Rad rad(0)
 ```
 
 - yank(uint id)

--- a/flap.md
+++ b/flap.md
@@ -199,11 +199,11 @@ Flap Semantics
 ```k
     syntax FlapAuthStep ::= "cage" Rad
  // ----------------------------------
-    rule <k> Flap . cage RAD => call Vat . move THIS MSGSENDER RAD ... </k>
+    rule <k> Flap . cage AMOUNT => call Vat . move THIS MSGSENDER AMOUNT ... </k>
          <msg-sender> MSGSENDER </msg-sender>
          <this> THIS </this>
          <flap-live> _ => false </flap-live>
-      requires RAD >=Rad rad(0)
+      requires AMOUNT >=Rad rad(0)
 ```
 
 - yank(uint id)

--- a/flap.md
+++ b/flap.md
@@ -15,13 +15,13 @@ Flap Configuration
 ```k
     configuration
       <flap-state>
-        <flap-wards> .Set              </flap-wards>
-        <flap-bids>  .Map              </flap-bids>  // mapping (uint => Bid) Int |-> FlapBid
-        <flap-kicks> 0                 </flap-kicks>
-        <flap-live>  true              </flap-live>
-        <flap-beg>   wad(105 /Rat 100) </flap-beg>
-        <flap-ttl>   3 hours           </flap-ttl>
-        <flap-tau>   2 days            </flap-tau>
+        <flap-wards> .Set                   </flap-wards>
+        <flap-bids>  .Map                   </flap-bids>  // mapping (uint => Bid) Int |-> FlapBid
+        <flap-kicks> 0                      </flap-kicks>
+        <flap-live>  true                   </flap-live>
+        <flap-beg>   wad(105) /Wad wad(100) </flap-beg>
+        <flap-ttl>   3 hours                </flap-ttl>
+        <flap-tau>   2 days                 </flap-tau>
       </flap-state>
 ```
 

--- a/flip.md
+++ b/flip.md
@@ -101,7 +101,7 @@ The parameters controlled by governance are:
            <flip-beg> _ => BEG </flip-beg>
            ...
          </flip>
-      requires BEG >=Wad 0Wad
+      requires BEG >=Wad wad(0)
 
     rule <k> Flip ILKID . file ttl TTL => . ... </k>
          <flip>
@@ -162,9 +162,9 @@ Flip Semantics
            ...
          </flip>
          <frame-events> ... (.List => ListItem(FlipKick(MSGSENDER, ILK, KICKS +Int 1, LOT, BID, TAB, USR, GAL))) </frame-events>
-      requires TAB >=Rad 0Rad
-       andBool LOT >=Wad 0Wad
-       andBool BID >=Rad 0Rad
+      requires TAB >=Rad rad(0)
+       andBool LOT >=Wad wad(0)
+       andBool BID >=Rad rad(0)
 
     syntax FlipStep ::= "tick" Int
  // ------------------------------
@@ -195,8 +195,8 @@ Flip Semantics
            <flip-bids> ... ID |-> FlipBid(... bid: BID' => BID, lot: LOT', guy: GUY => MSGSENDER, tic: TIC => NOW +Int TTL, end: END, gal: GAL, tab: TAB) ... </flip-bids>
            ...
          </flip>
-      requires LOT >=Wad 0Wad
-       andBool BID >=Rad 0Rad
+      requires LOT >=Wad wad(0)
+       andBool BID >=Rad rad(0)
        andBool GUY =/=K 0
        andBool (TIC >Int NOW orBool TIC ==Int 0)
        andBool END >Int NOW
@@ -222,8 +222,8 @@ Flip Semantics
            <flip-bids> ... ID |-> FlipBid(... bid: BID', lot: LOT' => LOT, guy: GUY => MSGSENDER, tic: TIC => NOW +Int TTL, end: END, usr: USR, tab: TAB) ... </flip-bids>
            ...
          </flip>
-      requires LOT >=Wad 0Wad
-       andBool BID >=Rad 0Rad
+      requires LOT >=Wad wad(0)
+       andBool BID >=Rad rad(0)
        andBool GUY =/=K 0
        andBool (TIC >Int NOW orBool TIC ==Int 0)
        andBool END >Int NOW

--- a/flip.md
+++ b/flip.md
@@ -14,13 +14,13 @@ Flip Configuration
     configuration
       <flips>
         <flip multiplicity="*" type="Map">
-          <flip-ilk>   ""                </flip-ilk>
-          <flip-wards> .Set              </flip-wards>
-          <flip-bids>  .Map              </flip-bids> // mapping (uint => Bid) Int |-> FlipBid
-          <flip-beg>   wad(105 /Rat 100) </flip-beg>  // Minimum Bid Increase
-          <flip-ttl>   3 hours           </flip-ttl>  // Single Bid Lifetime
-          <flip-tau>   2 days            </flip-tau>  // Total Auction Length
-          <flip-kicks> 0                 </flip-kicks>
+          <flip-ilk>   ""                     </flip-ilk>
+          <flip-wards> .Set                   </flip-wards>
+          <flip-bids>  .Map                   </flip-bids> // mapping (uint => Bid) Int |-> FlipBid
+          <flip-beg>   wad(105) /Wad wad(100) </flip-beg>  // Minimum Bid Increase
+          <flip-ttl>   3 hours                </flip-ttl>  // Single Bid Lifetime
+          <flip-tau>   2 days                 </flip-tau>  // Total Auction Length
+          <flip-kicks> 0                      </flip-kicks>
         </flip>
       </flips>
 ```

--- a/flop.md
+++ b/flop.md
@@ -15,15 +15,15 @@ Flop Configuration
 ```k
     configuration
       <flop-state>
-        <flop-wards> .Set               </flop-wards>
-        <flop-bids>  .Map               </flop-bids>  // mapping (uint => Bid) Int |-> FlopBid
-        <flop-kicks>  0                 </flop-kicks>
-        <flop-live>   true              </flop-live>
-        <flop-beg>    wad(105 /Rat 100) </flop-beg>
-        <flop-pad>    wad(150 /Rat 100) </flop-pad>
-        <flop-ttl>    3 hours           </flop-ttl>
-        <flop-tau>    2 days            </flop-tau>
-        <flop-vow>    0:Address         </flop-vow>
+        <flop-wards> .Set                    </flop-wards>
+        <flop-bids>  .Map                    </flop-bids>  // mapping (uint => Bid) Int |-> FlopBid
+        <flop-kicks>  0                      </flop-kicks>
+        <flop-live>   true                   </flop-live>
+        <flop-beg>    wad(105) /Wad wad(100) </flop-beg>
+        <flop-pad>    wad(150) /Wad wad(100) </flop-pad>
+        <flop-ttl>    3 hours                </flop-ttl>
+        <flop-tau>    2 days                 </flop-tau>
+        <flop-vow>    0:Address              </flop-vow>
       </flop-state>
 ```
 

--- a/flop.md
+++ b/flop.md
@@ -91,7 +91,7 @@ The parameters controlled by governance are:
  // --------------------------------------
     rule <k> Flop . file beg BEG => . ... </k>
          <flop-beg> _ => BEG </flop-beg>
-      requires BEG >=Wad 0Wad
+      requires BEG >=Wad wad(0)
 
     rule <k> Flop . file ttl TTL => . ... </k>
          <flop-ttl> _ => TTL </flop-ttl>
@@ -103,7 +103,7 @@ The parameters controlled by governance are:
 
     rule <k> Flop . file pad PAD => . ... </k>
          <flop-pad> _ => PAD </flop-pad>
-      requires PAD >=Wad 0Wad
+      requires PAD >=Wad wad(0)
 
     rule <k> Flop . file vow-file ADDR => . ... </k>
          <flop-vow> _ => ADDR </flop-vow>
@@ -138,8 +138,8 @@ Flop Semantics
          <flop-kicks> KICKS => KICKS +Int 1 </flop-kicks>
          <flop-tau> TAU </flop-tau>
          <frame-events> ... (.List => ListItem(FlopKick(KICKS +Int 1, LOT, BID, GAL))) </frame-events>
-      requires LOT >=Wad 0Wad
-       andBool BID >=Rad 0Rad
+      requires LOT >=Wad wad(0)
+       andBool BID >=Rad rad(0)
 ```
 
 - tick(uint id)
@@ -172,8 +172,8 @@ Flop Semantics
          <flop-live> true </flop-live>
          <flop-beg> BEG </flop-beg>
          <flop-ttl> TTL </flop-ttl>
-      requires LOT >=Wad 0Wad
-       andBool BID >=Rad 0Rad
+      requires LOT >=Wad wad(0)
+       andBool BID >=Rad rad(0)
        andBool (TIC >Int NOW orBool TIC ==Int 0)
        andBool END >Int NOW
        andBool BID ==Rad BID'

--- a/gem.md
+++ b/gem.md
@@ -46,7 +46,7 @@ Because data isn't explicitely initialized to 0 in KMCD, we need explicit initia
     rule <k> Gem GEMID . initUser ADDR => . ... </k>
          <gem>
             <gem-id> GEMID </gem-id>
-            <gem-balances> BALS => BALS [ ADDR <- 0Wad ] </gem-balances>
+            <gem-balances> BALS => BALS [ ADDR <- wad(0) ] </gem-balances>
             ...
          </gem>
       requires notBool ADDR in_keys(BALS)
@@ -69,9 +69,9 @@ Gem Semantics
            </gem-balances>
            ...
          </gem>
-      requires VALUE >=Wad 0Wad
+      requires VALUE >=Wad wad(0)
        andBool ACCTSRC =/=K ACCTDST
-       andBool VALUE >=Wad 0Wad
+       andBool VALUE >=Wad wad(0)
        andBool BALANCE_SRC >=Wad VALUE
 
     rule <k> Gem GEMID . transferFrom ACCTSRC ACCTSRC VALUE => . ... </k>
@@ -80,31 +80,31 @@ Gem Semantics
            <gem-balances> ... ACCTSRC |-> BALANCE_SRC ... </gem-balances>
            ...
          </gem>
-      requires VALUE >=Wad 0Wad
+      requires VALUE >=Wad wad(0)
        andBool BALANCE_SRC >=Wad VALUE
 
     syntax GemStep ::= "move" Address Address Wad
  // ---------------------------------------------
     rule <k> Gem _ . (move ACCTSRC ACCTDST VALUE => transferFrom ACCTSRC ACCTDST VALUE) ... </k>
-      requires VALUE >=Wad 0Wad
+      requires VALUE >=Wad wad(0)
 
     syntax GemStep ::= "push" Address Wad
  // -------------------------------------
     rule <k> Gem _ . (push ACCTDST VALUE => transferFrom MSGSENDER ACCTDST VALUE) ... </k>
          <msg-sender> MSGSENDER </msg-sender>
-      requires VALUE >=Wad 0Wad
+      requires VALUE >=Wad wad(0)
 
     syntax GemStep ::= "pull" Address Wad
  // -------------------------------------
     rule <k> Gem _ . (pull ACCTSRC VALUE => transferFrom ACCTSRC MSGSENDER VALUE) ... </k>
          <msg-sender> MSGSENDER </msg-sender>
-      requires VALUE >=Wad 0Wad
+      requires VALUE >=Wad wad(0)
 
     syntax GemStep ::= "transfer" Address Wad
  // -----------------------------------------
     rule <k> Gem _ . (transfer ACCTDST VALUE => transferFrom MSGSENDER ACCTDST VALUE) ... </k>
          <msg-sender> MSGSENDER </msg-sender>
-      requires VALUE >=Wad 0Wad
+      requires VALUE >=Wad wad(0)
 
     syntax GemStep ::= "mint" Address Wad
  // -------------------------------------
@@ -114,7 +114,7 @@ Gem Semantics
            <gem-balances> ... ACCTDST |-> ( BALANCE_DST => BALANCE_DST +Wad VALUE ) ... </gem-balances>
            ...
          </gem>
-      requires VALUE >=Wad 0Wad
+      requires VALUE >=Wad wad(0)
 
     syntax GemStep ::= "burn" Address Wad
  // -------------------------------------
@@ -124,7 +124,7 @@ Gem Semantics
            <gem-balances> ... ACCTSRC |-> ( BALANCE_SRC => BALANCE_SRC -Wad VALUE ) ... </gem-balances>
            ...
          </gem>
-      requires VALUE >=Wad 0Wad
+      requires VALUE >=Wad wad(0)
        andBool BALANCE_SRC >=Wad VALUE
 ```
 

--- a/join.md
+++ b/join.md
@@ -116,17 +116,17 @@ Join Semantics
            <gem-join-live> true </gem-join-live>
            ...
          </gem-join>
-      requires AMOUNT >=Wad 0Wad
+      requires AMOUNT >=Wad wad(0)
 
     syntax GemJoinStep ::= "exit" Address Wad
  // -----------------------------------------
     rule <k> GemJoin GEMID . exit USR AMOUNT
-          => call Vat . slip GEMID MSGSENDER (0Wad -Wad AMOUNT)
+          => call Vat . slip GEMID MSGSENDER (wad(0) -Wad AMOUNT)
           ~> call Gem GEMID . transfer USR AMOUNT
          ...
          </k>
          <msg-sender> MSGSENDER </msg-sender>
-      requires AMOUNT >=Wad 0Wad
+      requires AMOUNT >=Wad wad(0)
 
     syntax DaiJoinStep ::= "join" Address Wad
  // -----------------------------------------
@@ -138,7 +138,7 @@ Join Semantics
          <msg-sender> MSGSENDER </msg-sender>
          <this> THIS </this>
          <dai-join-live> true </dai-join-live>
-      requires AMOUNT >=Wad 0Wad
+      requires AMOUNT >=Wad wad(0)
 
     syntax DaiJoinStep ::= "exit" Address Wad
  // -----------------------------------------
@@ -149,7 +149,7 @@ Join Semantics
          </k>
          <msg-sender> MSGSENDER </msg-sender>
          <this> THIS </this>
-      requires AMOUNT >=Wad 0Wad
+      requires AMOUNT >=Wad wad(0)
 ```
 
 Join Deactivation

--- a/jug.md
+++ b/jug.md
@@ -16,7 +16,7 @@ Jug Configuration
         <jug-wards> .Set      </jug-wards>
         <jug-ilks>  .Map      </jug-ilks> // mapping (bytes32 => JugIlk) String  |-> JugIlk
         <jug-vow>   0:Address </jug-vow>  //                             Address
-        <jug-base>  0Ray      </jug-base> //                             Ray
+        <jug-base>  ray(0)    </jug-base> //                             Ray
       </jug>
 ```
 
@@ -80,11 +80,11 @@ These parameters are controlled by governance:
          <jug-ilks> ... ILK |-> Ilk ( ... duty: (_ => DUTY) , rho: RHO ) ... </jug-ilks>
          <current-time> NOW </current-time>
       requires NOW ==Int RHO
-       andBool DUTY >=Ray 0Ray
+       andBool DUTY >=Ray ray(0)
 
     rule <k> Jug . file base BASE => . ... </k>
          <jug-base> _ => BASE </jug-base>
-      requires BASE >=Ray 0Ray
+      requires BASE >=Ray ray(0)
 
     rule <k> Jug . file vow-file ADDR => . ... </k>
          <jug-vow> _ => ADDR </jug-vow>
@@ -100,7 +100,7 @@ Jug Semantics
  // ------------------------------------
     rule <k> Jug . init ILK => . ... </k>
          <current-time> NOW </current-time>
-         <jug-ilks> ... ILK |-> Ilk ( ... duty: 0Ray => 1Ray, rho: _ => NOW ) ... </jug-ilks>
+         <jug-ilks> ... ILK |-> Ilk ( ... duty: ray(0) => ray(1), rho: _ => NOW ) ... </jug-ilks>
 ```
 
 ```k

--- a/kmcd-data.md
+++ b/kmcd-data.md
@@ -23,6 +23,9 @@ We model everything with arbitrary precision rationals, but use sort information
 -   `Rad`: result of multiplying `Wad` and `Ray` (highest precision). Represented in implementation as 1e45 fixed point.
 
 ```k
+    syntax Value ::= Wad | Ray | Rad
+ // --------------------------------
+
     syntax Int ::= "WAD" | "RAY" | "RAD"
  // ------------------------------------
     rule WAD => 1000000000000000000                            [macro]

--- a/kmcd-data.md
+++ b/kmcd-data.md
@@ -23,14 +23,14 @@ We model everything with arbitrary precision rationals, but use sort information
 -   `Rad`: result of multiplying `Wad` and `Ray` (highest precision). Represented in implementation as 1e45 fixed point.
 
 ```k
-    syntax Wad ::= wad ( Rat )
- // --------------------------
+    syntax Wad ::= wad ( Rat ) [klabel(wad), symbol]
+ // ------------------------------------------------
 
-    syntax Ray ::= ray ( Rat )
- // --------------------------
+    syntax Ray ::= ray ( Rat ) [klabel(ray), symbol]
+ // ------------------------------------------------
 
-    syntax Rad ::= rad ( Rat )
- // --------------------------
+    syntax Rad ::= rad ( Rat ) [klabel(rad), symbol]
+ // ------------------------------------------------
 
     syntax MaybeWad ::= Wad | ".Wad"
  // --------------------------------

--- a/kmcd-data.md
+++ b/kmcd-data.md
@@ -23,9 +23,6 @@ We model everything with arbitrary precision rationals, but use sort information
 -   `Rad`: result of multiplying `Wad` and `Ray` (highest precision). Represented in implementation as 1e45 fixed point.
 
 ```k
-    syntax MCDNum ::= Wad | Ray | Rad
- // ---------------------------------
-
     syntax Int ::= "WAD" | "RAY" | "RAD"
  // ------------------------------------
     rule WAD => 1000000000000000000                            [macro]

--- a/kmcd-data.md
+++ b/kmcd-data.md
@@ -46,23 +46,6 @@ We model everything with arbitrary precision rationals, but use sort information
 ```
 
 ```k
-    syntax Wad ::= "0Wad" | "1Wad"
- // ------------------------------
-    rule 0Wad => wad(0) [macro]
-    rule 1Wad => wad(1) [macro]
-
-    syntax Ray ::= "0Ray" | "1Ray"
- // ------------------------------
-    rule 0Ray => ray(0) [macro]
-    rule 1Ray => ray(1) [macro]
-
-    syntax Rad ::= "0Rad" | "1Rad"
- // ------------------------------
-    rule 0Rad => rad(0) [macro]
-    rule 1Rad => rad(1) [macro]
-```
-
-```k
     syntax Wad ::= Rad2Wad ( Rad ) [function]
  // -----------------------------------------
     rule Rad2Wad(rad(R)) => wad(R)

--- a/kmcd-data.md
+++ b/kmcd-data.md
@@ -23,6 +23,9 @@ We model everything with arbitrary precision rationals, but use sort information
 -   `Rad`: result of multiplying `Wad` and `Ray` (highest precision). Represented in implementation as 1e45 fixed point.
 
 ```k
+    syntax MCDNum ::= Wad | Ray | Rad
+ // ---------------------------------
+
     syntax Wad ::= wad ( Rat ) [klabel(wad), symbol]
  // ------------------------------------------------
 

--- a/kmcd-data.md
+++ b/kmcd-data.md
@@ -26,6 +26,12 @@ We model everything with arbitrary precision rationals, but use sort information
     syntax MCDNum ::= Wad | Ray | Rad
  // ---------------------------------
 
+    syntax Int ::= "WAD" | "RAY" | "RAD"
+ // ------------------------------------
+    rule WAD => 1000000000000000000                            [macro]
+    rule RAY => 1000000000000000000000000000                   [macro]
+    rule RAD => 1000000000000000000000000000000000000000000000 [macro]
+
     syntax Wad ::= wad ( Rat ) [klabel(wad), symbol]
  // ------------------------------------------------
 

--- a/kmcd-data.md
+++ b/kmcd-data.md
@@ -55,34 +55,26 @@ We model everything with arbitrary precision rationals, but use sort information
 
 ```k
     syntax Wad ::= Rad2Wad ( Rad ) [function]
-                 | Ray2Wad ( Ray ) [function]
  // -----------------------------------------
-    rule Ray2Wad(ray(R)) => wad(R)
     rule Rad2Wad(rad(R)) => wad(R)
 
     syntax Ray ::= Wad2Ray ( Wad ) [function]
-                 | Rad2Ray ( Rad ) [function]
  // -----------------------------------------
     rule Wad2Ray(wad(W)) => ray(W)
-    rule Rad2Ray(rad(R)) => ray(R)
 
     syntax Rad ::= Wad2Rad ( Wad ) [function]
-                 | Ray2Rad ( Ray ) [function]
  // -----------------------------------------
     rule Wad2Rad(wad(W)) => rad(W)
-    rule Ray2Rad(ray(R)) => rad(R)
 ```
 
 ```k
     syntax Wad ::= Wad "*Wad" Wad [function]
                  | Wad "/Wad" Wad [function]
-                 | Wad "^Wad" Int [function]
                  > Wad "+Wad" Wad [function]
                  | Wad "-Wad" Wad [function]
  // ----------------------------------------
     rule wad(R1) *Wad wad(R2) => wad(R1 *Rat R2)
     rule wad(R1) /Wad wad(R2) => wad(R1 /Rat R2)
-    rule wad(R1) ^Wad I       => wad(R1 ^Rat I)
     rule wad(R1) +Wad wad(R2) => wad(R1 +Rat R2)
     rule wad(R1) -Wad wad(R2) => wad(R1 -Rat R2)
 
@@ -99,36 +91,22 @@ We model everything with arbitrary precision rationals, but use sort information
     rule ray(R1) -Ray ray(R2) => ray(R1 -Rat R2)
 
     syntax Rad ::= Rad "*Rad" Rad [function]
-                 | Rad "/Rad" Rad [function]
-                 | Rad "^Rad" Int [function]
                  > Rad "+Rad" Rad [function]
                  | Rad "-Rad" Rad [function]
  // ----------------------------------------
     rule rad(R1) *Rad rad(R2) => rad(R1 *Rat R2)
-    rule rad(R1) /Rad rad(R2) => rad(R1 /Rat R2)
-    rule rad(R1) ^Rad I       => rad(R1 ^Rat I)
     rule rad(R1) +Rad rad(R2) => rad(R1 +Rat R2)
     rule rad(R1) -Rad rad(R2) => rad(R1 -Rat R2)
 ```
 
 ```k
     syntax Wad ::= minWad ( Wad , Wad ) [function]
-                 | maxWad ( Wad , Wad ) [function]
  // ----------------------------------------------
     rule minWad(wad(W1), wad(W2)) => wad(minRat(W1, W2))
-    rule maxWad(wad(W1), wad(W2)) => wad(maxRat(W1, W2))
-
-    syntax Ray ::= minRay ( Ray , Ray ) [function]
-                 | maxRay ( Ray , Ray ) [function]
- // ----------------------------------------------
-    rule minRay(ray(W1), ray(W2)) => ray(minRat(W1, W2))
-    rule maxRay(ray(W1), ray(W2)) => ray(maxRat(W1, W2))
 
     syntax Rad ::= minRad ( Rad , Rad ) [function]
-                 | maxRad ( Rad , Rad ) [function]
  // ----------------------------------------------
     rule minRad(rad(W1), rad(W2)) => rad(minRat(W1, W2))
-    rule maxRad(rad(W1), rad(W2)) => rad(maxRat(W1, W2))
 ```
 
 ```k

--- a/kmcd-data.md
+++ b/kmcd-data.md
@@ -23,8 +23,8 @@ We model everything with arbitrary precision rationals, but use sort information
 -   `Rad`: result of multiplying `Wad` and `Ray` (highest precision). Represented in implementation as 1e45 fixed point.
 
 ```k
-    syntax Value ::= Wad | Ray | Rad
- // --------------------------------
+    syntax Value ::= Wad | Ray | Rad | Int
+ // --------------------------------------
 
     syntax Int ::= "WAD" | "RAY" | "RAD"
  // ------------------------------------

--- a/kmcd-driver.md
+++ b/kmcd-driver.md
@@ -121,9 +121,7 @@ On `exception`, the entire current call is discarded to trigger state roll-back 
 
     rule <k> call MCD => exception MCD ... </k> [owise]
 
-    rule <k> W:Wad => . ... </k> <return-value> _ => W </return-value>
-    rule <k> R:Ray => . ... </k> <return-value> _ => R </return-value>
-    rule <k> R:Rad => . ... </k> <return-value> _ => R </return-value>
+    rule <k> V:Value => . ... </k> <return-value> _ => V </return-value>
 
     rule <k> . => CONT </k>
          <msg-sender> MSGSENDER => PREVSENDER </msg-sender>

--- a/kmcd-driver.md
+++ b/kmcd-driver.md
@@ -121,8 +121,9 @@ On `exception`, the entire current call is discarded to trigger state roll-back 
 
     rule <k> call MCD => exception MCD ... </k> [owise]
 
-    rule <k> R:MCDNum => . ... </k>
-         <return-value> _ => R </return-value>
+    rule <k> W:Wad => . ... </k> <return-value> _ => W </return-value>
+    rule <k> R:Ray => . ... </k> <return-value> _ => R </return-value>
+    rule <k> R:Rad => . ... </k> <return-value> _ => R </return-value>
 
     rule <k> . => CONT </k>
          <msg-sender> MSGSENDER => PREVSENDER </msg-sender>

--- a/kmcd-driver.md
+++ b/kmcd-driver.md
@@ -121,9 +121,7 @@ On `exception`, the entire current call is discarded to trigger state roll-back 
 
     rule <k> call MCD => exception MCD ... </k> [owise]
 
-    syntax ReturnValue ::= MCDNum
- // -----------------------------
-    rule <k> R:ReturnValue => . ... </k>
+    rule <k> R:MCDNum => . ... </k>
          <return-value> _ => R </return-value>
 
     rule <k> . => CONT </k>

--- a/kmcd-driver.md
+++ b/kmcd-driver.md
@@ -121,8 +121,8 @@ On `exception`, the entire current call is discarded to trigger state roll-back 
 
     rule <k> call MCD => exception MCD ... </k> [owise]
 
-    syntax ReturnValue ::= Rat
- // --------------------------
+    syntax ReturnValue ::= MCDNum
+ // -----------------------------
     rule <k> R:ReturnValue => . ... </k>
          <return-value> _ => R </return-value>
 

--- a/kmcd-prelude.md
+++ b/kmcd-prelude.md
@@ -103,8 +103,8 @@ module KMCD-PRELUDE
          // Initialize Spot for gold
          transact ADMIN Spot . init     "gold"
          transact ADMIN Spot . setPrice "gold" wad(3 ether)
-         transact ADMIN Spot . file       mat "gold" 1Ray
-         transact ADMIN Spot . file       par 1Ray
+         transact ADMIN Spot . file       mat "gold" ray(1)
+         transact ADMIN Spot . file       par ray(1)
 
          // Initialize Flipper for gold
          transact ADMIN Flip "gold" . init
@@ -555,7 +555,7 @@ module KMCD-GEN
          <pot-chi> POT_CHI </pot-chi>
       requires lengthBytes(BS) >Int 0
 
-    rule <k> GenPotFileDSR => LogGen ( transact ADMIN Pot . file dsr (randRayBounded(head(BS), #dsrSpread() /Ray ray(100)) +Ray 1Ray) ) ... </k>
+    rule <k> GenPotFileDSR => LogGen ( transact ADMIN Pot . file dsr (randRayBounded(head(BS), #dsrSpread() /Ray ray(100)) +Ray ray(1)) ) ... </k>
          <random> BS => tail(BS) </random>
          <used-random> BS' => BS' +Bytes headAsBytes(BS) </used-random>
       requires lengthBytes(BS) >Int 0

--- a/kmcd-props.md
+++ b/kmcd-props.md
@@ -26,17 +26,17 @@ Sometimes you need a lookup to default to zero, and want to cast the result as a
     syntax Wad ::= #lookupWad ( Map , Address ) [function]
  // ------------------------------------------------------
     rule #lookupWad(M, A) => { M[A] }:>Wad requires A in_keys(M)
-    rule #lookupWad(M, A) => 0Wad          [owise]
+    rule #lookupWad(M, A) => wad(0)        [owise]
 
     syntax Ray ::= #lookupRay ( Map , Address ) [function]
  // ------------------------------------------------------
     rule #lookupRay(M, A) => { M[A] }:>Ray requires A in_keys(M)
-    rule #lookupRay(M, A) => 0Ray          [owise]
+    rule #lookupRay(M, A) => ray(0)        [owise]
 
     syntax Rad ::= #lookupRad ( Map , Address ) [function]
  // ------------------------------------------------------
     rule #lookupRad(M, A) => { M[A] }:>Rad requires A in_keys(M)
-    rule #lookupRad(M, A) => 0Rad          [owise]
+    rule #lookupRad(M, A) => rad(0)        [owise]
 ```
 
 ### Measure Event
@@ -79,23 +79,23 @@ State predicates that capture undesirable states in the system (representing vio
  // -------------------------------------------------------
     rule controlDaiForUser(ADDR) => (vatDaiForUser(ADDR) +Rad potDaiForUser(ADDR)) +Rad erc20DaiForUser(ADDR)
 
-    rule    vatDaiForUser(_)    => 0Rad [owise]
+    rule    vatDaiForUser(_)    => rad(0) [owise]
     rule [[ vatDaiForUser(ADDR) => VAT_DAI ]]
          <vat-dai> ... ADDR |-> VAT_DAI:Rad ... </vat-dai>
 
     rule potDaiForUser(ADDR) => vatDaiForUser(Pot) *Rad Wad2Rad(portionOfPie(ADDR))
 
-    rule    erc20DaiForUser(_)    => 0Rad [owise]
+    rule    erc20DaiForUser(_)    => rad(0) [owise]
     rule [[ erc20DaiForUser(ADDR) => Wad2Rad(USER_ADAPT_DAI) ]]
          <dai-balance> ... ADDR |-> USER_ADAPT_DAI:Wad ... </dai-balance>
 
     syntax Wad ::= portionOfPie ( Address ) [function]
  // --------------------------------------------------
-    rule    portionOfPie(_)    => 0Wad [owise]
+    rule    portionOfPie(_)    => wad(0) [owise]
     rule [[ portionOfPie(ADDR) => USER_PIE /Wad PIE ]]
          <pot-pies> ... ADDR |-> USER_PIE:Wad ... </pot-pies>
          <pot-pie> PIE </pot-pie>
-      requires PIE =/=Wad 0Wad
+      requires PIE =/=Wad wad(0)
        andBool ADDR =/=K Pot
 ```
 
@@ -139,10 +139,10 @@ Total backed debt (sum over each CDP's art times corresponding ilk's rate)
     syntax Rad ::= calcSumOfScaledArts   (      Map, Map     ) [function]
                  | calcSumOfScaledArtsAux(List, Map, Map, Rad) [function]
  // ---------------------------------------------------------------------
-    rule calcSumOfScaledArts(VAT_ILKS, VAT_URNS) => calcSumOfScaledArtsAux(keys_list(VAT_ILKS), VAT_ILKS, VAT_URNS, 0Rad)
+    rule calcSumOfScaledArts(VAT_ILKS, VAT_URNS) => calcSumOfScaledArtsAux(keys_list(VAT_ILKS), VAT_ILKS, VAT_URNS, rad(0))
 
     rule calcSumOfScaledArtsAux(                        .List ,        _ ,        _ , TOTAL ) => TOTAL
-    rule calcSumOfScaledArtsAux( ListItem(ILK_ID) VAT_ILK_IDS , VAT_ILKS , VAT_URNS , TOTAL ) => calcSumOfScaledArtsAux(VAT_ILK_IDS, VAT_ILKS, VAT_URNS, TOTAL +Rad (sumOfUrnArt(VAT_URNS, ILK_ID, 0Wad) *Rate rate({VAT_ILKS[ILK_ID]}:>VatIlk)))
+    rule calcSumOfScaledArtsAux( ListItem(ILK_ID) VAT_ILK_IDS , VAT_ILKS , VAT_URNS , TOTAL ) => calcSumOfScaledArtsAux(VAT_ILK_IDS, VAT_ILKS, VAT_URNS, TOTAL +Rad (sumOfUrnArt(VAT_URNS, ILK_ID, wad(0)) *Rate rate({VAT_ILKS[ILK_ID]}:>VatIlk)))
 ```
 
 ### Flap Measures
@@ -153,7 +153,7 @@ Sum of all lot values (i.e. total surplus dai up for auction).
     syntax Rad ::= sumOfAllFlapLots   (      Map     ) [function]
                  | sumOfAllFlapLotsAux(List, Map, Rad) [function]
  // -------------------------------------------------------------
-    rule sumOfAllFlapLots(FLAP_BIDS) => sumOfAllFlapLotsAux(keys_list(FLAP_BIDS), FLAP_BIDS, 0Rad)
+    rule sumOfAllFlapLots(FLAP_BIDS) => sumOfAllFlapLotsAux(keys_list(FLAP_BIDS), FLAP_BIDS, rad(0))
 
     rule sumOfAllFlapLotsAux(                          .List ,         _ , SUM ) => SUM
     rule sumOfAllFlapLotsAux( ListItem(BID_ID) FLAP_BIDS_IDS , FLAP_BIDS , SUM ) => sumOfAllFlapLotsAux(FLAP_BIDS_IDS, FLAP_BIDS, SUM +Rad lot({FLAP_BIDS[BID_ID]}:>FlapBid))
@@ -165,7 +165,7 @@ Sum of all bid values (i.e. total amount of MKR that's been bid on dai currently
     syntax Wad ::= sumOfAllFlapBids   (      Map     ) [function]
                  | sumOfAllFlapBidsAux(List, Map, Wad) [function]
  // -------------------------------------------------------------
-    rule sumOfAllFlapBids(FLAP_BIDS) => sumOfAllFlapBidsAux(keys_list(FLAP_BIDS), FLAP_BIDS, 0Wad)
+    rule sumOfAllFlapBids(FLAP_BIDS) => sumOfAllFlapBidsAux(keys_list(FLAP_BIDS), FLAP_BIDS, wad(0))
 
     rule sumOfAllFlapBidsAux(                          .List ,         _ , SUM ) => SUM
     rule sumOfAllFlapBidsAux( ListItem(BID_ID) FLAP_BIDS_IDS , FLAP_BIDS , SUM ) => sumOfAllFlapBidsAux(FLAP_BIDS_IDS, FLAP_BIDS, SUM +Wad bid({FLAP_BIDS[BID_ID]}:>FlapBid))
@@ -179,17 +179,17 @@ A violation occurs if any of the properties above holds.
 ```k
     syntax Map ::= "#violationFSMs" [function]
  // ------------------------------------------
-    rule #violationFSMs => ( "Zero-Time Pot Interest Accumulation" |-> zeroTimePotInterest                           )
-                           ( "Pot Interest Accumulation After End" |-> potEndInterest                                )
-                           ( "Unauthorized Flip Kick"              |-> unAuthFlipKick                                )
-                           ( "Unauthorized Flap Kick"              |-> unAuthFlapKick                                )
-                           ( "Total Bound on Debt"                 |-> totalDebtBounded(... dsr: 1Ray)               )
-                           ( "PotChi PotPie VatPot"                |-> potChiPieDai(... offset: 0Rad, joining: 0Wad) )
-                           ( "Total Backed Debt Consistency"       |-> totalBackedDebtConsistency                    )
-                           ( "Debt Constant After Thaw"            |-> debtConstantAfterThaw                         )
-                           ( "Flap Dai Consistency"                |-> flapDaiConsistency                            )
-                           ( "Flap MKR Consistency"                |-> flapMkrConsistency                            )
-                           ( "Flop Block Check"                    |-> flopBlockCheck(... embers: 0Rad, dented: 0)   )
+    rule #violationFSMs => ( "Zero-Time Pot Interest Accumulation" |-> zeroTimePotInterest                               )
+                           ( "Pot Interest Accumulation After End" |-> potEndInterest                                    )
+                           ( "Unauthorized Flip Kick"              |-> unAuthFlipKick                                    )
+                           ( "Unauthorized Flap Kick"              |-> unAuthFlapKick                                    )
+                           ( "Total Bound on Debt"                 |-> totalDebtBounded(... dsr: ray(1))                 )
+                           ( "PotChi PotPie VatPot"                |-> potChiPieDai(... offset: rad(0), joining: wad(0)) )
+                           ( "Total Backed Debt Consistency"       |-> totalBackedDebtConsistency                        )
+                           ( "Debt Constant After Thaw"            |-> debtConstantAfterThaw                             )
+                           ( "Flap Dai Consistency"                |-> flapDaiConsistency                                )
+                           ( "Flap MKR Consistency"                |-> flapMkrConsistency                                )
+                           ( "Flop Block Check"                    |-> flopBlockCheck(... embers: rad(0), dented: 0)     )
 ```
 
 A violation can be checked using the Admin step `assert`. If a violation is detected,
@@ -270,7 +270,7 @@ Vat.debt should not change after End.thaw is called, as this implies the creatio
 ```k
     syntax ViolationFSM ::= "debtConstantAfterThaw"
  // -----------------------------------------------
-    rule derive(debtConstantAfterThaw, Measure(... debt: DEBT, endDebt: END_DEBT)) => Violated(debtConstantAfterThaw) requires (END_DEBT =/=Rad 0Rad) andBool (DEBT =/=Rad END_DEBT)
+    rule derive(debtConstantAfterThaw, Measure(... debt: DEBT, endDebt: END_DEBT)) => Violated(debtConstantAfterThaw) requires (END_DEBT =/=Rad rad(0)) andBool (DEBT =/=Rad END_DEBT)
 ```
 
 ### Bounded Debt Growth
@@ -285,7 +285,7 @@ The Debt growth should be bounded in principle by the interest rates available i
     rule derive(totalDebtBounded(... dsr: DSR), Measure(... debt: DEBT)) => totalDebtBoundedRun(... debt: DEBT, dsr: DSR)
 
     rule derive( totalDebtBoundedRun(... debt: DEBT, dsr: _  ) #as PREV , Measure(... debt: DEBT')            ) => Violated(PREV) requires DEBT' >Rad DEBT
-    rule derive( totalDebtBoundedRun(... debt: DEBT, dsr: DSR)          , TimeStep(TIME, _)                   ) => totalDebtBoundedRun(... debt: DEBT +Rad rmul(vatDaiForUser(Pot), (DSR ^Ray TIME) -Ray 1Ray), dsr: DSR)
+    rule derive( totalDebtBoundedRun(... debt: DEBT, dsr: DSR)          , TimeStep(TIME, _)                   ) => totalDebtBoundedRun(... debt: DEBT +Rad rmul(vatDaiForUser(Pot), (DSR ^Ray TIME) -Ray ray(1)), dsr: DSR)
     rule derive( totalDebtBoundedRun(... debt: DEBT, dsr: DSR)          , LogNote(_ , Vat . frob _ _ _ _ _ _) ) => totalDebtBounded(... dsr: DSR)
     rule derive( totalDebtBoundedRun(... debt: DEBT, dsr: DSR)          , LogNote(_ , Vat . suck _ _ AMOUNT)  ) => totalDebtBoundedRun(... debt: DEBT +Rad AMOUNT, dsr: DSR)
     rule derive( totalDebtBoundedRun(... debt: DEBT, dsr: DSR)          , LogNote(_ , Pot . file dsr DSR')    ) => totalDebtBoundedRun(... debt: DEBT, dsr: DSR')
@@ -301,12 +301,12 @@ The Pot Chi multiplied by Pot Pie should equal the Vat Dai for the Pot
 ```k
     syntax ViolationFSM ::= potChiPieDai ( offset: Rad , joining: Wad )
  // -------------------------------------------------------------------
-    rule derive( potChiPieDai(... offset: OFFSET, joining: JOINING ) , LogNote(_, Pot . join WAD)       ) => potChiPieDai(... offset: OFFSET          , joining: JOINING +Wad WAD )
-    rule derive( potChiPieDai(... offset: OFFSET, joining: JOINING ) , LogNote(_, Vat . move _ Pot RAD) ) => potChiPieDai(... offset: OFFSET +Rad RAD , joining: JOINING          )
+    rule derive( potChiPieDai(... offset: OFFSET, joining: JOINING ) , LogNote(_, Pot . join AMOUNT)       ) => potChiPieDai(... offset: OFFSET             , joining: JOINING +Wad AMOUNT )
+    rule derive( potChiPieDai(... offset: OFFSET, joining: JOINING ) , LogNote(_, Vat . move _ Pot AMOUNT) ) => potChiPieDai(... offset: OFFSET +Rad AMOUNT , joining: JOINING             )
 
-    rule derive(potChiPieDai(... offset: OFFSET => OFFSET -Rad (JOINING *Rate POT_CHI), joining: JOINING => 0Wad), Measure(... potChi: POT_CHI)) requires JOINING =/=Wad 0Wad
+    rule derive(potChiPieDai(... offset: OFFSET => OFFSET -Rad (JOINING *Rate POT_CHI), joining: JOINING => wad(0)), Measure(... potChi: POT_CHI)) requires JOINING =/=Wad wad(0)
 
-    rule derive(potChiPieDai(... offset: OFFSET, joining: 0Wad) #as PREV, Measure(... controlDai: CONTROL_DAI, potChi: POT_CHI, potPie: POT_PIE)) => Violated(PREV) requires POT_PIE *Rate POT_CHI =/=Rad #lookupRad(CONTROL_DAI, Pot) -Rad OFFSET
+    rule derive(potChiPieDai(... offset: OFFSET, joining: wad(0)) #as PREV, Measure(... controlDai: CONTROL_DAI, potChi: POT_CHI, potPie: POT_PIE)) => Violated(PREV) requires POT_PIE *Rate POT_CHI =/=Rad #lookupRad(CONTROL_DAI, Pot) -Rad OFFSET
 ```
 
 ### Kicking off a fake `flip` auction (inspired by lucash-flip)

--- a/pot.md
+++ b/pot.md
@@ -113,27 +113,27 @@ Pot Semantics
 
     syntax PotStep ::= "join" Wad
  // -----------------------------
-    rule <k> Pot . join WAD => call Vat . move MSGSENDER THIS ( WAD *Rate CHI ) ... </k>
+    rule <k> Pot . join AMOUNT => call Vat . move MSGSENDER THIS ( AMOUNT *Rate CHI ) ... </k>
          <this> THIS </this>
          <current-time> NOW </current-time>
          <msg-sender> MSGSENDER </msg-sender>
-         <pot-pies> ... MSGSENDER |-> ( MSGSENDER_PIE => MSGSENDER_PIE +Wad WAD ) ... </pot-pies>
-         <pot-pie> PIE => PIE +Wad WAD </pot-pie>
+         <pot-pies> ... MSGSENDER |-> ( MSGSENDER_PIE => MSGSENDER_PIE +Wad AMOUNT ) ... </pot-pies>
+         <pot-pie> PIE => PIE +Wad AMOUNT </pot-pie>
          <pot-chi> CHI </pot-chi>
          <pot-rho> RHO </pot-rho>
-      requires WAD >=Wad wad(0)
+      requires AMOUNT >=Wad wad(0)
        andBool NOW ==Int RHO
 
     syntax PotStep ::= "exit" Wad
  // -----------------------------
-    rule <k> Pot . exit WAD => call Vat . move THIS MSGSENDER ( WAD *Rate CHI ) ... </k>
+    rule <k> Pot . exit AMOUNT => call Vat . move THIS MSGSENDER ( AMOUNT *Rate CHI ) ... </k>
          <this> THIS </this>
          <msg-sender> MSGSENDER </msg-sender>
-         <pot-pies> ... MSGSENDER |-> ( MSGSENDER_PIE => MSGSENDER_PIE -Wad WAD ) ... </pot-pies>
-         <pot-pie> PIE => PIE -Wad WAD </pot-pie>
+         <pot-pies> ... MSGSENDER |-> ( MSGSENDER_PIE => MSGSENDER_PIE -Wad AMOUNT ) ... </pot-pies>
+         <pot-pie> PIE => PIE -Wad AMOUNT </pot-pie>
          <pot-chi> CHI </pot-chi>
-      requires WAD >=Wad wad(0)
-       andBool MSGSENDER_PIE >=Wad WAD
+      requires AMOUNT >=Wad wad(0)
+       andBool MSGSENDER_PIE >=Wad AMOUNT
 
     syntax PotAuthStep ::= "cage"
  // -----------------------------

--- a/pot.md
+++ b/pot.md
@@ -15,9 +15,9 @@ Pot Configuration
       <pot>
         <pot-wards> .Set      </pot-wards>
         <pot-pies>  .Map      </pot-pies> // mapping (address => uint256) Address |-> Wad
-        <pot-pie>   0Wad      </pot-pie>
-        <pot-dsr>   1Ray      </pot-dsr>
-        <pot-chi>   1Ray      </pot-chi>
+        <pot-pie>   wad(0)    </pot-pie>
+        <pot-dsr>   ray(1)    </pot-dsr>
+        <pot-chi>   ray(1)    </pot-chi>
         <pot-vow>   0:Address </pot-vow>
         <pot-rho>   0         </pot-rho>
         <pot-live>  true      </pot-live>
@@ -71,7 +71,7 @@ These parameters are controlled by governance:
          <current-time> NOW </current-time>
          <pot-live> true </pot-live>
       requires NOW ==Int RHO
-       andBool DSR >=Ray 0Ray
+       andBool DSR >=Ray ray(0)
 
     rule <k> Pot . file vow-file ADDR => . ... </k>
          <pot-vow> _ => ADDR </pot-vow>
@@ -90,7 +90,7 @@ Because data isn't explicitely initialized to 0 in KMCD, we need explicit initia
     syntax PotAuthStep ::= "initUser" Address
  // -----------------------------------------
     rule <k> Pot . initUser ADDR => . ... </k>
-         <pot-pies> PIES => PIES [ ADDR <- 0Wad ] </pot-pies>
+         <pot-pies> PIES => PIES [ ADDR <- wad(0) ] </pot-pies>
       requires notBool ADDR in_keys(PIES)
 ```
 
@@ -100,7 +100,7 @@ Pot Semantics
 ```k
     syntax PotStep ::= "drip"
  // -------------------------
-    rule <k> Pot . drip => call Vat . suck VOW THIS ( PIE *Rate ( CHI *Ray ( DSR ^Ray (NOW -Int RHO) -Ray 1Ray ) ) ) ... </k>
+    rule <k> Pot . drip => call Vat . suck VOW THIS ( PIE *Rate ( CHI *Ray ( DSR ^Ray (NOW -Int RHO) -Ray ray(1) ) ) ) ... </k>
          <this> THIS </this>
          <current-time> NOW </current-time>
          <pot-chi> CHI => CHI *Ray (DSR ^Ray (NOW -Int RHO)) </pot-chi>
@@ -109,7 +109,7 @@ Pot Semantics
          <pot-vow> VOW </pot-vow>
          <pot-pie> PIE </pot-pie>
       requires NOW >=Int RHO
-       andBool DSR >=Ray 1Ray // to ensure positive interest rate
+       andBool DSR >=Ray ray(1) // to ensure positive interest rate
 
     syntax PotStep ::= "join" Wad
  // -----------------------------
@@ -121,7 +121,7 @@ Pot Semantics
          <pot-pie> PIE => PIE +Wad WAD </pot-pie>
          <pot-chi> CHI </pot-chi>
          <pot-rho> RHO </pot-rho>
-      requires WAD >=Wad 0Wad
+      requires WAD >=Wad wad(0)
        andBool NOW ==Int RHO
 
     syntax PotStep ::= "exit" Wad
@@ -132,14 +132,14 @@ Pot Semantics
          <pot-pies> ... MSGSENDER |-> ( MSGSENDER_PIE => MSGSENDER_PIE -Wad WAD ) ... </pot-pies>
          <pot-pie> PIE => PIE -Wad WAD </pot-pie>
          <pot-chi> CHI </pot-chi>
-      requires WAD >=Wad 0Wad
+      requires WAD >=Wad wad(0)
        andBool MSGSENDER_PIE >=Wad WAD
 
     syntax PotAuthStep ::= "cage"
  // -----------------------------
     rule <k> Pot . cage => . ... </k>
          <pot-live> _ => false </pot-live>
-         <pot-dsr> _ => 1Ray </pot-dsr>
+         <pot-dsr> _ => ray(1) </pot-dsr>
 ```
 
 ```k

--- a/spot.md
+++ b/spot.md
@@ -82,10 +82,10 @@ These parameters are controlled by governance/oracles:
          <spot-live> true </spot-live>
          <spot-ilks> ... ILKID |-> SpotIlk ( ... pip: (_ => .Wad) ) ... </spot-ilks>
 
-    rule <k> Spot . file pip ILKID WAD:Wad => . ... </k>
+    rule <k> Spot . file pip ILKID PRICE:Wad => . ... </k>
          <spot-live> true </spot-live>
-         <spot-ilks> ... ILKID |-> SpotIlk ( ... pip: (_ => WAD) ) ... </spot-ilks>
-      requires WAD >=Wad wad(0)
+         <spot-ilks> ... ILKID |-> SpotIlk ( ... pip: (_ => PRICE) ) ... </spot-ilks>
+      requires PRICE >=Wad wad(0)
 
     rule <k> Spot . file mat ILKID MAT => . ... </k>
          <spot-live> true </spot-live>

--- a/spot.md
+++ b/spot.md
@@ -13,10 +13,10 @@ Spot Configuration
 ```k
     configuration
       <spot>
-        <spot-wards> .Set </spot-wards>
-        <spot-ilks>  .Map </spot-ilks> // mapping (bytes32 => ilk)  String  |-> SpotIlk
-        <spot-par>   1Ray </spot-par>
-        <spot-live>  true </spot-live>
+        <spot-wards> .Set   </spot-wards>
+        <spot-ilks>  .Map   </spot-ilks> // mapping (bytes32 => ilk)  String  |-> SpotIlk
+        <spot-par>   ray(1) </spot-par>
+        <spot-live>  true   </spot-live>
       </spot>
 ```
 
@@ -85,17 +85,17 @@ These parameters are controlled by governance/oracles:
     rule <k> Spot . file pip ILKID WAD:Wad => . ... </k>
          <spot-live> true </spot-live>
          <spot-ilks> ... ILKID |-> SpotIlk ( ... pip: (_ => WAD) ) ... </spot-ilks>
-      requires WAD >=Wad 0Wad
+      requires WAD >=Wad wad(0)
 
     rule <k> Spot . file mat ILKID MAT => . ... </k>
          <spot-live> true </spot-live>
          <spot-ilks> ... ILKID |-> SpotIlk ( ... mat: (_ => MAT) ) ... </spot-ilks>
-      requires MAT >=Ray 0Ray
+      requires MAT >=Ray ray(0)
 
     rule <k> Spot . file par PAR => . ... </k>
          <spot-live> true </spot-live>
          <spot-par> _ => PAR </spot-par>
-      requires PAR >=Ray 0Ray
+      requires PAR >=Ray ray(0)
 ```
 
 **TODO**: We currently store a `MaybeWad` for `pip` instead of a contract address to call to get that data.
@@ -122,7 +122,7 @@ Because data isn't explicitely initialized to 0 in KMCD, we need explicit initia
                           | "setPrice" String Wad
  // ---------------------------------------------
     rule <k> Spot . init ILKID => . ... </k>
-         <spot-ilks> ILKS => ILKS [ ILKID <- SpotIlk( ... pip: .Wad, mat: 0Ray ) ] </spot-ilks>
+         <spot-ilks> ILKS => ILKS [ ILKID <- SpotIlk( ... pip: .Wad, mat: ray(0) ) ] </spot-ilks>
       requires notBool ILKID in_keys(ILKS)
 
     rule <k> Spot . setPrice ILKID PRICE => . ... </k>

--- a/vat.md
+++ b/vat.md
@@ -11,17 +11,17 @@ Vat Configuration
 ```k
     configuration
       <vat>
-        <vat-wards> .Set </vat-wards>
-        <vat-can>   .Map </vat-can>  // mapping (address (address => uint))       Address |-> Set
-        <vat-ilks>  .Map </vat-ilks> // mapping (bytes32 => Ilk)                  String  |-> VatIlk
-        <vat-urns>  .Map </vat-urns> // mapping (bytes32 => (address => Urn))     CDPID   |-> VatUrn
-        <vat-gem>   .Map </vat-gem>  // mapping (bytes32 => (address => uint256)) CDPID   |-> Wad
-        <vat-dai>   .Map </vat-dai>  // mapping (address => uint256)              Address |-> Rad
-        <vat-sin>   .Map </vat-sin>  // mapping (address => uint256)              Address |-> Rad
-        <vat-debt>  0Rad </vat-debt> // Total Dai Issued
-        <vat-vice>  0Rad </vat-vice> // Total Unbacked Dai
-        <vat-Line>  0Rad </vat-Line> // Total Debt Ceiling
-        <vat-live>  true </vat-live> // Access Flag
+        <vat-wards> .Set   </vat-wards>
+        <vat-can>   .Map   </vat-can>  // mapping (address (address => uint))       Address |-> Set
+        <vat-ilks>  .Map   </vat-ilks> // mapping (bytes32 => Ilk)                  String  |-> VatIlk
+        <vat-urns>  .Map   </vat-urns> // mapping (bytes32 => (address => Urn))     CDPID   |-> VatUrn
+        <vat-gem>   .Map   </vat-gem>  // mapping (bytes32 => (address => uint256)) CDPID   |-> Wad
+        <vat-dai>   .Map   </vat-dai>  // mapping (address => uint256)              Address |-> Rad
+        <vat-sin>   .Map   </vat-sin>  // mapping (address => uint256)              Address |-> Rad
+        <vat-debt>  rad(0) </vat-debt> // Total Dai Issued
+        <vat-vice>  rad(0) </vat-vice> // Total Unbacked Dai
+        <vat-Line>  rad(0) </vat-Line> // Total Debt Ceiling
+        <vat-live>  true   </vat-live> // Access Flag
       </vat>
 ```
 
@@ -138,22 +138,22 @@ The parameters controlled by governance are:
     rule <k> Vat . file Line LINE => . ... </k>
          <vat-live> true </vat-live>
          <vat-Line> _ => LINE </vat-Line>
-      requires LINE >=Rad 0Rad
+      requires LINE >=Rad rad(0)
 
     rule <k> Vat . file spot ILKID SPOT => . ... </k>
          <vat-live> true </vat-live>
          <vat-ilks> ... ILKID |-> Ilk ( ... spot: (_ => SPOT) ) ... </vat-ilks>
-      requires SPOT >=Ray 0Ray
+      requires SPOT >=Ray ray(0)
 
     rule <k> Vat . file line ILKID LINE => . ... </k>
          <vat-live> true </vat-live>
          <vat-ilks> ... ILKID |-> Ilk ( ... line: (_ => LINE) ) ... </vat-ilks>
-      requires LINE >=Rad 0Rad
+      requires LINE >=Rad rad(0)
 
     rule <k> Vat . file dust ILKID DUST => . ... </k>
          <vat-live> true </vat-live>
          <vat-ilks> ... ILKID |-> Ilk ( ... dust: (_ => DUST) ) ... </vat-ilks>
-      requires DUST >=Rad 0Rad
+      requires DUST >=Rad rad(0)
 ```
 
 Vat Initialization
@@ -173,23 +173,23 @@ Because data isn't explicitely initialized to 0 in KMCD, we need explicit initia
                          | "initCDP" String Address
  // -----------------------------------------------
     rule <k> Vat . initIlk ILKID => . ... </k>
-         <vat-ilks> ILKS => ILKS [ ILKID <- Ilk ( ... Art: 0Wad , rate: 1Ray , spot: 0Ray , line: 0Rad , dust: 0Rad ) ] </vat-ilks>
+         <vat-ilks> ILKS => ILKS [ ILKID <- Ilk ( ... Art: wad(0) , rate: ray(1) , spot: ray(0) , line: rad(0) , dust: rad(0) ) ] </vat-ilks>
       requires notBool ILKID in_keys(ILKS)
 
     rule <k> Vat . initUser ADDR => . ... </k>
          <vat-can> CAN => CAN [ ADDR <- .Set ] </vat-can>
-         <vat-dai> DAI => DAI [ ADDR <- 0Rad ] </vat-dai>
-         <vat-sin> SIN => SIN [ ADDR <- 0Rad ] </vat-sin>
+         <vat-dai> DAI => DAI [ ADDR <- rad(0) ] </vat-dai>
+         <vat-sin> SIN => SIN [ ADDR <- rad(0) ] </vat-sin>
       requires notBool ADDR in_keys(CAN)
        andBool notBool ADDR in_keys(DAI)
        andBool notBool ADDR in_keys(SIN)
 
     rule <k> Vat . initGem ILKID ADDR => . ... </k>
-         <vat-gem> GEMS => GEMS [ { ILKID , ADDR } <- 0Wad ] </vat-gem>
+         <vat-gem> GEMS => GEMS [ { ILKID , ADDR } <- wad(0) ] </vat-gem>
       requires notBool { ILKID , ADDR } in_keys(GEMS)
 
     rule <k> Vat . initCDP ILKID ADDR => . ... </k>
-         <vat-urns> URNS => URNS [ { ILKID , ADDR } <- Urn( ... ink: 0Wad , art: 0Wad ) ] </vat-urns>
+         <vat-urns> URNS => URNS [ { ILKID , ADDR } <- Urn( ... ink: wad(0) , art: wad(0) ) ] </vat-urns>
       requires notBool { ILKID , ADDR } in_keys(URNS)
 ```
 
@@ -253,7 +253,7 @@ This is quite permissive, and would allow the account to drain all your locked c
     rule <k> Vat . safe ILKID ADDR => . ... </k>
          <vat-ilks> ...   ILKID          |-> ILK ... </vat-ilks>
          <vat-urns> ... { ILKID , ADDR } |-> URN ... </vat-urns>
-      requires 0Rad <=Rad urnBalance(ILK, URN)
+      requires rad(0) <=Rad urnBalance(ILK, URN)
        andBool urnDebt(ILK, URN) <=Rad line(ILK)
 
     syntax VatStep ::= "nondusty" String Address
@@ -261,7 +261,7 @@ This is quite permissive, and would allow the account to drain all your locked c
     rule <k> Vat . nondusty ILKID ADDR => . ... </k>
          <vat-ilks> ...   ILKID          |-> ILK ... </vat-ilks>
          <vat-urns> ... { ILKID , ADDR } |-> URN ... </vat-urns>
-      requires dust(ILK) <=Rad urnDebt(ILK, URN) orBool 0Rad ==Rad urnDebt(ILK, URN)
+      requires dust(ILK) <=Rad urnDebt(ILK, URN) orBool rad(0) ==Rad urnDebt(ILK, URN)
 ```
 
 ### Ilk Initialization (`<vat-ilks>`)
@@ -272,7 +272,7 @@ This is quite permissive, and would allow the account to drain all your locked c
     syntax VatAuthStep ::= "init" String
  // ------------------------------------
     rule <k> Vat . init ILKID => . ... </k>
-         <vat-ilks> ... ILKID |-> Ilk(... rate: 0Ray => 1Ray) ... </vat-ilks>
+         <vat-ilks> ... ILKID |-> Ilk(... rate: ray(0) => ray(1)) ... </vat-ilks>
 ```
 
 ### Collateral manipulation (`<vat-gem>`)
@@ -290,7 +290,7 @@ This is quite permissive, and would allow the account to drain all your locked c
  // ------------------------------------------------
     rule <k> Vat . slip ILKID ADDRTO NEWCOL => . ... </k>
          <vat-gem> ... { ILKID , ADDRTO } |-> ( COL => COL +Wad NEWCOL ) ... </vat-gem>
-      requires NEWCOL >=Wad 0Wad
+      requires NEWCOL >=Wad wad(0)
 
     syntax VatStep ::= "flux" String Address Address Wad
  // ----------------------------------------------------
@@ -301,13 +301,13 @@ This is quite permissive, and would allow the account to drain all your locked c
            { ILKID , ADDRTO   } |-> ( COLTO   => COLTO   +Wad COL )
            ...
          </vat-gem>
-      requires COL     >=Wad 0Wad
+      requires COL     >=Wad wad(0)
        andBool COLFROM >=Wad COL
        andBool wish ADDRFROM
 
     rule <k> Vat . flux ILKID ADDRFROM ADDRFROM COL => . ... </k>
          <vat-gem> ... { ILKID , ADDRFROM } |-> COLFROM ... </vat-gem>
-      requires COL     >=Wad 0Wad
+      requires COL     >=Wad wad(0)
        andBool COLFROM >=Wad COL
        andBool wish ADDRFROM
 ```
@@ -326,13 +326,13 @@ This is quite permissive, and would allow the account to drain all your locked c
            ADDRTO   |-> (DAITO   => DAITO   +Rad DAI)
            ...
          </vat-dai>
-      requires DAI     >=Rad 0Rad
+      requires DAI     >=Rad rad(0)
        andBool DAIFROM >=Rad DAI
        andBool wish ADDRFROM
 
     rule <k> Vat . move ADDRFROM ADDRFROM DAI => . ... </k>
          <vat-dai> ... ADDRFROM |-> DAIFROM ... </vat-dai>
-      requires DAI     >=Rad 0Rad
+      requires DAI     >=Rad rad(0)
        andBool DAIFROM >=Rad DAI
        andBool wish ADDRFROM
 ```
@@ -405,18 +405,18 @@ This is quite permissive, and would allow the account to drain all your locked c
          <vat-dai> ... ADDRW |-> ( DAIW => DAIW +Rad (DART *Rate RATE) ) ... </vat-dai>
          <vat-Line> LINE </vat-Line>
       requires ILKV >=Wad DINK
-       andBool ( DART <=Wad 0Wad
+       andBool ( DART <=Wad wad(0)
                orBool ((ILKART +Wad DART) *Rate RATE <=Rad ILKLINE andBool DEBT +Rad (DART *Rate RATE) <=Rad LINE)
                     )
-       andBool      ( (DART <=Wad 0Wad andBool DINK >=Wad 0Wad)
+       andBool      ( (DART <=Wad wad(0) andBool DINK >=Wad wad(0))
                orBool (URNART +Wad DART) *Rate RATE <=Rad (INK +Wad DINK) *Rate SPOT
                     )
-       andBool      ( (DART <=Wad 0Wad andBool DINK >=Wad 0Wad)
+       andBool      ( (DART <=Wad wad(0) andBool DINK >=Wad wad(0))
                orBool wish ADDRU
                     )
-       andBool (DINK <=Wad 0Wad orBool wish ADDRV)
-       andBool (DART >=Wad 0Wad orBool wish ADDRW)
-       andBool (URNART +Wad DART ==Wad 0Wad orBool (URNART +Wad DART) *Rate RATE >=Rad DUST)
+       andBool (DINK <=Wad wad(0) orBool wish ADDRV)
+       andBool (DART >=Wad wad(0) orBool wish ADDRW)
+       andBool (URNART +Wad DART ==Wad wad(0) orBool (URNART +Wad DART) *Rate RATE >=Rad DUST)
 ```
 
 ### Debt/Dai manipulation (`<vat-debt>`, `<vat-dai>`, `<vat-vice>`, `<vat-sin>`)
@@ -433,7 +433,7 @@ This is quite permissive, and would allow the account to drain all your locked c
          <vat-vice> VICE => VICE -Rad AMOUNT </vat-vice>
          <vat-sin> ... ADDRFROM |-> (SIN => SIN -Rad AMOUNT) ... </vat-sin>
          <vat-dai> ... ADDRFROM |-> (DAI => DAI -Rad AMOUNT) ... </vat-dai>
-      requires AMOUNT >=Rad 0Rad
+      requires AMOUNT >=Rad rad(0)
        andBool DEBT >=Rad AMOUNT
        andBool VICE >=Rad AMOUNT
        andBool SIN  >=Rad AMOUNT
@@ -446,7 +446,7 @@ This is quite permissive, and would allow the account to drain all your locked c
          <vat-vice> VICE => VICE +Rad AMOUNT </vat-vice>
          <vat-sin> ... ADDRU |-> (SIN => SIN +Rad AMOUNT) ... </vat-sin>
          <vat-dai> ... ADDRV |-> (DAI => DAI +Rad AMOUNT) ... </vat-dai>
-      requires AMOUNT >=Rad 0Rad
+      requires AMOUNT >=Rad rad(0)
 ```
 
 ### CDP Manipulation

--- a/vow.md
+++ b/vow.md
@@ -17,16 +17,16 @@ Vow Configuration
 ```k
     configuration
       <vow>
-        <vow-wards> .Set </vow-wards>
-        <vow-sins>  .Map </vow-sins> // mapping (uint256 => uint256) Int |-> Rad
-        <vow-sin>   0Rad </vow-sin>
-        <vow-ash>   0Rad </vow-ash>
-        <vow-wait>  0    </vow-wait>
-        <vow-dump>  0Wad </vow-dump>
-        <vow-sump>  0Rad </vow-sump>
-        <vow-bump>  0Rad </vow-bump>
-        <vow-hump>  0Rad </vow-hump>
-        <vow-live>  true </vow-live>
+        <vow-wards> .Set   </vow-wards>
+        <vow-sins>  .Map   </vow-sins> // mapping (uint256 => uint256) Int |-> Rad
+        <vow-sin>   rad(0) </vow-sin>
+        <vow-ash>   rad(0) </vow-ash>
+        <vow-wait>  0      </vow-wait>
+        <vow-dump>  wad(0) </vow-dump>
+        <vow-sump>  rad(0) </vow-sump>
+        <vow-bump>  rad(0) </vow-bump>
+        <vow-hump>  rad(0) </vow-hump>
+        <vow-live>  true   </vow-live>
       </vow>
 ```
 
@@ -84,19 +84,19 @@ These praameters are set by governance:
 
     rule <k> Vow . file bump BUMP => . ... </k>
          <vow-bump> _ => BUMP </vow-bump>
-      requires BUMP >=Rad 0Rad
+      requires BUMP >=Rad rad(0)
 
     rule <k> Vow . file hump HUMP => . ... </k>
          <vow-hump> _ => HUMP </vow-hump>
-      requires HUMP >=Rad 0Rad
+      requires HUMP >=Rad rad(0)
 
     rule <k> Vow . file sump SUMP => . ... </k>
          <vow-sump> _ => SUMP </vow-sump>
-      requires SUMP >=Rad 0Rad
+      requires SUMP >=Rad rad(0)
 
     rule <k> Vow . file dump DUMP => . ... </k>
          <vow-dump> _ => DUMP </vow-dump>
-      requires DUMP >=Wad 0Wad
+      requires DUMP >=Wad wad(0)
 ```
 
 Vow Semantics
@@ -109,14 +109,14 @@ Vow Semantics
          <current-time> NOW </current-time>
          <vow-sins> ... NOW |-> (SIN' => SIN' +Rad TAB) ... </vow-sins>
          <vow-sin> SIN => SIN +Rad TAB </vow-sin>
-      requires TAB >=Rad 0Rad
+      requires TAB >=Rad rad(0)
 
     syntax VowStep ::= "flog" Int
  // -----------------------------
     rule <k> Vow . flog ERA => . ... </k>
          <current-time> NOW </current-time>
          <vow-wait> WAIT </vow-wait>
-         <vow-sins> ... ERA |-> (SIN' => 0Rad) ... </vow-sins>
+         <vow-sins> ... ERA |-> (SIN' => rad(0)) ... </vow-sins>
          <vow-sin> SIN => SIN -Rad SIN' </vow-sin>
       requires ERA >=Int 0
        andBool ERA +Int WAIT <=Int NOW
@@ -129,7 +129,7 @@ Vow Semantics
          <vat-sin> ... THIS |-> VATSIN ... </vat-sin>
          <vow-sin> SIN </vow-sin>
          <vow-ash> ASH </vow-ash>
-      requires AMOUNT >=Rad 0Rad
+      requires AMOUNT >=Rad rad(0)
        andBool AMOUNT <=Rad VATDAI
        andBool AMOUNT <=Rad (VATSIN -Rad SIN) -Rad ASH
 
@@ -139,7 +139,7 @@ Vow Semantics
          <this> THIS </this>
          <vat-dai> ... THIS |-> VATDAI ... </vat-dai>
          <vow-ash> ASH => ASH -Rad AMOUNT </vow-ash>
-       requires AMOUNT >=Rad 0Rad
+       requires AMOUNT >=Rad rad(0)
         andBool AMOUNT <=Rad ASH
         andBool AMOUNT <=Rad VATDAI
 
@@ -154,11 +154,11 @@ Vow Semantics
          <vow-sump> SUMP </vow-sump>
          <vow-dump> DUMP </vow-dump>
       requires SUMP <=Rad (VATSIN -Rad SIN) -Rad ASH
-       andBool VATDAI ==Rad 0Rad
+       andBool VATDAI ==Rad rad(0)
 
     syntax VowStep ::= "flap"
  // -------------------------
-    rule <k> Vow . flap => call Flap . kick BUMP 0Wad ... </k>
+    rule <k> Vow . flap => call Flap . kick BUMP wad(0) ... </k>
          <this> THIS </this>
          <vat-sin> ... THIS |-> VATSIN ... </vat-sin>
          <vat-dai> ... THIS |-> VATDAI ... </vat-dai>
@@ -167,7 +167,7 @@ Vow Semantics
          <vow-bump> BUMP </vow-bump>
          <vow-hump> HUMP </vow-hump>
       requires VATDAI >=Rad (VATSIN +Rad BUMP) +Rad HUMP
-       andBool (VATSIN -Rad SIN) -Rad ASH ==Rad 0Rad
+       andBool (VATSIN -Rad SIN) -Rad ASH ==Rad rad(0)
 
     syntax VowAuthStep ::= "cage"
  // -----------------------------
@@ -186,8 +186,8 @@ Vow Semantics
            ...
          </vat-dai>
          <vow-live> _ => false </vow-live>
-         <vow-sin> _ => 0Rad </vow-sin>
-         <vow-ash> _ => 0Rad </vow-ash>
+         <vow-sin> _ => rad(0) </vow-sin>
+         <vow-ash> _ => rad(0) </vow-ash>
       requires THIS =/=K Flap
 ```
 


### PR DESCRIPTION
There were still some issues with changing the underlying representation of these data-types, so this refactors to make it easier. Basic changes include:

-   Removal of `0{Wad,Ray,Rad}` and `1{Wad,Ray,Rad}` in favor of `{wad,ray,rad}(0)` and `{wad,ray,rad}(1)`.
-   Avoid names `WAD`, `RAY`, and `RAD` for variable names.
-   Switch away from directly putting rationals in configurations of `flip`, `flap`, and `flop`.
-   Add quantities `WAD`, `RAY`, and `RAD` for convenience later.