### PR TITLE
Improve random testing

### DIFF
--- a/mcd-pyk.py
+++ b/mcd-pyk.py
@@ -262,6 +262,20 @@ def argify(arg):
         newArg = '"' + newArg + '"'
     return newArg
 
+def solidityKeys(k):
+    args = []
+    if pyk.isKApply(k) and k['label'] == 'CDPID':
+        args = [ a for a in k['args'] ]
+    else:
+        args = [ a for a in [k] ]
+    return args
+
+def solidityArgs(ks):
+    allKeys = []
+    for k in ks:
+        allKeys.extend(solidityKeys(k))
+    return ', '.join([argify(printMCD(k)) for k in allKeys])
+
 def unimplemented(s):
     return '// UNIMPLEMENTED << ' + '\n    //'.join(s.split('\n')) + ' >>'
 
@@ -317,20 +331,6 @@ def noRewriteToDots(config):
         if not pyk.isKRewrite(subst[cell]):
             subst[cell] = pyk.ktokenDots
     return pyk.substitute(cfg, subst)
-
-def solidityKeys(k):
-    args = []
-    if pyk.isKApply(k) and k['label'] == 'CDPID':
-        args = [ a for a in k['args'] ]
-    else:
-        args = [ a for a in [k] ]
-    return args
-
-def solidityArgs(ks):
-    allKeys = []
-    for k in ks:
-        allKeys.extend(solidityKeys(k))
-    return ', '.join([argify(printMCD(k)) for k in allKeys])
 
 def stateAssertions(contract, field, value, subkeys = []):
     assertionData = []

--- a/mcd-pyk.py
+++ b/mcd-pyk.py
@@ -319,6 +319,15 @@ def noRewriteToDots(config):
             subst[cell] = pyk.ktokenDots
     return pyk.substitute(cfg, subst)
 
+def solidityArgs(k):
+    args = []
+    if pyk.isKApply(k) and k['label'] == 'CDPID':
+        args = [ a for a in k['args'] ]
+    else:
+        args = [ a for a in [k] ]
+    argStrs = [ argify(printMCD(a)) for a in args ]
+    return ', '.join(argStrs)
+
 def buildAssert(contract, field, value):
     assertionData = []
     if pyk.isKToken(value) and value['sort'] == 'Bool':
@@ -330,14 +339,15 @@ def buildAssert(contract, field, value):
         assertionData.append((actual, comparator, expected, True))
     elif pyk.isKApply(value) and value['label'] == '_Map_':
         for (k, v) in flattenMap(value):
+            keyStr = solidityArgs(k)
             if pyk.isKApply(v) and v['label'] == '_Set_':
                 for si in flattenSet(v):
-                    actual     = contract + '.' + field + '(' + argify(printMCD(k)) + ', ' + argify(printMCD(si)) + ')'
+                    actual     = contract + '.' + field + '(' + keyStr + ', ' + argify(printMCD(si)) + ')'
                     comparator = '!='
                     expected   = printMCD(intToken(0))
                     assertionData.append((actual, comparator, expected, True))
             else:
-                actual     = contract + '.' + field + '(' + argify(printMCD(k)) + ')'
+                actual     = contract + '.' + field + '(' + keyStr + ')'
                 comparator = '=='
                 expected   = printMCD(v)
                 assertionData.append((actual, comparator, expected, False))

--- a/mcd-pyk.py
+++ b/mcd-pyk.py
@@ -254,11 +254,11 @@ def solidify(input):
 
 def argify(arg):
     newArg = solidify(arg)
-    if    newArg in ['alice', 'bobby', 'admin', 'anyone']                                      \
+    if    newArg in ['alice', 'bobby', 'admin', 'anyone']                                        \
        or newArg in ['cat', 'dai', 'end', 'flap', 'flop', 'jug', 'pot', 'spotter', 'vat', 'vow'] \
        or newArg.endswith('Flip') or newArg.endswith('Join'):
         newArg = 'address(' + newArg + ')'
-    if newArg in ['gold']:
+    if newArg in ['gold', 'line', 'mat', 'par']:
         newArg = '"' + newArg + '"'
     return newArg
 

--- a/mcd-pyk.py
+++ b/mcd-pyk.py
@@ -92,7 +92,6 @@ MCD_definition_llvm_symbols [ '_Set_' ]                                    = lam
 MCD_definition_llvm_symbols [ '_Map_' ]                                    = lambda m1, m2: pyk.newLines([m1, m2])
 MCD_definition_llvm_symbols [ '___KMCD-DRIVER_MCDSteps_MCDStep_MCDSteps' ] = lambda s1, s2: pyk.newLines([s1, s2])
 
-
 def printMCD(k):
     return pyk.prettyPrintKast(k, MCD_definition_llvm_symbols)
 

--- a/mcd-pyk.py
+++ b/mcd-pyk.py
@@ -258,7 +258,7 @@ def argify(arg):
        or newArg in ['cat', 'dai', 'end', 'flap', 'flop', 'jug', 'pot', 'spotter', 'vat', 'vow'] \
        or newArg.endswith('Flip') or newArg.endswith('Join'):
         newArg = 'address(' + newArg + ')'
-    if newArg in ['gold', 'line', 'mat', 'par']:
+    if newArg in ['gold', 'line', 'mat', 'par', 'dsr']:
         newArg = '"' + newArg + '"'
     return newArg
 

--- a/mcd-pyk.py
+++ b/mcd-pyk.py
@@ -328,7 +328,7 @@ def solidityArgs(k):
     argStrs = [ argify(printMCD(a)) for a in args ]
     return ', '.join(argStrs)
 
-def buildAssert(contract, field, value):
+def stateAssertions(contract, field, value):
     assertionData = []
     if pyk.isKToken(value) and value['sort'] == 'Bool':
         actual     = contract + '.' + field + '()'
@@ -359,6 +359,10 @@ def buildAssert(contract, field, value):
     else:
         actual = contract + '.' + field + '()'
         assertionData.append((actual, '==', printMCD(value), False))
+    return assertionData
+
+def buildAsserts(contract, field, value):
+    assertionData = stateAssertions(contract, field, value)
     assertions = []
     for (actual, comparator, expected, implemented) in assertionData:
         aStr = 'assertTrue( ' + actual + ' ' + comparator + ' ' + expected + ' );'
@@ -380,7 +384,7 @@ def extractAsserts(config):
             if contract == 'Vat' and field == 'line':
                 field = 'Line'
             rhs = subst[cell]['rhs']
-            asserts.extend(buildAssert(contract, field, rhs))
+            asserts.extend(buildAsserts(contract, field, rhs))
     stateDelta = noRewriteToDots(stateDelta)
     stateDelta = pyk.collapseDots(stateDelta)
     return (printMCD(stateDelta), asserts)

--- a/mcd-pyk.py
+++ b/mcd-pyk.py
@@ -263,12 +263,12 @@ def argify(arg):
     return newArg
 
 def solidityKeys(k):
-    args = []
     if pyk.isKApply(k) and k['label'] == 'CDPID':
-        args = [ a for a in k['args'] ]
+        return [ a for a in k['args'] ]
+    elif pyk.isKApply(k) and k['label'] == 'FInt':
+        return [ a for a in [ k['args'][0] ] ]
     else:
-        args = [ a for a in [k] ]
-    return args
+        return [ a for a in [k] ]
 
 def solidityArgs(ks):
     allKeys = []
@@ -295,12 +295,12 @@ def extractCallEvent(logEvent):
             if fileable.endswith('-file'):
                 fileable = fileable[0:-5]
             fileargs = functionCall['args'][0]['args']
-            args.append('"' + fileable + '"')
-            for arg in fileargs:
-                args.append(argify(printMCD(arg)))
+            args.append(stringToken(fileable))
+            args.extend(fileargs)
         else:
-            args = [ argify(printMCD(arg)) for arg in functionCall['args'] ]
-        return [ caller + '.' + contract + '_' + function + '(' + ', '.join(args) + ');' ]
+            args = functionCall['args']
+        strArgs = solidityArgs(args)
+        return [ caller + '.' + contract + '_' + function + '(' + strArgs + ');' ]
     elif pyk.isKApply(logEvent) and logEvent['label'] == 'LogTimeStep':
         return [ 'hevm.warp(' + printMCD(logEvent['args'][0]) + ');' ]
     elif pyk.isKApply(logEvent) and logEvent['label'] == 'LogException':

--- a/mcd-pyk.py
+++ b/mcd-pyk.py
@@ -87,11 +87,12 @@ def kMapToDict(s, keyConvert = lambda x: x, valueConvert = lambda x: x):
 
 MCD_definition_llvm_symbols = pyk.buildSymbolTable(MCD_definition_llvm)
 
-MCD_definition_llvm_symbols [ '<_,_>Rat_RAT-COMMON_Rat_Int_Int' ]          = pyk.underbarUnparsing('_/Rat_')
+MCD_definition_llvm_symbols [ 'FInt' ]                                     = lambda v, o: v
 MCD_definition_llvm_symbols [ '_List_' ]                                   = lambda l1, l2: pyk.newLines([l1, l2])
 MCD_definition_llvm_symbols [ '_Set_' ]                                    = lambda s1, s2: pyk.newLines([s1, s2])
 MCD_definition_llvm_symbols [ '_Map_' ]                                    = lambda m1, m2: pyk.newLines([m1, m2])
 MCD_definition_llvm_symbols [ '___KMCD-DRIVER_MCDSteps_MCDStep_MCDSteps' ] = lambda s1, s2: pyk.newLines([s1, s2])
+
 
 def printMCD(k):
     return pyk.prettyPrintKast(k, MCD_definition_llvm_symbols)

--- a/mcd-pyk.py
+++ b/mcd-pyk.py
@@ -346,6 +346,11 @@ def buildAssert(contract, field, value):
                     comparator = '!='
                     expected   = printMCD(intToken(0))
                     assertionData.append((actual, comparator, expected, True))
+            elif pyk.isKApply(v) and v['label'] == 'FInt':
+                actual     = contract + '.' + field + '(' + keyStr + ')'
+                comparator = '=='
+                expected   = printMCD(v)
+                assertionData.append((actual, comparator, expected, True))
             else:
                 actual     = contract + '.' + field + '(' + keyStr + ')'
                 comparator = '=='

--- a/vat.md
+++ b/vat.md
@@ -92,8 +92,8 @@ CDP Data
     -   `art`: Total amount of debt against the CDP.
 
 ```k
-    syntax CDPID ::= "{" String "," Address "}"
- // -------------------------------------------
+    syntax CDPID ::= "{" String "," Address "}" [klabel(CDPID), symbol]
+ // -------------------------------------------------------------------
 
     syntax VatUrn ::= Urn ( ink: Wad , art: Wad ) [klabel(#VatUrn), symbol]
  // -----------------------------------------------------------------------


### PR DESCRIPTION
-   Handles maps with `CDPID`s as keys in generating assertions.
-   Switches to generating code for `FInt` correctly.
-   Adds functions `solidityArgs` and `solidityKeys` which make it easier to build Solidity function calls for both method calls and assertion building.
-   Refactors `stateAssertions` to be recursive, so that traversing the existing state and building assertions is simpler.