### PR TITLE
Solidity generation fixes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,9 +16,9 @@ pipeline {
         stage('Build') { steps { sh 'make build -j4 RELEASE=true' } }
         stage('Unit Test') {
           parallel {
-            stage('Run Simulation Tests') { steps { sh 'make test-execution -j8'    } }
-            stage('Python Runner')        { steps { sh 'make test-python-generator' } }
-            stage('Random Generation')    { steps { sh 'make test-random'           } }
+            stage('Run Simulation Tests') { steps { sh 'make test-execution -j8'        } }
+            stage('Python Runner')        { steps { sh 'make test-python-generator -j8' } }
+            stage('Random Generation')    { steps { sh 'make test-random'               } }
           }
         }
         stage('Solidity Test') { steps { sh 'make test-solidity' } }

--- a/kmcd-prelude.md
+++ b/kmcd-prelude.md
@@ -197,6 +197,16 @@ module KMCD-GEN
         </kmcd-gen>
       </kmcd-random>
 
+    syntax Address ::= chooseSender ( Int , List ) [function]
+ // ---------------------------------------------------------
+    rule chooseSender(RAND, ADDRS) => chooseAddress(RAND, #validSenders(ADDRS))
+
+    syntax List ::= #validSenders ( List ) [function]
+ // -------------------------------------------------
+    rule #validSenders(.List) => ListItem(ANYONE)
+    rule #validSenders(ListItem(_:MCDContract) REST => REST)
+    rule #validSenders(ListItem(I) REST) => ListItem(I) #validSenders(REST) [owise]
+
     syntax AdminStep ::= "snapshot"
  // -------------------------------
     rule <k> snapshot => . ... </k>
@@ -374,7 +384,7 @@ module KMCD-GEN
          </vat-urns>
       requires lengthBytes(BS) >Int 0
 
-    rule <k> GenVatMove => GenVatMove chooseAddress(head(BS), keys_list(VAT_DAIS)) ... </k>
+    rule <k> GenVatMove => GenVatMove chooseSender(head(BS), keys_list(VAT_DAIS)) ... </k>
          <random> BS => tail(BS) </random>
          <used-random> BS' => BS' +Bytes headAsBytes(BS) </used-random>
          <vat-dai> VAT_DAIS </vat-dai>
@@ -398,7 +408,7 @@ module KMCD-GEN
          </vat-dai>
       requires lengthBytes(BS) >Int 0
 
-    rule <k> GenVatHope => GenVatHope chooseAddress(head(BS), keys_list(VAT_DAI)) ... </k>
+    rule <k> GenVatHope => GenVatHope chooseSender(head(BS), keys_list(VAT_DAI)) ... </k>
          <random> BS => tail(BS) </random>
          <used-random> BS' => BS' +Bytes headAsBytes(BS) </used-random>
          <vat-dai> VAT_DAI </vat-dai>
@@ -427,7 +437,7 @@ module KMCD-GEN
 //         <gem-joins> GEM_JOINS </gem-joins>
 //      requires size(GEM_JOINS) >Int 0
 
-    rule <k> GenGemJoinJoin GEM_JOIN_ID => GenGemJoinJoin GEM_JOIN_ID chooseAddress(head(BS), keys_list(GEM_BALANCES)) ... </k>
+    rule <k> GenGemJoinJoin GEM_JOIN_ID => GenGemJoinJoin GEM_JOIN_ID chooseSender(head(BS), keys_list(GEM_BALANCES)) ... </k>
          <random> BS => tail(BS) </random>
          <used-random> BS' => BS' +Bytes headAsBytes(BS) </used-random>
          <gem>
@@ -455,7 +465,7 @@ module KMCD-GEN
                          | "GenFlapKick" Address Rad Wad
                          | "GenFlapYank"
  // ------------------------------------
-    rule <k> GenFlapKick => GenFlapKick chooseAddress(head(BS), keys_list(VAT_DAIS)) ... </k>
+    rule <k> GenFlapKick => GenFlapKick chooseSender(head(BS), keys_list(VAT_DAIS)) ... </k>
          <random> BS => tail(BS) </random>
          <used-random> BS' => BS' +Bytes headAsBytes(BS) </used-random>
          <vat-dai> VAT_DAIS </vat-dai>
@@ -541,7 +551,7 @@ module KMCD-GEN
     rule <k> GenPotCage => LogGen ( transact ADMIN  Pot . cage ) ... </k>
     rule <k> GenPotDrip => LogGen ( transact ANYONE Pot . drip ) ... </k>
 
-    rule <k> GenPotJoin => GenPotJoin chooseAddress(head(BS), keys_list(POT_PIES)) ... </k>
+    rule <k> GenPotJoin => GenPotJoin chooseSender(head(BS), keys_list(POT_PIES)) ... </k>
          <random> BS => tail(BS) </random>
          <used-random> BS' => BS' +Bytes headAsBytes(BS) </used-random>
          <pot-pies> POT_PIES </pot-pies>
@@ -560,7 +570,7 @@ module KMCD-GEN
          <used-random> BS' => BS' +Bytes headAsBytes(BS) </used-random>
       requires lengthBytes(BS) >Int 0
 
-    rule <k> GenPotExit => GenPotExit chooseAddress(head(BS), keys_list(POT_PIES)) ... </k>
+    rule <k> GenPotExit => GenPotExit chooseSender(head(BS), keys_list(POT_PIES)) ... </k>
          <random> BS => tail(BS) </random>
          <used-random> BS' => BS' +Bytes headAsBytes(BS) </used-random>
          <pot-pies> POT_PIES </pot-pies>
@@ -631,7 +641,7 @@ module KMCD-GEN
       requires lengthBytes(BS) >Int 0
        andBool size(FLIP_BIDS) >Int 0
 
-    rule <k> GenEndPack => GenEndPack chooseAddress(head(BS), keys_list(END_BAGS)) ... </k>
+    rule <k> GenEndPack => GenEndPack chooseSender(head(BS), keys_list(END_BAGS)) ... </k>
          <random> BS => tail(BS) </random>
          <used-random> BS' => BS' +Bytes headAsBytes(BS) </used-random>
          <end-bag> END_BAGS </end-bag>

--- a/mcd-pyk.py
+++ b/mcd-pyk.py
@@ -288,18 +288,16 @@ def extractCallEvents(logEvent):
             return []
         if function.endswith('Cage'):
             function = 'cage'
-        args = []
+        args = ""
         if function.endswith('file'):
             fileable = functionCall['args'][0]['label'].split('_')[0]
             if fileable.endswith('-file'):
                 fileable = fileable[0:-5]
             fileargs = functionCall['args'][0]['args']
-            args.append(stringToken(fileable))
-            args.extend(fileargs)
+            args = '"' + fileable + '", ' + solidityArgs(fileargs)
         else:
-            args = functionCall['args']
-        strArgs = solidityArgs(args)
-        return [ caller + '.' + contract + '_' + function + '(' + strArgs + ');' ]
+            args = solidityArgs(functionCall['args'])
+        return [ caller + '.' + contract + '_' + function + '(' + args + ');' ]
     elif pyk.isKApply(logEvent) and logEvent['label'] == 'LogTimeStep':
         return [ 'this.warpForward(' + printMCD(logEvent['args'][0]) + ');' ]
     elif pyk.isKApply(logEvent) and logEvent['label'] == 'LogException':

--- a/mcd-pyk.py
+++ b/mcd-pyk.py
@@ -261,6 +261,13 @@ def argify(arg):
         newArg = '"' + newArg + '"'
     return newArg
 
+def functionify(fname):
+    if fname == 'pie':
+        return 'Pie'
+    if fname == 'pies':
+        return 'pie'
+    return fname
+
 def solidityKeys(k):
     if pyk.isKApply(k) and k['label'] == 'CDPID':
         return [ a for a in k['args'] ]
@@ -325,14 +332,14 @@ def noRewriteToDots(config):
 def stateAssertions(contract, field, value, subkeys = []):
     assertionData = []
     if pyk.isKToken(value) and value['sort'] == 'Bool':
-        actual     = contract + '.' + field + '(' + solidityArgs(subkeys) + ')'
+        actual     = contract + '.' + functionify(field) + '(' + solidityArgs(subkeys) + ')'
         comparator = '=='
         expected   = printMCD(intToken(0))
         if value['token'] == 'true':
             comparator = '!='
         assertionData.append((actual, comparator, expected, True))
     elif pyk.isKApply(value) and value['label'] == 'FInt':
-        actual     = contract + '.' + field + '(' + solidityArgs(subkeys) + ')'
+        actual     = contract + '.' + functionify(field) + '(' + solidityArgs(subkeys) + ')'
         comparator = '=='
         expected   = printMCD(value['args'][0])
         assertionData.append((actual, comparator, expected, True))
@@ -345,12 +352,12 @@ def stateAssertions(contract, field, value, subkeys = []):
             elif pyk.isKApply(v) and v['label'] == 'FInt':
                 assertionData.extend(stateAssertions(contract, field, v, subkeys = keys))
             else:
-                actual     = contract + '.' + field + '(' + solidityArgs(keys) + ')'
+                actual     = contract + '.' + functionify(field) + '(' + solidityArgs(keys) + ')'
                 comparator = '=='
                 expected   = printMCD(v)
                 assertionData.append((actual, comparator, expected, False))
     else:
-        actual = contract + '.' + field + '()'
+        actual = contract + '.' + functionify(field) + '()'
         assertionData.append((actual, '==', printMCD(value), False))
     return assertionData
 

--- a/mcd-pyk.py
+++ b/mcd-pyk.py
@@ -291,7 +291,7 @@ def extractCallEvents(logEvent):
         contract = solidify(printMCD(logEvent['args'][1]['args'][0]))
         functionCall = logEvent['args'][1]['args'][1]
         function = functionCall['label'].split('_')[0]
-        if function.startswith('init') or function.startswith('deploy') or function.startswith('constructor'):
+        if function.startswith('init') or function.startswith('deploy') or function.startswith('constructor') or function.startswith('poke'):
             return []
         if function.endswith('Cage'):
             function = 'cage'

--- a/mcd-pyk.py
+++ b/mcd-pyk.py
@@ -284,7 +284,7 @@ def extractCallEvents(logEvent):
         contract = solidify(printMCD(logEvent['args'][1]['args'][0]))
         functionCall = logEvent['args'][1]['args'][1]
         function = functionCall['label'].split('_')[0]
-        if function.startswith('init'):
+        if function.startswith('init') or function.startswith('deploy') or function.startswith('constructor'):
             return []
         if function.endswith('Cage'):
             function = 'cage'


### PR DESCRIPTION
Major changes include:

-   Skip generating calls for deployment or constructor function calls.
-   Choose only addresses which make sense for randomly generated transactions (non-ADMIN non-MCD-contract addresses).
-   Correct the name used for pot `pie` and `Pie` fields in solidity generation.