### PR TITLE
Updates before adding constructors/deploy logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,6 @@ export PYTHONPATH
 
 .PHONY: all clean clean-test                                                \
         deps deps-k deps-media                                              \
-        defn defn-llvm defn-haskell                                         \
         build build-llvm build-haskell                                      \
         test test-execution test-python-generator test-random test-solidity
 .SECONDARY:
@@ -88,7 +87,6 @@ ALL_FILES          := $(patsubst %, %.md, $(SOURCE_FILES)) $(EXTRA_SOURCE_FILES)
 tangle_concrete := k & (concrete | ! symbolic)
 tangle_symbolic := k & (symbolic | ! concrete)
 
-defn:  defn-llvm  defn-haskell
 build: build-llvm build-haskell
 
 KOMPILE_OPTS += --emit-json
@@ -121,7 +119,6 @@ llvm_dir           := $(DEFN_DIR)/llvm
 llvm_files         := $(ALL_FILES)
 llvm_kompiled      := $(llvm_dir)/$(llvm_main_file)-kompiled/interpreter
 
-defn-llvm:  $(llvm_files)
 build-llvm: $(llvm_kompiled)
 
 $(llvm_kompiled): $(llvm_files)
@@ -139,7 +136,6 @@ haskell_dir           := $(DEFN_DIR)/haskell
 haskell_files         := $(ALL_FILES)
 haskell_kompiled      := $(haskell_dir)/$(haskell_main_file)-kompiled/definition.kore
 
-defn-haskell:  $(haskell_files)
 build-haskell: $(haskell_kompiled)
 
 $(haskell_kompiled): $(haskell_files)

--- a/cat.md
+++ b/cat.md
@@ -74,9 +74,9 @@ Cat Events
 
     syntax CatStep ::= "emitBite" String Address Wad Wad Rad
  // --------------------------------------------------------
-    rule <k> emitBite ILK URN INK ART TAB => ID ... </k>
+    rule <k> emitBite ILK_ID URN INK ART TAB => ID ... </k>
          <return-value> ID:Int </return-value>
-         <frame-events> ... (.List => ListItem(Bite(ILK, URN, INK, ART, TAB, Flip ILK, ID))) </frame-events>
+         <frame-events> ... (.List => ListItem(Bite(ILK_ID, URN, INK, ART, TAB, Flip ILK_ID, ID))) </frame-events>
 ```
 
 File-able Fields
@@ -99,12 +99,12 @@ The parameters controlled by governance are:
     rule <k> Cat . file vow-file ADDR => . ... </k>
          <cat-vow> _ => ADDR </cat-vow>
 
-    rule <k> Cat . file chop ILKID CHOP => . ... </k>
-         <cat-ilks> ... ILKID |-> Ilk ( ... chop: (_ => CHOP) ) ... </cat-ilks>
+    rule <k> Cat . file chop ILK_ID CHOP => . ... </k>
+         <cat-ilks> ... ILK_ID |-> Ilk ( ... chop: (_ => CHOP) ) ... </cat-ilks>
       requires CHOP >=Ray ray(0)
 
-    rule <k> Cat . file lump ILKID LUMP => . ... </k>
-         <cat-ilks> ... ILKID |-> Ilk ( ... lump: (_ => LUMP) ) ... </cat-ilks>
+    rule <k> Cat . file lump ILK_ID LUMP => . ... </k>
+         <cat-ilks> ... ILK_ID |-> Ilk ( ... lump: (_ => LUMP) ) ... </cat-ilks>
       requires LUMP >=Wad wad(0)
 ```
 
@@ -118,14 +118,14 @@ Cat Semantics
 ```k
     syntax CatStep ::= "bite" String Address
  // ----------------------------------------
-    rule <k> Cat . bite ILK URN
+    rule <k> Cat . bite ILK_ID URN
           => #fun(LOT
           => #fun(ART
           => #fun(TAB
-          => call Vat . grab ILK URN THIS VOWADDR (wad(0) -Wad LOT) (wad(0) -Wad ART)
+          => call Vat . grab ILK_ID URN THIS VOWADDR (wad(0) -Wad LOT) (wad(0) -Wad ART)
           ~> call Vow . fess TAB
-          ~> call Flip ILK . kick URN VOWADDR rmul(TAB, CHOP) LOT rad(0)
-          ~> emitBite ILK URN LOT ART TAB)
+          ~> call Flip ILK_ID . kick URN VOWADDR rmul(TAB, CHOP) LOT rad(0)
+          ~> emitBite ILK_ID URN LOT ART TAB)
           (ART *Rate RATE))
           (minWad(URNART, (LOT *Wad URNART) /Wad INK)))
           (minWad(INK, LUMP))
@@ -133,9 +133,9 @@ Cat Semantics
          </k>
          <this> THIS </this>
          <cat-live> true </cat-live>
-         <cat-ilks> ... ILK |-> Ilk(... chop: CHOP, lump: LUMP) ... </cat-ilks>
-         <vat-ilks> ... ILK |-> Ilk(... rate: RATE, spot: SPOT) ... </vat-ilks>
-         <vat-urns> ... { ILK, URN } |-> Urn(... ink: INK, art: URNART ) ... </vat-urns>
+         <cat-ilks> ... ILK_ID |-> Ilk(... chop: CHOP, lump: LUMP) ... </cat-ilks>
+         <vat-ilks> ... ILK_ID |-> Ilk(... rate: RATE, spot: SPOT) ... </vat-ilks>
+         <vat-urns> ... { ILK_ID , URN } |-> Urn(... ink: INK, art: URNART ) ... </vat-urns>
          <cat-vow> VOWADDR </cat-vow>
       requires (INK *Rate SPOT) <Rad (URNART *Rate RATE)
 

--- a/end.md
+++ b/end.md
@@ -93,24 +93,24 @@ End Initialization
 Because data isn't explicitely initialized to 0 in KMCD, we need explicit initializers for various pieces of data.
 
 -   `initGap`: Initialize the gap for a given ilk to 0.
-    **TODO**: Should `End . initGap ILKID` happen directly when `End . cage ILKID` happens?
+    **TODO**: Should `End . initGap ILK_ID` happen directly when `End . cage ILK_ID` happens?
 
 ```k
     syntax EndAuthStep ::= "initGap" String
                          | "initBag" Address
                          | "initOut" String Address
  // -----------------------------------------------
-    rule <k> End . initGap ILKID => . ... </k>
-         <end-gap> GAPS => GAPS [ ILKID <- wad(0) ] </end-gap>
-      requires notBool ILKID in_keys(GAPS)
+    rule <k> End . initGap ILK_ID => . ... </k>
+         <end-gap> GAPS => GAPS [ ILK_ID <- wad(0) ] </end-gap>
+      requires notBool ILK_ID in_keys(GAPS)
 
     rule <k> End . initBag ADDR => . ... </k>
          <end-bag> BAGS => BAGS [ ADDR <- wad(0) ] </end-bag>
       requires notBool ADDR in_keys(BAGS)
 
-    rule <k> End . initOut ILKID ADDR => . ... </k>
-         <end-out> OUTS => OUTS [ { ILKID , ADDR } <- wad(0) ] </end-out>
-      requires notBool { ILKID , ADDR } in_keys(OUTS)
+    rule <k> End . initOut ILK_ID ADDR => . ... </k>
+         <end-out> OUTS => OUTS [ { ILK_ID , ADDR } <- wad(0) ] </end-out>
+      requires notBool { ILK_ID , ADDR } in_keys(OUTS)
 ```
 
 End Semantics
@@ -132,31 +132,31 @@ End Semantics
 
     syntax EndStep ::= "cage" String
  // --------------------------------
-    rule <k> End . cage ILK:String => . ... </k>
+    rule <k> End . cage ILK_ID:String => . ... </k>
          <end-live> false </end-live>
-         <end-tag> TAGS => TAGS [ ILK <- wdiv(PAR, PIP) ] </end-tag>
-         <end-art> ARTS => ARTS [ ILK <- ART ] </end-art>
+         <end-tag> TAGS => TAGS [ ILK_ID <- wdiv(PAR, PIP) ] </end-tag>
+         <end-art> ARTS => ARTS [ ILK_ID <- ART ] </end-art>
          <spot-par> PAR </spot-par>
-         <spot-ilks> ... ILK |-> SpotIlk(... pip: PIP) ... </spot-ilks>
-         <vat-ilks> ... ILK |-> Ilk(... Art: ART)::VatIlk ... </vat-ilks>
-       requires notBool ILK in_keys(TAGS)
+         <spot-ilks> ... ILK_ID |-> SpotIlk(... pip: PIP) ... </spot-ilks>
+         <vat-ilks> ... ILK_ID |-> Ilk(... Art: ART)::VatIlk ... </vat-ilks>
+       requires notBool ILK_ID in_keys(TAGS)
 
     syntax EndStep ::= "skip" String Int
  // ------------------------------------
-    rule <k> End . skip ILK ID
+    rule <k> End . skip ILK_ID ID
           => call Vat . suck Vow Vow  TAB
           ~> call Vat . suck Vow THIS BID
-          ~> call Vat . hope Flip ILK
-          ~> call Flip ILK . yank ID
-          ~> call Vat . grab ILK USR THIS Vow LOT (TAB /Rate RATE)
+          ~> call Vat . hope Flip ILK_ID
+          ~> call Flip ILK_ID . yank ID
+          ~> call Vat . grab ILK_ID USR THIS Vow LOT (TAB /Rate RATE)
          ...
          </k>
          <this> THIS </this>
-         <end-tag> ... ILK |-> TAG ... </end-tag>
-         <end-art> ... ILK |-> (ART => ART +Wad (TAB /Rate RATE)) ... </end-art>
-         <vat-ilks> ... ILK |-> Ilk(... rate: RATE)::VatIlk ... </vat-ilks>
+         <end-tag> ... ILK_ID |-> TAG ... </end-tag>
+         <end-art> ... ILK_ID |-> (ART => ART +Wad (TAB /Rate RATE)) ... </end-art>
+         <vat-ilks> ... ILK_ID |-> Ilk(... rate: RATE)::VatIlk ... </vat-ilks>
          <flip>
-           <flip-ilk> ILK </flip-ilk>
+           <flip-ilk> ILK_ID </flip-ilk>
            <flip-bids> ... ID |-> FlipBid(... bid: BID, lot: LOT, usr: USR, tab: TAB) ... </flip-bids>
            ...
          </flip>
@@ -166,26 +166,26 @@ End Semantics
 
     syntax EndStep ::= "skim" String Address
  // ----------------------------------------
-    rule <k> End . skim ILK ADDR
-          => call Vat . grab ILK ADDR THIS Vow (wad(0) -Wad minWad(INK, rmul(rmul(ART, RATE), TAG))) (wad(0) -Wad ART)
+    rule <k> End . skim ILK_ID ADDR
+          => call Vat . grab ILK_ID ADDR THIS Vow (wad(0) -Wad minWad(INK, rmul(rmul(ART, RATE), TAG))) (wad(0) -Wad ART)
          ...
          </k>
          <this> THIS </this>
-         <end-tag> ... ILK |-> TAG ... </end-tag>
-         <end-gap> ... ILK |-> (GAP => GAP +Wad (rmul(rmul(ART, RATE), TAG) -Wad minWad(INK, rmul(rmul(ART, RATE), TAG)))) ... </end-gap>
-         <vat-ilks> ... ILK |-> Ilk(... rate: RATE)::VatIlk ... </vat-ilks>
-         <vat-urns> ... {ILK, ADDR} |-> Urn(... ink: INK, art: ART) ... </vat-urns>
+         <end-tag> ... ILK_ID |-> TAG ... </end-tag>
+         <end-gap> ... ILK_ID |-> (GAP => GAP +Wad (rmul(rmul(ART, RATE), TAG) -Wad minWad(INK, rmul(rmul(ART, RATE), TAG)))) ... </end-gap>
+         <vat-ilks> ... ILK_ID |-> Ilk(... rate: RATE)::VatIlk ... </vat-ilks>
+         <vat-urns> ... {ILK_ID, ADDR} |-> Urn(... ink: INK, art: ART) ... </vat-urns>
       requires TAG =/=Ray ray(0)
 
     syntax EndStep ::= "free" String
  // --------------------------------
-    rule <k> End . free ILK
-          => call Vat . grab ILK MSGSENDER MSGSENDER Vow (wad(0) -Wad INK) wad(0)
+    rule <k> End . free ILK_ID
+          => call Vat . grab ILK_ID MSGSENDER MSGSENDER Vow (wad(0) -Wad INK) wad(0)
          ...
          </k>
          <msg-sender> MSGSENDER </msg-sender>
          <end-live> false </end-live>
-         <vat-urns> ... {ILK, MSGSENDER} |-> Urn(... ink: INK, art: ART) ... </vat-urns>
+         <vat-urns> ... {ILK_ID, MSGSENDER} |-> Urn(... ink: INK, art: ART) ... </vat-urns>
       requires ART ==Wad wad(0)
 
     syntax EndStep ::= "thaw"
@@ -202,16 +202,16 @@ End Semantics
 
     syntax EndStep ::= "flow" String
  // --------------------------------
-    rule <k> End . flow ILK => . ... </k>
+    rule <k> End . flow ILK_ID => . ... </k>
          <end-debt> DEBT </end-debt>
-         <end-fix> FIX => FIX [ ILK <- rdiv(Wad2Ray(rmul(rmul(ART, RATE), TAG) -Wad GAP), DEBT) ] </end-fix>
-         <end-tag> ... ILK |-> TAG ... </end-tag>
-         <end-gap> ... ILK |-> GAP ... </end-gap>
-         <end-art> ... ILK |-> ART ... </end-art>
-         <vat-ilks> ... ILK |-> Ilk(... rate: RATE)::VatIlk ... </vat-ilks>
+         <end-fix> FIX => FIX [ ILK_ID <- rdiv(Wad2Ray(rmul(rmul(ART, RATE), TAG) -Wad GAP), DEBT) ] </end-fix>
+         <end-tag> ... ILK_ID |-> TAG ... </end-tag>
+         <end-gap> ... ILK_ID |-> GAP ... </end-gap>
+         <end-art> ... ILK_ID |-> ART ... </end-art>
+         <vat-ilks> ... ILK_ID |-> Ilk(... rate: RATE)::VatIlk ... </vat-ilks>
       requires DEBT =/=Rad rad(0)
        andBool rmul(rmul(ART, RATE), TAG) >=Wad GAP
-       andBool notBool ILK in_keys(FIX)
+       andBool notBool ILK_ID in_keys(FIX)
 
     syntax EndStep ::= "pack" Wad
  // -----------------------------
@@ -227,14 +227,14 @@ End Semantics
 
     syntax EndStep ::= "cash" String Wad
  // ------------------------------------
-    rule <k> End . cash ILK AMOUNT
-          => call Vat . flux ILK THIS MSGSENDER rmul(AMOUNT, FIX)
+    rule <k> End . cash ILK_ID AMOUNT
+          => call Vat . flux ILK_ID THIS MSGSENDER rmul(AMOUNT, FIX)
          ...
          </k>
          <msg-sender> MSGSENDER </msg-sender>
          <this> THIS </this>
-         <end-fix> ... ILK |-> FIX ... </end-fix>
-         <end-out> ... {ILK, MSGSENDER} |-> (OUT => OUT +Wad AMOUNT) ... </end-out>
+         <end-fix> ... ILK_ID |-> FIX ... </end-fix>
+         <end-out> ... {ILK_ID, MSGSENDER} |-> (OUT => OUT +Wad AMOUNT) ... </end-out>
          <end-bag> ... MSGSENDER |-> BAG ... </end-bag>
       requires AMOUNT >=Wad wad(0)
        andBool FIX =/=Ray ray(0)

--- a/fixed-int.md
+++ b/fixed-int.md
@@ -50,13 +50,14 @@ In all cases, the returned integers will be in the width of the first operand.
                   > FInt "+FInt" FInt [function]
                   | FInt "-FInt" FInt [function]
  // --------------------------------------------
-    rule FInt(VALUE1, ONE1) *FInt FInt(VALUE2, ONE2) => FInt((VALUE1 *Int VALUE2) /Int ONE2, ONE1)
-    rule FInt(VALUE1, ONE1) /FInt FInt(VALUE2, ONE2) => FInt((VALUE1 *Int ONE2) /Int VALUE2, ONE1) requires VALUE2 =/=Int 0
-    rule FInt(VALUE, ONE) ^FInt E                    => FInt((VALUE ^Int E) /Int (ONE ^Int (E -Int 1)), ONE)          requires E  >Int 0
-    rule FInt(VALUE, ONE) ^FInt E                    => 1FInt(ONE)                                                    requires E ==Int 0
-    rule FInt(VALUE, ONE) ^FInt E                    => FInt((ONE ^Int (1 -Int E)) /Int (VALUE ^Int (0 -Int E)), ONE) requires E  <Int 0
-    rule FInt(VALUE1, ONE1) +FInt FInt(VALUE2, ONE2) => FInt(VALUE1 +Int ((VALUE2 *Int ONE1) /Int ONE2), ONE1)
-    rule FInt(VALUE1, ONE1) -FInt FInt(VALUE2, ONE2) => FInt(VALUE1 -Int ((VALUE2 *Int ONE1) /Int ONE2), ONE1)
+    rule FInt(VALUE1, ONE1) *FInt FInt(VALUE2, ONE2) => FInt((VALUE1 *Int VALUE2) /Int ONE2             , ONE1)
+    rule FInt(VALUE1, ONE1) /FInt FInt(VALUE2, ONE2) => FInt((VALUE1 *Int ONE2) /Int VALUE2             , ONE1) requires VALUE2 =/=Int 0
+    rule FInt(VALUE1, ONE1) +FInt FInt(VALUE2, ONE2) => FInt(VALUE1 +Int ((VALUE2 *Int ONE1) /Int ONE2) , ONE1)
+    rule FInt(VALUE1, ONE1) -FInt FInt(VALUE2, ONE2) => FInt(VALUE1 -Int ((VALUE2 *Int ONE1) /Int ONE2) , ONE1)
+
+    rule FInt( VALUE, ONE) ^FInt E => FInt((VALUE ^Int E) /Int (ONE ^Int (E -Int 1)), ONE)          requires E  >Int 0
+    rule FInt(_VALUE, ONE) ^FInt E => 1FInt(ONE)                                                    requires E ==Int 0
+    rule FInt( VALUE, ONE) ^FInt E => FInt((ONE ^Int (1 -Int E)) /Int (VALUE ^Int (0 -Int E)), ONE) requires E  <Int 0
 ```
 
 Comparisons

--- a/flip.md
+++ b/flip.md
@@ -30,7 +30,7 @@ Flip Configuration
     syntax FlipContract ::= "Flip" String
     syntax MCDStep ::= FlipContract "." FlipStep [klabel(flipStep)]
  // ---------------------------------------------------------------
-    rule contract(Flip ILKID . _) => Flip ILKID
+    rule contract(Flip ILK_ID . _) => Flip ILK_ID
 ```
 
 Flip Authorization
@@ -40,20 +40,20 @@ Flip Authorization
     syntax FlipStep ::= FlipAuthStep
     syntax AuthStep ::= FlipContract "." FlipAuthStep [klabel(flipStep)]
  // --------------------------------------------------------------------
-    rule [[ wards(Flip ILKID) => WARDS ]] <flip> <flip-ilk> ILKID </flip-ilk> <flip-wards> WARDS </flip-wards> ... </flip>
+    rule [[ wards(Flip ILK_ID) => WARDS ]] <flip> <flip-ilk> ILK_ID </flip-ilk> <flip-wards> WARDS </flip-wards> ... </flip>
 
     syntax FlipAuthStep ::= WardStep
  // --------------------------------
-    rule <k> Flip ILKID . rely ADDR => . ... </k>
+    rule <k> Flip ILK_ID . rely ADDR => . ... </k>
          <flip>
-           <flip-ilk> ILKID </flip-ilk>
+           <flip-ilk> ILK_ID </flip-ilk>
            <flip-wards> ... (.Set => SetItem(ADDR)) </flip-wards>
            ...
          </flip>
 
-    rule <k> Flip ILKID . deny ADDR => . ... </k>
+    rule <k> Flip ILK_ID . deny ADDR => . ... </k>
          <flip>
-           <flip-ilk> ILKID </flip-ilk>
+           <flip-ilk> ILK_ID </flip-ilk>
            <flip-wards> WARDS => WARDS -Set SetItem(ADDR) </flip-wards>
            ...
          </flip>
@@ -95,25 +95,25 @@ The parameters controlled by governance are:
                       | "ttl" Int
                       | "tau" Int
  // -----------------------------
-    rule <k> Flip ILKID . file beg BEG => . ... </k>
+    rule <k> Flip ILK_ID . file beg BEG => . ... </k>
          <flip>
-           <flip-ilk> ILKID </flip-ilk>
+           <flip-ilk> ILK_ID </flip-ilk>
            <flip-beg> _ => BEG </flip-beg>
            ...
          </flip>
       requires BEG >=Wad wad(0)
 
-    rule <k> Flip ILKID . file ttl TTL => . ... </k>
+    rule <k> Flip ILK_ID . file ttl TTL => . ... </k>
          <flip>
-           <flip-ilk> ILKID </flip-ilk>
+           <flip-ilk> ILK_ID </flip-ilk>
            <flip-ttl> _ => TTL </flip-ttl>
            ...
          </flip>
       requires TTL >=Int 0
 
-    rule <k> Flip ILKID . file tau TAU => . ... </k>
+    rule <k> Flip ILK_ID . file tau TAU => . ... </k>
          <flip>
-           <flip-ilk> ILKID </flip-ilk>
+           <flip-ilk> ILK_ID </flip-ilk>
            <flip-tau> _ => TAU </flip-tau>
            ...
          </flip>
@@ -136,8 +136,8 @@ Flip Initialization
 ```k
     syntax FlipAuthStep ::= "init"
  // ------------------------------
-    rule <k> Flip ILK . init => . ... </k>
-         <flips> ... (.Bag => <flip> <flip-ilk> ILK </flip-ilk> ... </flip>) ... </flips>
+    rule <k> Flip ILK_ID . init => . ... </k>
+         <flips> ... (.Bag => <flip> <flip-ilk> ILK_ID </flip-ilk> ... </flip>) ... </flips>
 ```
 
 Flip Semantics
@@ -146,8 +146,8 @@ Flip Semantics
 ```k
     syntax FlipAuthStep ::= "kick" Address Address Rad Wad Rad
  // ----------------------------------------------------------
-    rule <k> Flip ILK . kick USR GAL TAB LOT BID
-          => call Vat . flux ILK MSGSENDER THIS LOT
+    rule <k> Flip ILK_ID . kick USR GAL TAB LOT BID
+          => call Vat . flux ILK_ID MSGSENDER THIS LOT
           ~> KICKS +Int 1
          ...
          </k>
@@ -155,23 +155,23 @@ Flip Semantics
          <this> THIS </this>
          <current-time> NOW </current-time>
          <flip>
-           <flip-ilk> ILK </flip-ilk>
+           <flip-ilk> ILK_ID </flip-ilk>
            <flip-tau> TAU </flip-tau>
            <flip-kicks> KICKS => KICKS +Int 1 </flip-kicks>
            <flip-bids> ... .Map => KICKS +Int 1 |-> FlipBid( ... bid: BID, lot: LOT, guy: MSGSENDER, tic: 0, end: NOW +Int TAU, usr: USR, gal: GAL, tab: TAB ) ... </flip-bids>
            ...
          </flip>
-         <frame-events> ... (.List => ListItem(FlipKick(MSGSENDER, ILK, KICKS +Int 1, LOT, BID, TAB, USR, GAL))) </frame-events>
+         <frame-events> ... (.List => ListItem(FlipKick(MSGSENDER, ILK_ID, KICKS +Int 1, LOT, BID, TAB, USR, GAL))) </frame-events>
       requires TAB >=Rad rad(0)
        andBool LOT >=Wad wad(0)
        andBool BID >=Rad rad(0)
 
     syntax FlipStep ::= "tick" Int
  // ------------------------------
-    rule <k> Flip ILK . tick ID => . ... </k>
+    rule <k> Flip ILK_ID . tick ID => . ... </k>
          <current-time> NOW </current-time>
          <flip>
-           <flip-ilk> ILK </flip-ilk>
+           <flip-ilk> ILK_ID </flip-ilk>
            <flip-tau> TAU </flip-tau>
            <flip-bids> ... ID |-> FlipBid(... tic: TIC, end: END => NOW +Int TAU) ... </flip-bids>
            ...
@@ -181,7 +181,7 @@ Flip Semantics
 
     syntax FlipStep ::= "tend" Int Wad Rad
  // --------------------------------------
-    rule <k> Flip ILK . tend ID LOT BID
+    rule <k> Flip ILK_ID . tend ID LOT BID
           => #if MSGSENDER =/=K GUY #then call Vat . move MSGSENDER GUY BID' #else . #fi
           ~> call Vat . move MSGSENDER GAL (BID -Rad BID')
          ...
@@ -189,7 +189,7 @@ Flip Semantics
          <msg-sender> MSGSENDER </msg-sender>
          <current-time> NOW </current-time>
          <flip>
-           <flip-ilk> ILK </flip-ilk>
+           <flip-ilk> ILK_ID </flip-ilk>
            <flip-beg> BEG </flip-beg>
            <flip-ttl> TTL </flip-ttl>
            <flip-bids> ... ID |-> FlipBid(... bid: BID' => BID, lot: LOT', guy: GUY => MSGSENDER, tic: TIC => NOW +Int TTL, end: END, gal: GAL, tab: TAB) ... </flip-bids>
@@ -207,16 +207,16 @@ Flip Semantics
 
     syntax FlipStep ::= "dent" Int Wad Rad
  // --------------------------------------
-    rule <k> Flip ILK . dent ID LOT BID
+    rule <k> Flip ILK_ID . dent ID LOT BID
           => #if MSGSENDER =/=K GUY #then call Vat . move MSGSENDER GUY BID #else . #fi
-          ~> call Vat.flux ILK THIS USR (LOT' -Wad LOT)
+          ~> call Vat.flux ILK_ID THIS USR (LOT' -Wad LOT)
          ...
          </k>
          <msg-sender> MSGSENDER </msg-sender>
          <this> THIS </this>
          <current-time> NOW </current-time>
          <flip>
-           <flip-ilk> ILK </flip-ilk>
+           <flip-ilk> ILK_ID </flip-ilk>
            <flip-beg> BEG </flip-beg>
            <flip-ttl> TTL </flip-ttl>
            <flip-bids> ... ID |-> FlipBid(... bid: BID', lot: LOT' => LOT, guy: GUY => MSGSENDER, tic: TIC => NOW +Int TTL, end: END, usr: USR, tab: TAB) ... </flip-bids>
@@ -234,11 +234,11 @@ Flip Semantics
 
     syntax FlipStep ::= "deal" Int
  // ------------------------------
-    rule <k> Flip ILK . deal ID => call Vat . flux ILK THIS GUY LOT ... </k>
+    rule <k> Flip ILK_ID . deal ID => call Vat . flux ILK_ID THIS GUY LOT ... </k>
          <this> THIS </this>
          <current-time> NOW </current-time>
          <flip>
-           <flip-ilk> ILK </flip-ilk>
+           <flip-ilk> ILK_ID </flip-ilk>
            <flip-bids> ... ID |-> FlipBid(... lot: LOT, guy: GUY, tic: TIC, end: END) => .Map ... </flip-bids>
            ...
          </flip>
@@ -247,15 +247,15 @@ Flip Semantics
 
     syntax FlipAuthStep ::= "yank" Int
  // ----------------------------------
-    rule <k> Flip ILK . yank ID
-          => call Vat . flux ILK THIS MSGSENDER LOT
+    rule <k> Flip ILK_ID . yank ID
+          => call Vat . flux ILK_ID THIS MSGSENDER LOT
           ~> call Vat . move MSGSENDER GUY BID
          ...
          </k>
          <msg-sender> MSGSENDER </msg-sender>
          <this> THIS </this>
          <flip>
-           <flip-ilk> ILK </flip-ilk>
+           <flip-ilk> ILK_ID </flip-ilk>
            <flip-bids> ... ID |-> FlipBid(... bid: BID, lot: LOT, guy: GUY, tab: TAB) => .Map ... </flip-bids>
            ...
          </flip>

--- a/flop.md
+++ b/flop.md
@@ -168,8 +168,6 @@ Flop Semantics
           => KICKS +Int 1
          ...
          </k>
-         <msg-sender> MSGSENDER </msg-sender>
-         <this> THIS </this>
          <current-time> NOW </current-time>
          <flop-live> true </flop-live>
          <flop-bids> ... .Map => KICKS +Int 1 |-> FlopBid(... bid: BID, lot: LOT, guy: GAL, tic: 0, end: NOW +Int TAU) ... </flop-bids>
@@ -231,7 +229,6 @@ Flop Semantics
           => call Vat . suck VOWADDR GUY BID
          ...
          </k>
-         <this> THIS </this>
          <flop-bids> ... ID |-> FlopBid(... bid: BID, guy: GUY) => .Map ... </flop-bids>
          <flop-live> false </flop-live>
          <flop-vow> VOWADDR </flop-vow>

--- a/jug.md
+++ b/jug.md
@@ -103,7 +103,6 @@ Jug Semantics
          <jug-ilks> ... ILK_ID |-> Ilk ( ... duty: ray(0) => ray(1), rho: _ => NOW ) ... </jug-ilks>
 
     rule <k> Jug . init ILK_ID ... </k>
-         <current-time> NOW </current-time>
          <jug-ilks> JUG_ILKS => JUG_ILKS [ ILK_ID <- Ilk ( ... duty: ray(0) , rho: 0 ) ] </jug-ilks>
       requires notBool ILK_ID in_keys(JUG_ILKS)
 ```

--- a/jug.md
+++ b/jug.md
@@ -105,6 +105,7 @@ Jug Semantics
     rule <k> Jug . init ILK ... </k>
          <current-time> NOW </current-time>
          <jug-ilks> JUG_ILKS => JUG_ILKS [ ILK <- Ilk ( ... duty: ray(0) , rho: 0 ) ] </jug-ilks>
+      requires notBool ILK in_keys(JUG_ILKS)
 ```
 
 ```k

--- a/jug.md
+++ b/jug.md
@@ -101,6 +101,10 @@ Jug Semantics
     rule <k> Jug . init ILK => . ... </k>
          <current-time> NOW </current-time>
          <jug-ilks> ... ILK |-> Ilk ( ... duty: ray(0) => ray(1), rho: _ => NOW ) ... </jug-ilks>
+
+    rule <k> Jug . init ILK ... </k>
+         <current-time> NOW </current-time>
+         <jug-ilks> JUG_ILKS => JUG_ILKS [ ILK <- Ilk ( ... duty: ray(0) , rho: 0 ) ] </jug-ilks>
 ```
 
 ```k

--- a/jug.md
+++ b/jug.md
@@ -76,8 +76,8 @@ These parameters are controlled by governance:
                      | "base" Ray
                      | "vow-file" Address
  // -------------------------------------
-    rule <k> Jug . file duty ILKID DUTY => . ... </k>
-         <jug-ilks> ... ILK |-> Ilk ( ... duty: (_ => DUTY) , rho: RHO ) ... </jug-ilks>
+    rule <k> Jug . file duty ILK_ID DUTY => . ... </k>
+         <jug-ilks> ... ILK_ID |-> Ilk ( ... duty: (_ => DUTY) , rho: RHO ) ... </jug-ilks>
          <current-time> NOW </current-time>
       requires NOW ==Int RHO
        andBool DUTY >=Ray ray(0)
@@ -98,23 +98,23 @@ Jug Semantics
 ```k
     syntax JugAuthStep ::= "init" String
  // ------------------------------------
-    rule <k> Jug . init ILK => . ... </k>
+    rule <k> Jug . init ILK_ID => . ... </k>
          <current-time> NOW </current-time>
-         <jug-ilks> ... ILK |-> Ilk ( ... duty: ray(0) => ray(1), rho: _ => NOW ) ... </jug-ilks>
+         <jug-ilks> ... ILK_ID |-> Ilk ( ... duty: ray(0) => ray(1), rho: _ => NOW ) ... </jug-ilks>
 
-    rule <k> Jug . init ILK ... </k>
+    rule <k> Jug . init ILK_ID ... </k>
          <current-time> NOW </current-time>
-         <jug-ilks> JUG_ILKS => JUG_ILKS [ ILK <- Ilk ( ... duty: ray(0) , rho: 0 ) ] </jug-ilks>
-      requires notBool ILK in_keys(JUG_ILKS)
+         <jug-ilks> JUG_ILKS => JUG_ILKS [ ILK_ID <- Ilk ( ... duty: ray(0) , rho: 0 ) ] </jug-ilks>
+      requires notBool ILK_ID in_keys(JUG_ILKS)
 ```
 
 ```k
     syntax JugStep ::= "drip" String
  // --------------------------------
-    rule <k> Jug . drip ILK => call Vat . fold ILK ADDRESS ( ( (BASE +Ray ILKDUTY) ^Ray (TIME -Int ILKRHO) ) *Ray ILKRATE ) -Ray ILKRATE ... </k>
+    rule <k> Jug . drip ILK_ID => call Vat . fold ILK_ID ADDRESS ( ( (BASE +Ray ILKDUTY) ^Ray (TIME -Int ILKRHO) ) *Ray ILKRATE ) -Ray ILKRATE ... </k>
          <current-time> TIME </current-time>
-         <vat-ilks> ... ILK |-> Ilk ( ... rate: ILKRATE ) ... </vat-ilks>
-         <jug-ilks> ... ILK |-> Ilk ( ... duty: ILKDUTY, rho: ILKRHO => TIME ) ... </jug-ilks>
+         <vat-ilks> ... ILK_ID |-> Ilk ( ... rate: ILKRATE ) ... </vat-ilks>
+         <jug-ilks> ... ILK_ID |-> Ilk ( ... duty: ILKDUTY, rho: ILKRHO => TIME ) ... </jug-ilks>
          <jug-vow> ADDRESS </jug-vow>
          <jug-base> BASE </jug-base>
       requires TIME >=Int ILKRHO

--- a/kmcd-data.md
+++ b/kmcd-data.md
@@ -87,7 +87,7 @@ We model everything with arbitrary precision rationals, but use sort information
                  | Wad "-Wad" Wad [function]
  // ----------------------------------------
     rule FI1 *Wad FI2    => FI1 *FInt FI2
-    rule FI1 /Wad wad(0) => wad(0)
+    rule _   /Wad wad(0) => wad(0)
     rule FI1 /Wad FI2    => FI1 /FInt FI2 [owise]
     rule FI1 ^Wad I      => FI1 ^FInt I
     rule FI1 +Wad FI2    => FI1 +FInt FI2
@@ -100,7 +100,7 @@ We model everything with arbitrary precision rationals, but use sort information
                  | Ray "-Ray" Ray [function]
  // ----------------------------------------
     rule FI1 *Ray FI2    => FI1 *FInt FI2
-    rule FI1 /Ray ray(0) => ray(0)
+    rule _   /Ray ray(0) => ray(0)
     rule FI1 /Ray FI2    => FI1 /FInt FI2 [owise]
     rule FI1 ^Ray I      => FI1 ^FInt I
     rule FI1 +Ray FI2    => FI1 +FInt FI2
@@ -113,7 +113,7 @@ We model everything with arbitrary precision rationals, but use sort information
                  | Rad "-Rad" Rad [function]
  // ----------------------------------------
     rule FI1 *Rad FI2    => FI1 *FInt FI2
-    rule FI1 /Rad rad(0) => rad(0)
+    rule _   /Rad rad(0) => rad(0)
     rule FI1 /Rad FI2    => FI1 /FInt FI2 [owise]
     rule FI1 ^Rad I      => FI1 ^FInt I
     rule FI1 +Rad FI2    => FI1 +FInt FI2

--- a/kmcd-driver.md
+++ b/kmcd-driver.md
@@ -139,7 +139,7 @@ On `exception`, the entire current call is discarded to trigger state roll-back 
 
     rule <k> . => CONT </k>
          <msg-sender> MSGSENDER => PREVSENDER </msg-sender>
-         <this> THIS => MSGSENDER </this>
+         <this> _THIS => MSGSENDER </this>
          <call-stack> ListItem(frame(PREVSENDER, PREVEVENTS, CONT)) => .List ... </call-stack>
          <tx-log> Transaction(... events: L => L EVENTS) </tx-log>
          <frame-events> EVENTS => PREVEVENTS </frame-events>
@@ -153,12 +153,12 @@ On `exception`, the entire current call is discarded to trigger state roll-back 
 
     rule <k> exception E ~> _ => exception E ~> CONT </k>
          <msg-sender> MSGSENDER => PREVSENDER </msg-sender>
-         <this> THIS => MSGSENDER </this>
+         <this> _THIS => MSGSENDER </this>
          <call-stack> ListItem(frame(PREVSENDER, PREVEVENTS, CONT)) => .List ... </call-stack>
          <tx-log> Transaction(... events: L => L EVENTS) </tx-log>
          <frame-events> EVENTS => PREVEVENTS </frame-events>
 
-    rule <k> exception MCDSTEP ~> dropState => popState ... </k>
+    rule <k> exception _MCDSTEP ~> dropState => popState ... </k>
          <call-stack> .List </call-stack>
 
     rule <k> exception _ ~> (assert => .) ... </k>

--- a/kmcd-prelude.md
+++ b/kmcd-prelude.md
@@ -354,9 +354,9 @@ module KMCD-GEN
          <vat-gem> ... CDPID |-> VAT_GEM ... </vat-gem>
       requires lengthBytes(BS) >Int 0
 
-    rule <k> GenVatFrob { ILKID , ADDRESS } DINK
+    rule <k> GenVatFrob { ILK_ID , ADDRESS } DINK
           => #fun( DARTBOUND
-                => LogGen ( transact ADDRESS Vat . frob ILKID ADDRESS ADDRESS ADDRESS DINK ((wad(2) *Wad randWadBounded(head(BS), DARTBOUND)) -Wad DARTBOUND) )
+                => LogGen ( transact ADDRESS Vat . frob ILK_ID ADDRESS ADDRESS ADDRESS DINK ((wad(2) *Wad randWadBounded(head(BS), DARTBOUND)) -Wad DARTBOUND) )
                  ) ((((URNINK +Wad DINK) *Rate SPOT) /Rate RATE) -Wad URNART)
          ...
          </k>
@@ -364,12 +364,12 @@ module KMCD-GEN
          <used-random> BS' => BS' +Bytes headAsBytes(BS) </used-random>
          <vat-ilks>
            ...
-           ILKID |-> Ilk ( ... rate: RATE, spot: SPOT )
+           ILK_ID |-> Ilk ( ... rate: RATE, spot: SPOT )
            ...
          </vat-ilks>
          <vat-urns>
            ...
-           { ILKID , ADDRESS } |-> Urn ( ... ink: URNINK, art: URNART )
+           { ILK_ID , ADDRESS } |-> Urn ( ... ink: URNINK, art: URNART )
            ...
          </vat-urns>
       requires lengthBytes(BS) >Int 0
@@ -419,7 +419,7 @@ module KMCD-GEN
                             | "GenGemJoinJoin" String
                             | "GenGemJoinJoin" String Address
  // ---------------------------------------------------------
-    // **TODO**: Would be better to choose from an ILK with <gem-id>
+    // **TODO**: Would be better to choose from an ILK_ID with <gem-id>
     rule <k> GenGemJoinJoin => GenGemJoinJoin chooseString(head(BS), (ListItem("MKR") ListItem("gold"))) ... </k>
          <random> BS => tail(BS) </random>
          <used-random> BS' => BS' +Bytes headAsBytes(BS) </used-random>
@@ -527,7 +527,7 @@ module KMCD-GEN
          <used-random> BS' => BS' +Bytes headAsBytes(BS) </used-random>
       requires lengthBytes(BS) >Int 0
 
-    rule <k> GenFlipKick { ILKID , ADDRESS } STORAGE BENEFICIARY LOT BID => LogGen ( transact ADDRESS Flip ILKID . kick STORAGE BENEFICIARY rad(1000) LOT BID ) ... </k>
+    rule <k> GenFlipKick { ILK_ID , ADDRESS } STORAGE BENEFICIARY LOT BID => LogGen ( transact ADDRESS Flip ILK_ID . kick STORAGE BENEFICIARY rad(1000) LOT BID ) ... </k>
 
     syntax GenStep ::= GenPotStep
     syntax GenPotStep ::= "GenPotJoin"
@@ -595,7 +595,7 @@ module KMCD-GEN
       requires lengthBytes(BS) >Int 0
        andBool size(ILKS) >Int 0
 
-    // **TODO**: Would be better to choose from an ILK with <end-tag> and <end-gap> too
+    // **TODO**: Would be better to choose from an ILK_ID with <end-tag> and <end-gap> too
     rule <k> GenEndSkim => GenEndSkim chooseCDPID(head(BS), keys_list(VAT_URNS)) ... </k>
          <random> BS => tail(BS) </random>
          <used-random> BS' => BS' +Bytes headAsBytes(BS) </used-random>
@@ -603,7 +603,7 @@ module KMCD-GEN
       requires lengthBytes(BS) >Int 0
        andBool size(VAT_URNS) >Int 0
 
-    rule <k> GenEndSkim { ILKID , ADDRESS } => LogGen ( transact ANYONE End . skim ILKID ADDRESS ) ... </k>
+    rule <k> GenEndSkim { ILK_ID , ADDRESS } => LogGen ( transact ANYONE End . skim ILK_ID ADDRESS ) ... </k>
 
     rule <k> GenEndFlow => LogGen ( transact ANYONE End . flow chooseString(head(BS), keys_list(ILKS)) ) ... </k>
          <random> BS => tail(BS) </random>
@@ -612,7 +612,7 @@ module KMCD-GEN
       requires lengthBytes(BS) >Int 0
        andBool size(ILKS) >Int 0
 
-    // **TODO**: Would be better to pick an ILKID from <flips>
+    // **TODO**: Would be better to pick an ILK_ID from <flips>
     rule <k> GenEndSkip => GenEndSkip chooseString(head(BS), keys_list(ILKS)) ... </k>
          <random> BS => tail(BS) </random>
          <used-random> BS' => BS' +Bytes headAsBytes(BS) </used-random>
@@ -620,11 +620,11 @@ module KMCD-GEN
       requires lengthBytes(BS) >Int 0
        andBool size(ILKS) >Int 0
 
-    rule <k> GenEndSkip ILKID => LogGen ( transact ANYONE End . skip ILKID chooseInt(head(BS), keys_list(FLIP_BIDS)) ) ... </k>
+    rule <k> GenEndSkip ILK_ID => LogGen ( transact ANYONE End . skip ILK_ID chooseInt(head(BS), keys_list(FLIP_BIDS)) ) ... </k>
          <random> BS => tail(BS) </random>
          <used-random> BS' => BS' +Bytes headAsBytes(BS) </used-random>
          <flip>
-           <flip-ilk> ILKID </flip-ilk>
+           <flip-ilk> ILK_ID </flip-ilk>
            <flip-bids> FLIP_BIDS </flip-bids>
            ...
          </flip>
@@ -651,10 +651,10 @@ module KMCD-GEN
       requires lengthBytes(BS) >Int 0
        andBool size(END_OUTS) >Int 0
 
-    rule <k> GenEndCash { ILKID , ADDRESS } => LogGen ( transact ADDRESS End . cash ILKID randWadBounded(head(BS), BAG -Wad OUT) ) ... </k>
+    rule <k> GenEndCash { ILK_ID , ADDRESS } => LogGen ( transact ADDRESS End . cash ILK_ID randWadBounded(head(BS), BAG -Wad OUT) ) ... </k>
          <random> BS => tail(BS) </random>
          <used-random> BS' => BS' +Bytes headAsBytes(BS) </used-random>
-         <end-out> ... { ILKID , ADDRESS } |-> OUT ... </end-out>
+         <end-out> ... { ILK_ID , ADDRESS } |-> OUT ... </end-out>
          <end-bag> ... ADDRESS |-> BAG ... </end-bag>
       requires lengthBytes(BS) >Int 0
 endmodule

--- a/kmcd-prelude.md
+++ b/kmcd-prelude.md
@@ -114,7 +114,7 @@ module KMCD-PRELUDE
          transact ADMIN End . initGap "gold"
 
          // Initialize "gold for Vat
-         transact ADMIN Vat . initIlk "gold"
+         transact ADMIN Vat . init "gold"
          transact ADMIN Vat . file line "gold" rad(1000 ether)
          transact ANYONE Spot . poke "gold"
 

--- a/kmcd-prelude.md
+++ b/kmcd-prelude.md
@@ -254,7 +254,7 @@ module KMCD-GEN
          <used-random> _ => headAsBytes(BS) </used-random>
          <generator-next> N </generator-next>
          <generator-current> _ => head(BS) modInt N </generator-current>
-         <generator-remainder> GSS => .GenStep </generator-remainder>
+         <generator-remainder> _ => .GenStep </generator-remainder>
       requires lengthBytes(BS) >Int 0
        andBool N >Int 0
 
@@ -310,7 +310,7 @@ module KMCD-GEN
     rule <k> .GenStep | GSS => GSS ... </k> [priority(49)]
     rule <k> GSS | .GenStep => GSS ... </k> [priority(49)]
 
-    rule <k> .GenStep DB:DepthBound => . ... </k> [priority(49)]
+    rule <k> .GenStep _:DepthBound => . ... </k> [priority(49)]
 
     rule <k> GSS DB:DepthBound => #if DB ==K 0 #then . #else (GSS ; (GSS decrement(DB))) | .GenStep #fi ... </k>
 

--- a/kmcd-props.md
+++ b/kmcd-props.md
@@ -25,18 +25,18 @@ Sometimes you need a lookup to default to zero, and want to cast the result as a
 ```k
     syntax Wad ::= #lookupWad ( Map , Address ) [function]
  // ------------------------------------------------------
-    rule #lookupWad(M, A) => { M[A] }:>Wad requires A in_keys(M)
-    rule #lookupWad(M, A) => wad(0)        [owise]
+    rule #lookupWad( M,  A) => { M[A] }:>Wad requires A in_keys(M)
+    rule #lookupWad(_M, _A) => wad(0)        [owise]
 
     syntax Ray ::= #lookupRay ( Map , Address ) [function]
  // ------------------------------------------------------
-    rule #lookupRay(M, A) => { M[A] }:>Ray requires A in_keys(M)
-    rule #lookupRay(M, A) => ray(0)        [owise]
+    rule #lookupRay( M,  A) => { M[A] }:>Ray requires A in_keys(M)
+    rule #lookupRay(_M, _A) => ray(0)        [owise]
 
     syntax Rad ::= #lookupRad ( Map , Address ) [function]
  // ------------------------------------------------------
-    rule #lookupRad(M, A) => { M[A] }:>Rad requires A in_keys(M)
-    rule #lookupRad(M, A) => rad(0)        [owise]
+    rule #lookupRad( M,  A) => { M[A] }:>Rad requires A in_keys(M)
+    rule #lookupRad(_M, _A) => rad(0)        [owise]
 ```
 
 ### Measure Event
@@ -126,7 +126,7 @@ Art of an ilk = Sum of all urn art across all users for that ilk.
 ```k
     syntax Wad ::= sumOfUrnArt(Map, String, Wad) [function, functional]
  // -------------------------------------------------------------------
-    rule sumOfUrnArt( {ILK_ID , ADDR} |-> Urn (... art: ART) URNS, ILK_ID', SUM)
+    rule sumOfUrnArt( {ILK_ID , _ADDR} |-> Urn (... art: ART) URNS, ILK_ID', SUM)
       => #if ILK_ID ==K ILK_ID'
             #then sumOfUrnArt( URNS, ILK_ID', SUM +Wad ART)
             #else sumOfUrnArt( URNS, ILK_ID', SUM)
@@ -240,7 +240,7 @@ You can inject `checkViolated(_)` steps to each FSM to see whether we should hal
  // ------------------------------------------------
     rule anyViolation(.List)                   => false
     rule anyViolation(ListItem(Violated(_)) _) => true
-    rule anyViolation(ListItem(VFSM)     REST) => anyViolation(REST) [owise]
+    rule anyViolation(ListItem(_VFSM)    REST) => anyViolation(REST) [owise]
 ```
 
 For each FSM, the user must define the `derive` function, which dictates how that FSM behaves.
@@ -262,7 +262,7 @@ A default `owise` rule is added which leaves the FSM state unchanged.
          </k>
          <processed-events> L => L ListItem(E) </processed-events>
 
-    rule <k> deriveVFSM(.List                 , E) => .                   ... </k>
+    rule <k> deriveVFSM(.List                 , _) => .                   ... </k>
     rule <k> deriveVFSM(ListItem(VFSMID) REST , E) => deriveVFSM(REST, E) ... </k>
          <properties> ... VFSMID |-> (VFSM => derive(VFSM, E)) ... </properties>
 ```
@@ -298,12 +298,12 @@ The Debt growth should be bounded in principle by the interest rates available i
  // --------------------------------------------------------------------
     rule derive(totalDebtBounded(... dsr: DSR), Measure(... debt: DEBT)) => totalDebtBoundedRun(... debt: DEBT, dsr: DSR)
 
-    rule derive( totalDebtBoundedRun(... debt: DEBT, dsr: _  ) #as PREV , Measure(... debt: DEBT')            ) => Violated(PREV) requires DEBT' >Rad DEBT
+    rule derive( totalDebtBoundedRun(... debt: DEBT          ) #as PREV , Measure(... debt: DEBT')            ) => Violated(PREV) requires DEBT' >Rad DEBT
     rule derive( totalDebtBoundedRun(... debt: DEBT, dsr: DSR)          , TimeStep(TIME, _)                   ) => totalDebtBoundedRun(... debt: DEBT +Rad rmul(vatDaiForUser(Pot), (DSR ^Ray TIME) -Ray ray(1)), dsr: DSR)
-    rule derive( totalDebtBoundedRun(... debt: DEBT, dsr: DSR)          , LogNote(_ , Vat . frob _ _ _ _ _ _) ) => totalDebtBounded(... dsr: DSR)
+    rule derive( totalDebtBoundedRun(...             dsr: DSR)          , LogNote(_ , Vat . frob _ _ _ _ _ _) ) => totalDebtBounded(... dsr: DSR)
     rule derive( totalDebtBoundedRun(... debt: DEBT, dsr: DSR)          , LogNote(_ , Vat . suck _ _ AMOUNT)  ) => totalDebtBoundedRun(... debt: DEBT +Rad AMOUNT, dsr: DSR)
-    rule derive( totalDebtBoundedRun(... debt: DEBT, dsr: DSR)          , LogNote(_ , Pot . file dsr DSR')    ) => totalDebtBoundedRun(... debt: DEBT, dsr: DSR')
-    rule derive( totalDebtBoundedRun(... debt: DEBT, dsr: _  )          , LogNote(_ , End . cage         )    ) => totalDebtBoundedEnd(... debt: DEBT)
+    rule derive( totalDebtBoundedRun(... debt: DEBT          )          , LogNote(_ , Pot . file dsr DSR')    ) => totalDebtBoundedRun(... debt: DEBT, dsr: DSR')
+    rule derive( totalDebtBoundedRun(... debt: DEBT          )          , LogNote(_ , End . cage         )    ) => totalDebtBoundedEnd(... debt: DEBT)
 
     rule derive(totalDebtBoundedEnd(... debt: DEBT) #as PREV, Measure(... debt: DEBT')) => Violated(PREV) requires DEBT' =/=Rad DEBT
 ```
@@ -391,9 +391,9 @@ The property checks if a successful `Pot . join` is preceded by a `TimeStep` mor
 
     rule derive(flopBlockCheck(... embers: EMBERS, dented: DENTED), FlopKick(_, _, BID, _)) => flopBlockCheck(... embers: EMBERS +Rad BID, dented: DENTED)
 
-    rule derive(flopBlockCheck(... embers: EMBERS, dented: DENTED), LogNote(_ , Flop . dent ID _ BID)) => flopBlockCheck(... embers: EMBERS -Rad BID, dented: DENTED +Int (2 ^Int ID))
+    rule derive(flopBlockCheck(... embers: EMBERS, dented: DENTED), LogNote(_ , Flop . dent  ID _  BID)) => flopBlockCheck(... embers: EMBERS -Rad BID, dented: DENTED +Int (2 ^Int ID))
         requires ( ( ( DENTED /Int ( 2 ^Int ID ) ) modInt 2 ) ==Int 0 )
-    rule derive(flopBlockCheck(... embers: EMBERS, dented: DENTED), LogNote(_ , Flop . dent ID _ BID)) => flopBlockCheck(... embers: EMBERS, dented: DENTED) [owise]
+    rule derive(flopBlockCheck(... embers: EMBERS, dented: DENTED), LogNote(_ , Flop . dent _ID _ _BID)) => flopBlockCheck(... embers: EMBERS, dented: DENTED) [owise]
 ```
 
 ```k

--- a/kmcd-props.md
+++ b/kmcd-props.md
@@ -126,13 +126,13 @@ Art of an ilk = Sum of all urn art across all users for that ilk.
 ```k
     syntax Wad ::= sumOfUrnArt(Map, String, Wad) [function, functional]
  // -------------------------------------------------------------------
-    rule sumOfUrnArt( {ILKID , ADDR} |-> Urn (... art: ART) URNS, ILKID', SUM)
-      => #if ILKID ==K ILKID'
-            #then sumOfUrnArt( URNS, ILKID', SUM +Wad ART)
-            #else sumOfUrnArt( URNS, ILKID', SUM)
+    rule sumOfUrnArt( {ILK_ID , ADDR} |-> Urn (... art: ART) URNS, ILK_ID', SUM)
+      => #if ILK_ID ==K ILK_ID'
+            #then sumOfUrnArt( URNS, ILK_ID', SUM +Wad ART)
+            #else sumOfUrnArt( URNS, ILK_ID', SUM)
          #fi
 
-    rule sumOfUrnArt( _ |-> _ URNS, ILKID', SUM ) => sumOfUrnArt( URNS, ILKID', SUM ) [owise]
+    rule sumOfUrnArt( _ |-> _ URNS, ILK_ID', SUM ) => sumOfUrnArt( URNS, ILK_ID', SUM ) [owise]
 
     rule sumOfUrnArt(.Map, _, SUM) => SUM
 ```

--- a/kmcd-props.md
+++ b/kmcd-props.md
@@ -126,7 +126,7 @@ Art of an ilk = Sum of all urn art across all users for that ilk.
 ```k
     syntax Wad ::= sumOfUrnArt(Map, String, Wad) [function, functional]
  // -------------------------------------------------------------------
-    rule sumOfUrnArt( {ILK_ID , _ADDR} |-> Urn (... art: ART) URNS, ILK_ID', SUM)
+    rule sumOfUrnArt( {ILK_ID , _} |-> Urn (... art: ART) URNS, ILK_ID', SUM)
       => #if ILK_ID ==K ILK_ID'
             #then sumOfUrnArt( URNS, ILK_ID', SUM +Wad ART)
             #else sumOfUrnArt( URNS, ILK_ID', SUM)
@@ -391,9 +391,9 @@ The property checks if a successful `Pot . join` is preceded by a `TimeStep` mor
 
     rule derive(flopBlockCheck(... embers: EMBERS, dented: DENTED), FlopKick(_, _, BID, _)) => flopBlockCheck(... embers: EMBERS +Rad BID, dented: DENTED)
 
-    rule derive(flopBlockCheck(... embers: EMBERS, dented: DENTED), LogNote(_ , Flop . dent  ID _  BID)) => flopBlockCheck(... embers: EMBERS -Rad BID, dented: DENTED +Int (2 ^Int ID))
+    rule derive(flopBlockCheck(... embers: EMBERS, dented: DENTED), LogNote(_ , Flop . dent ID _ BID)) => flopBlockCheck(... embers: EMBERS -Rad BID, dented: DENTED +Int (2 ^Int ID))
         requires ( ( ( DENTED /Int ( 2 ^Int ID ) ) modInt 2 ) ==Int 0 )
-    rule derive(flopBlockCheck(... embers: EMBERS, dented: DENTED), LogNote(_ , Flop . dent _ID _ _BID)) => flopBlockCheck(... embers: EMBERS, dented: DENTED) [owise]
+    rule derive(flopBlockCheck(... embers: EMBERS, dented: DENTED), LogNote(_ , Flop . dent _ _ _)) => flopBlockCheck(... embers: EMBERS, dented: DENTED) [owise]
 ```
 
 ```k

--- a/spot.md
+++ b/spot.md
@@ -78,18 +78,18 @@ These parameters are controlled by governance/oracles:
                       | "mat" String Ray
                       | "par" Ray
  // -----------------------------
-    rule <k> Spot . file pip ILKID .Wad => . ... </k>
+    rule <k> Spot . file pip ILK_ID .Wad => . ... </k>
          <spot-live> true </spot-live>
-         <spot-ilks> ... ILKID |-> SpotIlk ( ... pip: (_ => .Wad) ) ... </spot-ilks>
+         <spot-ilks> ... ILK_ID |-> SpotIlk ( ... pip: (_ => .Wad) ) ... </spot-ilks>
 
-    rule <k> Spot . file pip ILKID PRICE:Wad => . ... </k>
+    rule <k> Spot . file pip ILK_ID PRICE:Wad => . ... </k>
          <spot-live> true </spot-live>
-         <spot-ilks> ... ILKID |-> SpotIlk ( ... pip: (_ => PRICE) ) ... </spot-ilks>
+         <spot-ilks> ... ILK_ID |-> SpotIlk ( ... pip: (_ => PRICE) ) ... </spot-ilks>
       requires PRICE >=Wad wad(0)
 
-    rule <k> Spot . file mat ILKID MAT => . ... </k>
+    rule <k> Spot . file mat ILK_ID MAT => . ... </k>
          <spot-live> true </spot-live>
-         <spot-ilks> ... ILKID |-> SpotIlk ( ... mat: (_ => MAT) ) ... </spot-ilks>
+         <spot-ilks> ... ILK_ID |-> SpotIlk ( ... mat: (_ => MAT) ) ... </spot-ilks>
       requires MAT >=Ray ray(0)
 
     rule <k> Spot . file par PAR => . ... </k>
@@ -121,12 +121,12 @@ Because data isn't explicitely initialized to 0 in KMCD, we need explicit initia
     syntax SpotAuthStep ::= "init"     String
                           | "setPrice" String Wad
  // ---------------------------------------------
-    rule <k> Spot . init ILKID => . ... </k>
-         <spot-ilks> ILKS => ILKS [ ILKID <- SpotIlk( ... pip: .Wad, mat: ray(0) ) ] </spot-ilks>
-      requires notBool ILKID in_keys(ILKS)
+    rule <k> Spot . init ILK_ID => . ... </k>
+         <spot-ilks> ILKS => ILKS [ ILK_ID <- SpotIlk( ... pip: .Wad, mat: ray(0) ) ] </spot-ilks>
+      requires notBool ILK_ID in_keys(ILKS)
 
-    rule <k> Spot . setPrice ILKID PRICE => . ... </k>
-         <spot-ilks> ... ILKID |-> SpotIlk( ... pip: (_ => PRICE) ) ... </spot-ilks>
+    rule <k> Spot . setPrice ILK_ID PRICE => . ... </k>
+         <spot-ilks> ... ILK_ID |-> SpotIlk( ... pip: (_ => PRICE) ) ... </spot-ilks>
 ```
 
 Spot Semantics
@@ -135,15 +135,15 @@ Spot Semantics
 ```k
     syntax SpotStep ::= "poke" String
  // ---------------------------------
-    rule <k> Spot . poke ILK => call Vat . file spot ILK ((Wad2Ray(VALUE) /Ray PAR) /Ray MAT) ... </k>
-         <spot-ilks> ... ILK |-> SpotIlk (... pip: VALUE, mat: MAT ) ... </spot-ilks>
+    rule <k> Spot . poke ILK_ID => call Vat . file spot ILK_ID ((Wad2Ray(VALUE) /Ray PAR) /Ray MAT) ... </k>
+         <spot-ilks> ... ILK_ID |-> SpotIlk (... pip: VALUE, mat: MAT ) ... </spot-ilks>
          <spot-par> PAR </spot-par>
-         <frame-events> ... (.List => ListItem(Poke(ILK, VALUE, (Wad2Ray(VALUE) /Ray PAR) /Ray MAT))) </frame-events>
+         <frame-events> ... (.List => ListItem(Poke(ILK_ID, VALUE, (Wad2Ray(VALUE) /Ray PAR) /Ray MAT))) </frame-events>
       requires VALUE =/=K .Wad
 
-    rule <k> Spot . poke ILK => . ... </k>
-         <spot-ilks> ... ILK |-> SpotIlk (... pip: .Wad) ... </spot-ilks>
-         <frame-events> ... (.List => ListItem(NoPoke(ILK))) </frame-events>
+    rule <k> Spot . poke ILK_ID => . ... </k>
+         <spot-ilks> ... ILK_ID |-> SpotIlk (... pip: .Wad) ... </spot-ilks>
+         <frame-events> ... (.List => ListItem(NoPoke(ILK_ID))) </frame-events>
 ```
 Spot Deactivation
 -----------------

--- a/tests/attacks/blocked-flop.mcd.expected
+++ b/tests/attacks/blocked-flop.mcd.expected
@@ -321,9 +321,6 @@
             SetItem ( Flip "gold" )
             SetItem ( Flop )
             SetItem ( Pot )
-            End |-> .Set
-            Flap |-> .Set
-            Pot |-> .Set
             Vow |-> SetItem ( Flap )
           </vat-can>
           <vat-ilks>
@@ -688,7 +685,7 @@
       Vow |-> FInt ( 0 , 1000000000000000000000000000000000000000000000 ) , FInt ( 0 , 1000000000000000000 ) , Flap |-> FInt ( 0 , 1000000000000000000 )
       GemJoin "MKR" |-> FInt ( 0 , 1000000000000000000 )
       Vow |-> FInt ( 0 , 1000000000000000000 ) , FInt ( 0 , 1000000000000000000000000000000000000000000000 ) ) )
-      ListItem ( LogNote ( ADMIN , Vat . initIlk "gold" ) )
+      ListItem ( LogNote ( ADMIN , Vat . init "gold" ) )
       ListItem ( Measure ( FInt ( 0 , 1000000000000000000000000000000000000000000000 ) , End |-> FInt ( 0 , 1000000000000000000000000000000000000000000000 )
       Flap |-> FInt ( 0 , 1000000000000000000000000000000000000000000000 )
       Pot |-> FInt ( 0 , 1000000000000000000000000000000000000000000000 )

--- a/tests/attacks/lucash-flap-end.mcd.expected
+++ b/tests/attacks/lucash-flap-end.mcd.expected
@@ -321,9 +321,6 @@
             SetItem ( Flip "gold" )
             SetItem ( Flop )
             SetItem ( Pot )
-            End |-> .Set
-            Flap |-> .Set
-            Pot |-> .Set
             Vow |-> SetItem ( Flap )
           </vat-can>
           <vat-ilks>
@@ -688,7 +685,7 @@
       Vow |-> FInt ( 0 , 1000000000000000000000000000000000000000000000 ) , FInt ( 0 , 1000000000000000000 ) , Flap |-> FInt ( 0 , 1000000000000000000 )
       GemJoin "MKR" |-> FInt ( 0 , 1000000000000000000 )
       Vow |-> FInt ( 0 , 1000000000000000000 ) , FInt ( 0 , 1000000000000000000000000000000000000000000000 ) ) )
-      ListItem ( LogNote ( ADMIN , Vat . initIlk "gold" ) )
+      ListItem ( LogNote ( ADMIN , Vat . init "gold" ) )
       ListItem ( Measure ( FInt ( 0 , 1000000000000000000000000000000000000000000000 ) , End |-> FInt ( 0 , 1000000000000000000000000000000000000000000000 )
       Flap |-> FInt ( 0 , 1000000000000000000000000000000000000000000000 )
       Pot |-> FInt ( 0 , 1000000000000000000000000000000000000000000000 )

--- a/tests/attacks/lucash-flap-end.random.mcd.expected
+++ b/tests/attacks/lucash-flap-end.random.mcd.expected
@@ -321,9 +321,6 @@
             SetItem ( Flip "gold" )
             SetItem ( Flop )
             SetItem ( Pot )
-            End |-> .Set
-            Flap |-> .Set
-            Pot |-> .Set
             Vow |-> SetItem ( Flap )
           </vat-can>
           <vat-ilks>
@@ -688,7 +685,7 @@
       Vow |-> FInt ( 0 , 1000000000000000000000000000000000000000000000 ) , FInt ( 0 , 1000000000000000000 ) , Flap |-> FInt ( 0 , 1000000000000000000 )
       GemJoin "MKR" |-> FInt ( 0 , 1000000000000000000 )
       Vow |-> FInt ( 0 , 1000000000000000000 ) , FInt ( 0 , 1000000000000000000000000000000000000000000000 ) ) )
-      ListItem ( LogNote ( ADMIN , Vat . initIlk "gold" ) )
+      ListItem ( LogNote ( ADMIN , Vat . init "gold" ) )
       ListItem ( Measure ( FInt ( 0 , 1000000000000000000000000000000000000000000000 ) , End |-> FInt ( 0 , 1000000000000000000000000000000000000000000000 )
       Flap |-> FInt ( 0 , 1000000000000000000000000000000000000000000000 )
       Pot |-> FInt ( 0 , 1000000000000000000000000000000000000000000000 )

--- a/tests/attacks/lucash-flip-end.mcd.expected
+++ b/tests/attacks/lucash-flip-end.mcd.expected
@@ -320,9 +320,6 @@
             SetItem ( Flip "gold" )
             SetItem ( Flop )
             SetItem ( Pot )
-            End |-> .Set
-            Flap |-> .Set
-            Pot |-> .Set
             Vow |-> SetItem ( Flap )
           </vat-can>
           <vat-ilks>
@@ -687,7 +684,7 @@
       Vow |-> FInt ( 0 , 1000000000000000000000000000000000000000000000 ) , FInt ( 0 , 1000000000000000000 ) , Flap |-> FInt ( 0 , 1000000000000000000 )
       GemJoin "MKR" |-> FInt ( 0 , 1000000000000000000 )
       Vow |-> FInt ( 0 , 1000000000000000000 ) , FInt ( 0 , 1000000000000000000000000000000000000000000000 ) ) )
-      ListItem ( LogNote ( ADMIN , Vat . initIlk "gold" ) )
+      ListItem ( LogNote ( ADMIN , Vat . init "gold" ) )
       ListItem ( Measure ( FInt ( 0 , 1000000000000000000000000000000000000000000000 ) , End |-> FInt ( 0 , 1000000000000000000000000000000000000000000000 )
       Flap |-> FInt ( 0 , 1000000000000000000000000000000000000000000000 )
       Pot |-> FInt ( 0 , 1000000000000000000000000000000000000000000000 )

--- a/tests/attacks/lucash-flip-end.random.mcd.expected
+++ b/tests/attacks/lucash-flip-end.random.mcd.expected
@@ -320,9 +320,6 @@
             SetItem ( Flip "gold" )
             SetItem ( Flop )
             SetItem ( Pot )
-            End |-> .Set
-            Flap |-> .Set
-            Pot |-> .Set
             Vow |-> SetItem ( Flap )
           </vat-can>
           <vat-ilks>
@@ -687,7 +684,7 @@
       Vow |-> FInt ( 0 , 1000000000000000000000000000000000000000000000 ) , FInt ( 0 , 1000000000000000000 ) , Flap |-> FInt ( 0 , 1000000000000000000 )
       GemJoin "MKR" |-> FInt ( 0 , 1000000000000000000 )
       Vow |-> FInt ( 0 , 1000000000000000000 ) , FInt ( 0 , 1000000000000000000000000000000000000000000000 ) ) )
-      ListItem ( LogNote ( ADMIN , Vat . initIlk "gold" ) )
+      ListItem ( LogNote ( ADMIN , Vat . init "gold" ) )
       ListItem ( Measure ( FInt ( 0 , 1000000000000000000000000000000000000000000000 ) , End |-> FInt ( 0 , 1000000000000000000000000000000000000000000000 )
       Flap |-> FInt ( 0 , 1000000000000000000000000000000000000000000000 )
       Pot |-> FInt ( 0 , 1000000000000000000000000000000000000000000000 )

--- a/tests/attacks/lucash-pot-end.mcd.expected
+++ b/tests/attacks/lucash-pot-end.mcd.expected
@@ -320,9 +320,6 @@
             SetItem ( Flip "gold" )
             SetItem ( Flop )
             SetItem ( Pot )
-            End |-> .Set
-            Flap |-> .Set
-            Pot |-> .Set
             Vow |-> SetItem ( Flap )
           </vat-can>
           <vat-ilks>
@@ -687,7 +684,7 @@
       Vow |-> FInt ( 0 , 1000000000000000000000000000000000000000000000 ) , FInt ( 0 , 1000000000000000000 ) , Flap |-> FInt ( 0 , 1000000000000000000 )
       GemJoin "MKR" |-> FInt ( 0 , 1000000000000000000 )
       Vow |-> FInt ( 0 , 1000000000000000000 ) , FInt ( 0 , 1000000000000000000000000000000000000000000000 ) ) )
-      ListItem ( LogNote ( ADMIN , Vat . initIlk "gold" ) )
+      ListItem ( LogNote ( ADMIN , Vat . init "gold" ) )
       ListItem ( Measure ( FInt ( 0 , 1000000000000000000000000000000000000000000000 ) , End |-> FInt ( 0 , 1000000000000000000000000000000000000000000000 )
       Flap |-> FInt ( 0 , 1000000000000000000000000000000000000000000000 )
       Pot |-> FInt ( 0 , 1000000000000000000000000000000000000000000000 )

--- a/tests/attacks/lucash-pot-end.random.mcd.expected
+++ b/tests/attacks/lucash-pot-end.random.mcd.expected
@@ -320,9 +320,6 @@
             SetItem ( Flip "gold" )
             SetItem ( Flop )
             SetItem ( Pot )
-            End |-> .Set
-            Flap |-> .Set
-            Pot |-> .Set
             Vow |-> SetItem ( Flap )
           </vat-can>
           <vat-ilks>
@@ -687,7 +684,7 @@
       Vow |-> FInt ( 0 , 1000000000000000000000000000000000000000000000 ) , FInt ( 0 , 1000000000000000000 ) , Flap |-> FInt ( 0 , 1000000000000000000 )
       GemJoin "MKR" |-> FInt ( 0 , 1000000000000000000 )
       Vow |-> FInt ( 0 , 1000000000000000000 ) , FInt ( 0 , 1000000000000000000000000000000000000000000000 ) ) )
-      ListItem ( LogNote ( ADMIN , Vat . initIlk "gold" ) )
+      ListItem ( LogNote ( ADMIN , Vat . init "gold" ) )
       ListItem ( Measure ( FInt ( 0 , 1000000000000000000000000000000000000000000000 ) , End |-> FInt ( 0 , 1000000000000000000000000000000000000000000000 )
       Flap |-> FInt ( 0 , 1000000000000000000000000000000000000000000000 )
       Pot |-> FInt ( 0 , 1000000000000000000000000000000000000000000000 )

--- a/tests/attacks/lucash-pot.mcd.expected
+++ b/tests/attacks/lucash-pot.mcd.expected
@@ -320,9 +320,6 @@
             SetItem ( Flip "gold" )
             SetItem ( Flop )
             SetItem ( Pot )
-            End |-> .Set
-            Flap |-> .Set
-            Pot |-> .Set
             Vow |-> SetItem ( Flap )
           </vat-can>
           <vat-ilks>
@@ -687,7 +684,7 @@
       Vow |-> FInt ( 0 , 1000000000000000000000000000000000000000000000 ) , FInt ( 0 , 1000000000000000000 ) , Flap |-> FInt ( 0 , 1000000000000000000 )
       GemJoin "MKR" |-> FInt ( 0 , 1000000000000000000 )
       Vow |-> FInt ( 0 , 1000000000000000000 ) , FInt ( 0 , 1000000000000000000000000000000000000000000000 ) ) )
-      ListItem ( LogNote ( ADMIN , Vat . initIlk "gold" ) )
+      ListItem ( LogNote ( ADMIN , Vat . init "gold" ) )
       ListItem ( Measure ( FInt ( 0 , 1000000000000000000000000000000000000000000000 ) , End |-> FInt ( 0 , 1000000000000000000000000000000000000000000000 )
       Flap |-> FInt ( 0 , 1000000000000000000000000000000000000000000000 )
       Pot |-> FInt ( 0 , 1000000000000000000000000000000000000000000000 )

--- a/tests/attacks/lucash-pot.random.mcd.expected
+++ b/tests/attacks/lucash-pot.random.mcd.expected
@@ -320,9 +320,6 @@
             SetItem ( Flip "gold" )
             SetItem ( Flop )
             SetItem ( Pot )
-            End |-> .Set
-            Flap |-> .Set
-            Pot |-> .Set
             Vow |-> SetItem ( Flap )
           </vat-can>
           <vat-ilks>
@@ -687,7 +684,7 @@
       Vow |-> FInt ( 0 , 1000000000000000000000000000000000000000000000 ) , FInt ( 0 , 1000000000000000000 ) , Flap |-> FInt ( 0 , 1000000000000000000 )
       GemJoin "MKR" |-> FInt ( 0 , 1000000000000000000 )
       Vow |-> FInt ( 0 , 1000000000000000000 ) , FInt ( 0 , 1000000000000000000000000000000000000000000000 ) ) )
-      ListItem ( LogNote ( ADMIN , Vat . initIlk "gold" ) )
+      ListItem ( LogNote ( ADMIN , Vat . init "gold" ) )
       ListItem ( Measure ( FInt ( 0 , 1000000000000000000000000000000000000000000000 ) , End |-> FInt ( 0 , 1000000000000000000000000000000000000000000000 )
       Flap |-> FInt ( 0 , 1000000000000000000000000000000000000000000000 )
       Pot |-> FInt ( 0 , 1000000000000000000000000000000000000000000000 )

--- a/tests/fixes/debtBoundDSR.mcd.expected
+++ b/tests/fixes/debtBoundDSR.mcd.expected
@@ -308,9 +308,6 @@
                 SetItem ( Flip "gold" )
                 SetItem ( Flop )
                 SetItem ( Pot )
-                End |-> .Set
-                Flap |-> .Set
-                Pot |-> .Set
                 Vow |-> SetItem ( Flap )
               </vat-can>
               <vat-ilks>
@@ -688,9 +685,6 @@
             SetItem ( Flip "gold" )
             SetItem ( Flop )
             SetItem ( Pot )
-            End |-> .Set
-            Flap |-> .Set
-            Pot |-> .Set
             Vow |-> SetItem ( Flap )
           </vat-can>
           <vat-ilks>
@@ -1055,7 +1049,7 @@
       Vow |-> FInt ( 0 , 1000000000000000000000000000000000000000000000 ) , FInt ( 0 , 1000000000000000000 ) , Flap |-> FInt ( 0 , 1000000000000000000 )
       GemJoin "MKR" |-> FInt ( 0 , 1000000000000000000 )
       Vow |-> FInt ( 0 , 1000000000000000000 ) , FInt ( 0 , 1000000000000000000000000000000000000000000000 ) ) )
-      ListItem ( LogNote ( ADMIN , Vat . initIlk "gold" ) )
+      ListItem ( LogNote ( ADMIN , Vat . init "gold" ) )
       ListItem ( Measure ( FInt ( 0 , 1000000000000000000000000000000000000000000000 ) , End |-> FInt ( 0 , 1000000000000000000000000000000000000000000000 )
       Flap |-> FInt ( 0 , 1000000000000000000000000000000000000000000000 )
       Pot |-> FInt ( 0 , 1000000000000000000000000000000000000000000000 )

--- a/tests/fixes/potChiPieDai.mcd.expected
+++ b/tests/fixes/potChiPieDai.mcd.expected
@@ -320,9 +320,6 @@
             SetItem ( Flip "gold" )
             SetItem ( Flop )
             SetItem ( Pot )
-            End |-> .Set
-            Flap |-> .Set
-            Pot |-> .Set
             Vow |-> SetItem ( Flap )
           </vat-can>
           <vat-ilks>
@@ -687,7 +684,7 @@
       Vow |-> FInt ( 0 , 1000000000000000000000000000000000000000000000 ) , FInt ( 0 , 1000000000000000000 ) , Flap |-> FInt ( 0 , 1000000000000000000 )
       GemJoin "MKR" |-> FInt ( 0 , 1000000000000000000 )
       Vow |-> FInt ( 0 , 1000000000000000000 ) , FInt ( 0 , 1000000000000000000000000000000000000000000000 ) ) )
-      ListItem ( LogNote ( ADMIN , Vat . initIlk "gold" ) )
+      ListItem ( LogNote ( ADMIN , Vat . init "gold" ) )
       ListItem ( Measure ( FInt ( 0 , 1000000000000000000000000000000000000000000000 ) , End |-> FInt ( 0 , 1000000000000000000000000000000000000000000000 )
       Flap |-> FInt ( 0 , 1000000000000000000000000000000000000000000000 )
       Pot |-> FInt ( 0 , 1000000000000000000000000000000000000000000000 )

--- a/vat.md
+++ b/vat.md
@@ -167,15 +167,10 @@ Because data isn't explicitely initialized to 0 in KMCD, we need explicit initia
 -   `initCDP`: Create an empty CDP of a given ilk for a given user.
 
 ```k
-    syntax VatAuthStep ::= "initIlk" String
-                         | "initUser" Address
+    syntax VatAuthStep ::= "initUser" Address
                          | "initGem" String Address
                          | "initCDP" String Address
  // -----------------------------------------------
-    rule <k> Vat . initIlk ILKID => . ... </k>
-         <vat-ilks> ILKS => ILKS [ ILKID <- Ilk ( ... Art: wad(0) , rate: ray(1) , spot: ray(0) , line: rad(0) , dust: rad(0) ) ] </vat-ilks>
-      requires notBool ILKID in_keys(ILKS)
-
     rule <k> Vat . initUser ADDR => . ... </k>
          <vat-dai> DAI => DAI [ ADDR <- rad(0) ] </vat-dai>
          <vat-sin> SIN => SIN [ ADDR <- rad(0) ] </vat-sin>
@@ -281,6 +276,10 @@ This is quite permissive, and would allow the account to drain all your locked c
  // ------------------------------------
     rule <k> Vat . init ILKID => . ... </k>
          <vat-ilks> ... ILKID |-> Ilk(... rate: ray(0) => ray(1)) ... </vat-ilks>
+
+    rule <k> Vat . init ILKID ... </k>
+         <vat-ilks> VAT_ILKS => VAT_ILKS [ ILKID <- Ilk (... Art: wad(0) , rate: ray(0) , spot: ray(0) , line: rad(0) , dust: rad(0) ) ] </vat-ilks>
+      requires notBool ILKID in_keys(VAT_ILKS)
 ```
 
 ### Collateral manipulation (`<vat-gem>`)

--- a/vat.md
+++ b/vat.md
@@ -177,11 +177,9 @@ Because data isn't explicitely initialized to 0 in KMCD, we need explicit initia
       requires notBool ILKID in_keys(ILKS)
 
     rule <k> Vat . initUser ADDR => . ... </k>
-         <vat-can> CAN => CAN [ ADDR <- .Set ] </vat-can>
          <vat-dai> DAI => DAI [ ADDR <- rad(0) ] </vat-dai>
          <vat-sin> SIN => SIN [ ADDR <- rad(0) ] </vat-sin>
-      requires notBool ADDR in_keys(CAN)
-       andBool notBool ADDR in_keys(DAI)
+      requires notBool ADDR in_keys(DAI)
        andBool notBool ADDR in_keys(SIN)
 
     rule <k> Vat . initGem ILKID ADDR => . ... </k>
@@ -242,6 +240,16 @@ This is quite permissive, and would allow the account to drain all your locked c
     rule <k> Vat . nope ADDRTO => . ... </k>
          <msg-sender> MSGSENDER </msg-sender>
          <vat-can> ... MSGSENDER |-> (CANADDRS => CANADDRS -Set SetItem(ADDRTO)) ... </vat-can>
+
+    rule <k> Vat . hope ADDRTO ... </k>
+         <msg-sender> MSGSENDER </msg-sender>
+         <vat-can> VAT_CANS => VAT_CANS [ MSGSENDER <- .Set ] </vat-can>
+      requires notBool MSGSENDER in_keys(VAT_CANS)
+
+    rule <k> Vat . nope ADDRTO => . ... </k>
+         <msg-sender> MSGSENDER </msg-sender>
+         <vat-can> VAT_CANS </vat-can>
+      requires notBool MSGSENDER in_keys(VAT_CANS)
 ```
 
 -   `Vat.safe` checks that a given `Urn` of a certain `ilk` is not over-leveraged.

--- a/vat.md
+++ b/vat.md
@@ -236,12 +236,12 @@ This is quite permissive, and would allow the account to drain all your locked c
          <msg-sender> MSGSENDER </msg-sender>
          <vat-can> ... MSGSENDER |-> (CANADDRS => CANADDRS -Set SetItem(ADDRTO)) ... </vat-can>
 
-    rule <k> Vat . hope ADDRTO ... </k>
+    rule <k> Vat . hope _ADDRTO ... </k>
          <msg-sender> MSGSENDER </msg-sender>
          <vat-can> VAT_CANS => VAT_CANS [ MSGSENDER <- .Set ] </vat-can>
       requires notBool MSGSENDER in_keys(VAT_CANS)
 
-    rule <k> Vat . nope ADDRTO => . ... </k>
+    rule <k> Vat . nope _ADDRTO => . ... </k>
          <msg-sender> MSGSENDER </msg-sender>
          <vat-can> VAT_CANS </vat-can>
       requires notBool MSGSENDER in_keys(VAT_CANS)
@@ -363,7 +363,7 @@ This is quite permissive, and would allow the account to drain all your locked c
          <vat-urns>
            ...
            { ILK_ID , ADDRFROM } |-> Urn ( INKFROM => INKFROM -Wad DINK , ARTFROM => ARTFROM -Wad DART )
-           { ILK_ID , ADDRTO   } |-> Urn ( INKTO   => INKTO   +Wad DINK , ARTTO   => ARTFROM +Wad DART )
+           { ILK_ID , ADDRTO   } |-> Urn ( INKTO   => INKTO   +Wad DINK , ARTTO   => ARTTO   +Wad DART )
            ...
          </vat-urns>
       requires INKFROM >=Wad DINK

--- a/vat.md
+++ b/vat.md
@@ -140,19 +140,19 @@ The parameters controlled by governance are:
          <vat-Line> _ => LINE </vat-Line>
       requires LINE >=Rad rad(0)
 
-    rule <k> Vat . file spot ILKID SPOT => . ... </k>
+    rule <k> Vat . file spot ILK_ID SPOT => . ... </k>
          <vat-live> true </vat-live>
-         <vat-ilks> ... ILKID |-> Ilk ( ... spot: (_ => SPOT) ) ... </vat-ilks>
+         <vat-ilks> ... ILK_ID |-> Ilk ( ... spot: (_ => SPOT) ) ... </vat-ilks>
       requires SPOT >=Ray ray(0)
 
-    rule <k> Vat . file line ILKID LINE => . ... </k>
+    rule <k> Vat . file line ILK_ID LINE => . ... </k>
          <vat-live> true </vat-live>
-         <vat-ilks> ... ILKID |-> Ilk ( ... line: (_ => LINE) ) ... </vat-ilks>
+         <vat-ilks> ... ILK_ID |-> Ilk ( ... line: (_ => LINE) ) ... </vat-ilks>
       requires LINE >=Rad rad(0)
 
-    rule <k> Vat . file dust ILKID DUST => . ... </k>
+    rule <k> Vat . file dust ILK_ID DUST => . ... </k>
          <vat-live> true </vat-live>
-         <vat-ilks> ... ILKID |-> Ilk ( ... dust: (_ => DUST) ) ... </vat-ilks>
+         <vat-ilks> ... ILK_ID |-> Ilk ( ... dust: (_ => DUST) ) ... </vat-ilks>
       requires DUST >=Rad rad(0)
 ```
 
@@ -177,13 +177,13 @@ Because data isn't explicitely initialized to 0 in KMCD, we need explicit initia
       requires notBool ADDR in_keys(DAI)
        andBool notBool ADDR in_keys(SIN)
 
-    rule <k> Vat . initGem ILKID ADDR => . ... </k>
-         <vat-gem> GEMS => GEMS [ { ILKID , ADDR } <- wad(0) ] </vat-gem>
-      requires notBool { ILKID , ADDR } in_keys(GEMS)
+    rule <k> Vat . initGem ILK_ID ADDR => . ... </k>
+         <vat-gem> GEMS => GEMS [ { ILK_ID , ADDR } <- wad(0) ] </vat-gem>
+      requires notBool { ILK_ID , ADDR } in_keys(GEMS)
 
-    rule <k> Vat . initCDP ILKID ADDR => . ... </k>
-         <vat-urns> URNS => URNS [ { ILKID , ADDR } <- Urn( ... ink: wad(0) , art: wad(0) ) ] </vat-urns>
-      requires notBool { ILKID , ADDR } in_keys(URNS)
+    rule <k> Vat . initCDP ILK_ID ADDR => . ... </k>
+         <vat-urns> URNS => URNS [ { ILK_ID , ADDR } <- Urn( ... ink: wad(0) , art: wad(0) ) ] </vat-urns>
+      requires notBool { ILK_ID , ADDR } in_keys(URNS)
 ```
 
 Vat Semantics
@@ -253,17 +253,17 @@ This is quite permissive, and would allow the account to drain all your locked c
 ```k
     syntax VatStep ::= "safe" String Address
  // ----------------------------------------
-    rule <k> Vat . safe ILKID ADDR => . ... </k>
-         <vat-ilks> ...   ILKID          |-> ILK ... </vat-ilks>
-         <vat-urns> ... { ILKID , ADDR } |-> URN ... </vat-urns>
+    rule <k> Vat . safe ILK_ID ADDR => . ... </k>
+         <vat-ilks> ...   ILK_ID          |-> ILK ... </vat-ilks>
+         <vat-urns> ... { ILK_ID , ADDR } |-> URN ... </vat-urns>
       requires rad(0) <=Rad urnBalance(ILK, URN)
        andBool urnDebt(ILK, URN) <=Rad line(ILK)
 
     syntax VatStep ::= "nondusty" String Address
  // --------------------------------------------
-    rule <k> Vat . nondusty ILKID ADDR => . ... </k>
-         <vat-ilks> ...   ILKID          |-> ILK ... </vat-ilks>
-         <vat-urns> ... { ILKID , ADDR } |-> URN ... </vat-urns>
+    rule <k> Vat . nondusty ILK_ID ADDR => . ... </k>
+         <vat-ilks> ...   ILK_ID          |-> ILK ... </vat-ilks>
+         <vat-urns> ... { ILK_ID , ADDR } |-> URN ... </vat-urns>
       requires dust(ILK) <=Rad urnDebt(ILK, URN) orBool rad(0) ==Rad urnDebt(ILK, URN)
 ```
 
@@ -274,12 +274,12 @@ This is quite permissive, and would allow the account to drain all your locked c
 ```k
     syntax VatAuthStep ::= "init" String
  // ------------------------------------
-    rule <k> Vat . init ILKID => . ... </k>
-         <vat-ilks> ... ILKID |-> Ilk(... rate: ray(0) => ray(1)) ... </vat-ilks>
+    rule <k> Vat . init ILK_ID => . ... </k>
+         <vat-ilks> ... ILK_ID |-> Ilk(... rate: ray(0) => ray(1)) ... </vat-ilks>
 
-    rule <k> Vat . init ILKID ... </k>
-         <vat-ilks> VAT_ILKS => VAT_ILKS [ ILKID <- Ilk (... Art: wad(0) , rate: ray(0) , spot: ray(0) , line: rad(0) , dust: rad(0) ) ] </vat-ilks>
-      requires notBool ILKID in_keys(VAT_ILKS)
+    rule <k> Vat . init ILK_ID ... </k>
+         <vat-ilks> VAT_ILKS => VAT_ILKS [ ILK_ID <- Ilk (... Art: wad(0) , rate: ray(0) , spot: ray(0) , line: rad(0) , dust: rad(0) ) ] </vat-ilks>
+      requires notBool ILK_ID in_keys(VAT_ILKS)
 ```
 
 ### Collateral manipulation (`<vat-gem>`)
@@ -295,25 +295,25 @@ This is quite permissive, and would allow the account to drain all your locked c
 ```k
     syntax VatAuthStep ::= "slip" String Address Wad
  // ------------------------------------------------
-    rule <k> Vat . slip ILKID ADDRTO NEWCOL => . ... </k>
-         <vat-gem> ... { ILKID , ADDRTO } |-> ( COL => COL +Wad NEWCOL ) ... </vat-gem>
+    rule <k> Vat . slip ILK_ID ADDRTO NEWCOL => . ... </k>
+         <vat-gem> ... { ILK_ID , ADDRTO } |-> ( COL => COL +Wad NEWCOL ) ... </vat-gem>
       requires NEWCOL >=Wad wad(0)
 
     syntax VatStep ::= "flux" String Address Address Wad
  // ----------------------------------------------------
-    rule <k> Vat . flux ILKID ADDRFROM ADDRTO COL => . ... </k>
+    rule <k> Vat . flux ILK_ID ADDRFROM ADDRTO COL => . ... </k>
          <vat-gem>
            ...
-           { ILKID , ADDRFROM } |-> ( COLFROM => COLFROM -Wad COL )
-           { ILKID , ADDRTO   } |-> ( COLTO   => COLTO   +Wad COL )
+           { ILK_ID , ADDRFROM } |-> ( COLFROM => COLFROM -Wad COL )
+           { ILK_ID , ADDRTO   } |-> ( COLTO   => COLTO   +Wad COL )
            ...
          </vat-gem>
       requires COL     >=Wad wad(0)
        andBool COLFROM >=Wad COL
        andBool wish ADDRFROM
 
-    rule <k> Vat . flux ILKID ADDRFROM ADDRFROM COL => . ... </k>
-         <vat-gem> ... { ILKID , ADDRFROM } |-> COLFROM ... </vat-gem>
+    rule <k> Vat . flux ILK_ID ADDRFROM ADDRFROM COL => . ... </k>
+         <vat-gem> ... { ILK_ID , ADDRFROM } |-> COLFROM ... </vat-gem>
       requires COL     >=Wad wad(0)
        andBool COLFROM >=Wad COL
        andBool wish ADDRFROM
@@ -355,15 +355,15 @@ This is quite permissive, and would allow the account to drain all your locked c
 ```k
     syntax VatStep ::= "fork" String Address Address Wad Wad
  // --------------------------------------------------------
-    rule <k> Vat . fork ILKID ADDRFROM ADDRTO DINK DART
-          => Vat . safe     ILKID ADDRFROM ~> Vat . safe     ILKID ADDRTO
-          ~> Vat . nondusty ILKID ADDRFROM ~> Vat . nondusty ILKID ADDRTO
+    rule <k> Vat . fork ILK_ID ADDRFROM ADDRTO DINK DART
+          => Vat . safe     ILK_ID ADDRFROM ~> Vat . safe     ILK_ID ADDRTO
+          ~> Vat . nondusty ILK_ID ADDRFROM ~> Vat . nondusty ILK_ID ADDRTO
          ...
          </k>
          <vat-urns>
            ...
-           { ILKID , ADDRFROM } |-> Urn ( INKFROM => INKFROM -Wad DINK , ARTFROM => ARTFROM -Wad DART )
-           { ILKID , ADDRTO   } |-> Urn ( INKTO   => INKTO   +Wad DINK , ARTTO   => ARTFROM +Wad DART )
+           { ILK_ID , ADDRFROM } |-> Urn ( INKFROM => INKFROM -Wad DINK , ARTFROM => ARTFROM -Wad DART )
+           { ILK_ID , ADDRTO   } |-> Urn ( INKTO   => INKTO   +Wad DINK , ARTTO   => ARTFROM +Wad DART )
            ...
          </vat-urns>
       requires INKFROM >=Wad DINK
@@ -371,12 +371,12 @@ This is quite permissive, and would allow the account to drain all your locked c
        andBool wish ADDRFROM
        andBool wish ADDRTO
 
-    rule <k> Vat . fork ILKID ADDRFROM ADDRFROM DINK DART
-          => Vat . safe     ILKID ADDRFROM ~> Vat . safe     ILKID ADDRFROM
-          ~> Vat . nondusty ILKID ADDRFROM ~> Vat . nondusty ILKID ADDRFROM
+    rule <k> Vat . fork ILK_ID ADDRFROM ADDRFROM DINK DART
+          => Vat . safe     ILK_ID ADDRFROM ~> Vat . safe     ILK_ID ADDRFROM
+          ~> Vat . nondusty ILK_ID ADDRFROM ~> Vat . nondusty ILK_ID ADDRFROM
          ...
          </k>
-         <vat-urns> ... { ILKID , ADDRFROM } |-> Urn ( INKFROM , ARTFROM ) ... </vat-urns>
+         <vat-urns> ... { ILK_ID , ADDRFROM } |-> Urn ( INKFROM , ARTFROM ) ... </vat-urns>
       requires INKFROM >=Wad DINK
        andBool ARTFROM >=Wad DART
        andBool wish ADDRFROM
@@ -391,11 +391,11 @@ This is quite permissive, and would allow the account to drain all your locked c
 ```k
     syntax VatAuthStep ::= "grab" String Address Address Address Wad Wad
  // --------------------------------------------------------------------
-    rule <k> Vat . grab ILKID ADDRU ADDRV ADDRW DINK DART => . ... </k>
+    rule <k> Vat . grab ILK_ID ADDRU ADDRV ADDRW DINK DART => . ... </k>
          <vat-vice> VICE => VICE -Rad (DART *Rate RATE) </vat-vice>
-         <vat-urns> ... { ILKID , ADDRU } |-> Urn ( INK => INK +Wad DINK , URNART => URNART +Wad DART ) ... </vat-urns>
-         <vat-ilks> ... ILKID |-> Ilk ( ILKART => ILKART +Wad DART , RATE , _ , _ , _ ) ... </vat-ilks>
-         <vat-gem> ... { ILKID , ADDRV } |-> ( ILKV => ILKV -Wad DINK ) ... </vat-gem>
+         <vat-urns> ... { ILK_ID , ADDRU } |-> Urn ( INK => INK +Wad DINK , URNART => URNART +Wad DART ) ... </vat-urns>
+         <vat-ilks> ... ILK_ID |-> Ilk ( ILKART => ILKART +Wad DART , RATE , _ , _ , _ ) ... </vat-ilks>
+         <vat-gem> ... { ILK_ID , ADDRV } |-> ( ILKV => ILKV -Wad DINK ) ... </vat-gem>
          <vat-sin> ... ADDRW |-> ( SINW => SINW -Rad (DART *Rate RATE) ) ... </vat-sin>
       requires ILKV >=Wad DINK
        andBool SINW >=Rad (DART *Rate RATE)
@@ -403,12 +403,12 @@ This is quite permissive, and would allow the account to drain all your locked c
 
     syntax VatStep ::= "frob" String Address Address Address Wad Wad
  // ----------------------------------------------------------------
-    rule <k> Vat . frob ILKID ADDRU ADDRV ADDRW DINK DART => . ... </k>
+    rule <k> Vat . frob ILK_ID ADDRU ADDRV ADDRW DINK DART => . ... </k>
          <vat-live> true </vat-live>
          <vat-debt> DEBT => DEBT +Rad (DART *Rate RATE) </vat-debt>
-         <vat-urns> ... { ILKID , ADDRU } |-> Urn ( INK => INK +Wad DINK , URNART => URNART +Wad DART ) ... </vat-urns>
-         <vat-ilks> ... ILKID |-> Ilk (... Art: ILKART => ILKART +Wad DART , rate: RATE , spot: SPOT, line: ILKLINE, dust: DUST ) ... </vat-ilks>
-         <vat-gem> ... { ILKID , ADDRV } |-> ( ILKV => ILKV -Wad DINK ) ... </vat-gem>
+         <vat-urns> ... { ILK_ID , ADDRU } |-> Urn ( INK => INK +Wad DINK , URNART => URNART +Wad DART ) ... </vat-urns>
+         <vat-ilks> ... ILK_ID |-> Ilk (... Art: ILKART => ILKART +Wad DART , rate: RATE , spot: SPOT, line: ILKLINE, dust: DUST ) ... </vat-ilks>
+         <vat-gem> ... { ILK_ID , ADDRV } |-> ( ILKV => ILKV -Wad DINK ) ... </vat-gem>
          <vat-dai> ... ADDRW |-> ( DAIW => DAIW +Rad (DART *Rate RATE) ) ... </vat-dai>
          <vat-Line> LINE </vat-Line>
       requires ILKV >=Wad DINK
@@ -463,10 +463,10 @@ This is quite permissive, and would allow the account to drain all your locked c
 ```k
     syntax VatAuthStep ::= "fold" String Address Ray
  // ------------------------------------------------
-    rule <k> Vat . fold ILKID ADDRU RATE => . ... </k>
+    rule <k> Vat . fold ILK_ID ADDRU RATE => . ... </k>
          <vat-live> true </vat-live>
          <vat-debt> DEBT => DEBT +Rad (ILKART *Rate RATE) </vat-debt>
-         <vat-ilks> ... ILKID |-> Ilk ( ILKART , ILKRATE => ILKRATE +Ray RATE , _ , _ , _ ) ... </vat-ilks>
+         <vat-ilks> ... ILK_ID |-> Ilk ( ILKART , ILKRATE => ILKRATE +Ray RATE , _ , _ , _ ) ... </vat-ilks>
          <vat-dai> ... ADDRU |-> ( DAI => DAI +Rad (ILKART *Rate RATE) ) ... </vat-dai>
 ```
 


### PR DESCRIPTION
-   Rename all occurances of `ILKID` to `ILK_ID` for consistency (easier grep-ability).
-   Add file parameters to some of the contracts that were not present before.
-   Some contracts get "default initialization" of their data-structures. Ideally we would have a solution to always do this, but we don't. So for now, I've handled the few cases that show up.
-   Removes all the `Unused variable` warnings that show up with newest K.