### PR TITLE
Run MKR testing harness on CI

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,7 +10,7 @@
     path = deps/dss
     url = https://github.com/makerdao/dss
     ignore = untracked
-[submodule "tests/mkr-mcd-spec-sort-tests"]
-    path = tests/mkr-mcd-spec-sort-tests
+[submodule "tests/mkr-mcd-spec-sol-tests"]
+    path = tests/mkr-mcd-spec-sol-tests
     url = https://github.com/makerdao/mkr-mcd-spec-sol-tests.git
     ignore = untracked

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,7 @@
     path = deps/dss
     url = https://github.com/makerdao/dss
     ignore = untracked
+[submodule "tests/mkr-mcd-spec-sort-tests"]
+    path = tests/mkr-mcd-spec-sort-tests
+    url = https://github.com/makerdao/mkr-mcd-spec-sol-tests.git
+    ignore = untracked

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,6 +7,6 @@
     url = https://github.com/kframework/k
     ignore = untracked
 [submodule "deps/dss"]
-	path = deps/dss
-	url = https://github.com/makerdao/dss
-	ignore = untracked
+    path = deps/dss
+    url = https://github.com/makerdao/dss
+    ignore = untracked

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,12 @@ RUN    apt-get update        \
         libprocps-dev        \
         pandoc               \
         pkg-config           \
-        python3
+        python3              \
+        sudo
 
 ARG USER_ID=1000
 ARG GROUP_ID=1000
-RUN groupadd -g $GROUP_ID user && useradd -m -u $USER_ID -s /bin/sh -g user user
+RUN groupadd -g $GROUP_ID user && useradd -m -u $USER_ID -s /bin/sh -g user -G sudo user
 
 USER user:user
 WORKDIR /home/user
@@ -26,3 +27,6 @@ RUN    git config --global user.email "admin@runtimeverification.com" \
     && echo '    identityagent SSH_AUTH_SOCK'      >> ~/.ssh/config   \
     && echo '    stricthostkeychecking accept-new' >> ~/.ssh/config   \
     && chmod go-rwx -R ~/.ssh
+
+RUN curl https://dapp.tools/install | sh
+ENV PATH="$PATH:$HOME/.nix-profile/bin"

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN    apt-get update        \
     && apt-get upgrade --yes \
     && apt-get install --yes \
         cmake                \
+        curl                 \
         libprocps-dev        \
         pandoc               \
         pkg-config           \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,13 +14,14 @@ pipeline {
     stage('Build and Test') {
       stages {
         stage('Build') { steps { sh 'make build -j4' } }
-        stage('Test') {
+        stage('Unit Test') {
           parallel {
             stage('Run Simulation Tests') { steps { sh 'make test-execution -j8'    } }
             stage('Python Runner')        { steps { sh 'make test-python-generator' } }
             stage('Random Generation')    { steps { sh 'make test-random'           } }
           }
         }
+        stage('Solidity Test') { steps { sh 'make test-solidity' } }
       }
     }
     stage('Deploy') {

--- a/Makefile
+++ b/Makefile
@@ -129,8 +129,8 @@ test-random: mcd-pyk.py
 	python3 $< random-test 1 1 $(init_random_seeds) --emit-solidity
 
 test-solidity:
-	cd tests/mkr-mcd-spec-sort-tests \
-	    && dapp build                \
+	cd tests/mkr-mcd-spec-sol-tests \
+	    && dapp build               \
 	    && dapp test
 
 ### Testing Parameters

--- a/Makefile
+++ b/Makefile
@@ -28,11 +28,11 @@ LUA_PATH:=$(PANDOC_TANGLE_SUBMODULE)/?.lua;;
 export TANGLER
 export LUA_PATH
 
-.PHONY: all clean                                             \
-        deps deps-k deps-media                                \
-        defn defn-llvm defn-haskell                           \
-        build build-llvm build-haskell                        \
-        test test-execution test-python-generator test-random
+.PHONY: all clean                                                           \
+        deps deps-k deps-media                                              \
+        defn defn-llvm defn-haskell                                         \
+        build build-llvm build-haskell                                      \
+        test test-execution test-python-generator test-random test-solidity
 .SECONDARY:
 
 all: build
@@ -115,7 +115,7 @@ $(haskell_kompiled): $(haskell_files)
 
 KMCD_RANDOMSEED := ""
 
-test: test-execution test-python-generator test-random
+test: test-execution test-python-generator test-random test-solidity
 
 execution_tests_random := $(wildcard tests/*/*.random.mcd)
 execution_tests := $(wildcard tests/*/*.mcd)
@@ -127,6 +127,11 @@ init_random_seeds :=
 
 test-random: mcd-pyk.py
 	python3 $< random-test 1 1 $(init_random_seeds) --emit-solidity
+
+test-solidity:
+	cd tests/mkr-mcd-spec-sort-tests \
+	    && dapp build                \
+	    && dapp test
 
 ### Testing Parameters
 


### PR DESCRIPTION
This just sets up the MKR testing harness for https://github.com/makerdao/mkr-mcd-spec-sol-tests to run on CI (just to make sure we have all the dependencies we need in place).

Next PR will update to actually generate the tests as specified and run them.