### PR TITLE
Simplifications for symbolic reasoning

### DIFF
--- a/fixed-int.md
+++ b/fixed-int.md
@@ -5,6 +5,8 @@ This module implements fixed point integers in K.
 Once it stabalizes, it should be upstreamed into the K Prelude.
 
 ```k
+requires "domains.md"
+
 module FIXED-INT
     imports INT
     imports BOOL

--- a/kmcd-driver.md
+++ b/kmcd-driver.md
@@ -163,8 +163,6 @@ At the moment these are typically used in the codebase to check prerequisite con
     syntax LockStep ::= LockAuthStep
     syntax AuthStep ::= LockAuthStep
  // --------------------------------
-    rule <k> makecall MCD => exception MCD ... </k> [owise]
-
     rule <k> V:Value => . ... </k> <return-value> _ => V </return-value>
 
     rule <k> checkauth MCD:AuthStep => .             ... </k> <this> THIS </this> requires isAuthorized(THIS, contract(MCD))

--- a/kmcd-driver.md
+++ b/kmcd-driver.md
@@ -60,8 +60,8 @@ The special account `ANYONE` is not authorized to do anything, so represents any
     syntax MCDStep ::= AdminStep
  // ----------------------------
 
-    syntax Set ::= wards ( MCDContract ) [function]
- // -----------------------------------------------
+    syntax Set ::= wards ( MCDContract ) [function, functional]
+ // -----------------------------------------------------------
     rule wards(_) => .Set [owise]
 
     syntax Address ::= "ADMIN" | "ANYONE"
@@ -70,7 +70,6 @@ The special account `ANYONE` is not authorized to do anything, so represents any
     syntax Bool ::= isAuthorized ( Address , MCDContract ) [function]
  // -----------------------------------------------------------------
     rule isAuthorized( ADDR , MCDCONTRACT ) => ADDR ==K ADMIN orBool ADDR in wards(MCDCONTRACT)
-
 ```
 
 Transactions
@@ -146,8 +145,8 @@ At the moment these are typically used in the codebase to check prerequisite con
 
 ```k
     syntax AuthStep
-    syntax MCDStep ::= AuthStep
- // ---------------------------
+    syntax MCDStep ::= LockStep | AuthStep
+ // --------------------------------------
 
     syntax WardStep ::= "rely" Address
                       | "deny" Address
@@ -160,13 +159,10 @@ At the moment these are typically used in the codebase to check prerequisite con
                           | "unlock"      MCDStep
  // ---------------------------------------------
 
-    syntax MCDStep   ::= LockStep
-
     syntax LockAuthStep
     syntax LockStep ::= LockAuthStep
     syntax AuthStep ::= LockAuthStep
  // --------------------------------
-
     rule <k> makecall MCD => exception MCD ... </k> [owise]
 
     rule <k> V:Value => . ... </k> <return-value> _ => V </return-value>

--- a/kmcd-prelude.md
+++ b/kmcd-prelude.md
@@ -185,9 +185,9 @@ module KMCD-GEN
  // -----------------------------
     rule #timeStepMax() => 2 [macro]
 
-    syntax Ray ::= #dsrSpread() [function]
- // --------------------------------------
-    rule #dsrSpread() => ray(20)
+    syntax Ray ::= #dsrSpread()
+ // ---------------------------
+    rule #dsrSpread() => ray(20) [macro]
 
     syntax Int   ::= head        ( Bytes ) [function]
     syntax Bytes ::= tail        ( Bytes ) [function]

--- a/vat.md
+++ b/vat.md
@@ -231,9 +231,9 @@ This is quite permissive, and would allow the account to drain all your locked c
 ```k
     syntax Bool ::= wish(Address, Address, Map) [function, functional]
  // ------------------------------------------------------------------
-    rule wish(ADDRFROM, MSGSENDER,        _) => true                                   requires ADDRFROM ==K MSGSENDER
-    rule wish(ADDRFROM, MSGSENDER, CANADDRS) => MSGSENDER in {CANADDRS[ADDRFROM]}:>Set requires ADDRFROM in_keys(CANADDRS)
-    rule wish(       _,         _,        _) => false                                  [owise]
+    rule [wish.same]  : wish(ADDRFROM, MSGSENDER,        _) => true                                   requires ADDRFROM ==K MSGSENDER
+    rule [wish.check] : wish(ADDRFROM, MSGSENDER, CANADDRS) => MSGSENDER in {CANADDRS[ADDRFROM]}:>Set requires ADDRFROM in_keys(CANADDRS)
+    rule [wish.nope]  : wish(       _,         _,        _) => false                                  [owise]
 
     syntax VatStep ::= "hope" Address | "nope" Address
  // --------------------------------------------------

--- a/vat.md
+++ b/vat.md
@@ -231,8 +231,8 @@ This is quite permissive, and would allow the account to drain all your locked c
 ```k
     syntax Bool ::= wish(Address, Address, Map) [function, functional]
  // ------------------------------------------------------------------
-    rule [wish.same]  : wish(ADDRFROM, MSGSENDER,        _) => true                                   requires ADDRFROM ==K MSGSENDER
-    rule [wish.check] : wish(ADDRFROM, MSGSENDER, CANADDRS) => MSGSENDER in {CANADDRS[ADDRFROM]}:>Set requires ADDRFROM in_keys(CANADDRS)
+    rule [wish.same]  : wish(ADDRFROM, MSGSENDER,        _) => true                                   requires ADDRFROM  ==K MSGSENDER
+    rule [wish.check] : wish(ADDRFROM, MSGSENDER, CANADDRS) => MSGSENDER in {CANADDRS[ADDRFROM]}:>Set requires ADDRFROM =/=K MSGSENDER andBool ADDRFROM in_keys(CANADDRS)
     rule [wish.nope]  : wish(       _,         _,        _) => false                                  [owise]
 
     syntax VatStep ::= "hope" Address | "nope" Address


### PR DESCRIPTION
These are a few simplifications to the semantics I found which help my local work with symbolic reasoning.

- Make `wish` a non-contextual function, so that it's possible to use it over the pre/post states in proofs.
- Mark `wards` as functional.
- Add `domains.md` explicit import.
- `makeCall` no longer defaults to throwing an exception, because `checkLock` and `checkAuth` handle that.