### PR TITLE
Add sort annotations to speed up sort inference

### DIFF
--- a/cat.md
+++ b/cat.md
@@ -126,8 +126,8 @@ The parameters controlled by governance are:
          <cat-ilks> ... ILK_ID |-> Ilk ( ... lump: (_ => LUMP) ) ... </cat-ilks>
       requires LUMP >=Wad wad(0)
 
-    rule <k> Cat . file flip ILK_ID CAT_FLIP => . ... </k>
-         <cat-ilks> ... ILK_ID |-> Ilk ( ... flip: (_ => CAT_FLIP) ) ... </cat-ilks>
+    rule <k> Cat . file flip ILK_ID:String CAT_FLIP:Address => . ... </k>
+         <cat-ilks> ... ILK_ID |-> Ilk ( ... flip: (_:Address => CAT_FLIP) ) ... </cat-ilks>
 
     rule <k> Cat . file flip ILK_ID _ ... </k>
          <cat-ilks> CAT_ILKS => CAT_ILKS [ ILK_ID <- Ilk(... flip: 0, chop: ray(0), lump: wad(0)) ] </cat-ilks>

--- a/kmcd-driver.md
+++ b/kmcd-driver.md
@@ -89,11 +89,11 @@ Use `transact ...` for initiating top-level calls from a given user.
     rule <k> transact ADDR:Address MCD:MCDStep => pushState ~> call MCD ~> #end-transact ~> assert ~> dropState ... </k>
          <this> _ => ADDR </this>
          <msg-sender> _ => ADDR </msg-sender>
-         <mcd-call-stack> _ => .List </mcd-call-stack>
-         <pre-state> _ => .K </pre-state>
+         <mcd-call-stack> _:List => .List </mcd-call-stack>
+         <pre-state> _:K => .K </pre-state>
          <tx-log> _ => Transaction(... acct: ADDR, call: MCD, events: .List, txException: false) </tx-log>
-         <frame-events> _ => .List </frame-events>
-         <return-value> _ => .K </return-value>
+         <frame-events> _:List => .List </frame-events>
+         <return-value> _:K => .K </return-value>
 
     rule <k> #end-transact => . ... </k>
          <events> ... (.List => ListItem(TXLOG)) </events>
@@ -127,11 +127,11 @@ On `exception`, the entire current call is discarded to trigger state roll-back 
  // ---------------------------------
     rule <k> call MCD:MCDStep => checkauth MCD ~> checklock MCD ~> makecall MCD ~> checkunlock MCD ...  </k>
 
-    rule <k> makecall MCD:MCDStep ~> CONT => MCD </k>
+    rule <k> makecall MCD:MCDStep ~> CONT:K => MCD </k>
          <msg-sender> MSGSENDER => THIS </msg-sender>
          <this> THIS => contract(MCD) </this>
          <mcd-call-stack> .List => ListItem(frame(MSGSENDER, EVENTS, CONT)) ... </mcd-call-stack>
-         <frame-events> EVENTS => ListItem(LogNote(MSGSENDER, MCD)) </frame-events>
+         <frame-events> EVENTS:List => ListItem(LogNote(MSGSENDER, MCD)) </frame-events>
 
     rule <k> . => CONT </k>
          <msg-sender> MSGSENDER => PREVSENDER </msg-sender>
@@ -197,12 +197,12 @@ During the regular execution of a step this implies popping the `mcd-call-stack`
  // ----------------------------------------
     rule <k> MCDSTEP:MCDStep => exception MCDSTEP ... </k> requires notBool isAdminStep(MCDSTEP) [owise]
 
-    rule <k> exception E ~> _ => exception E ~> CONT </k>
+    rule <k> exception E ~> _:K => exception E ~> CONT </k>
          <msg-sender> MSGSENDER => PREVSENDER </msg-sender>
          <this> _THIS => MSGSENDER </this>
-         <mcd-call-stack> ListItem(frame(PREVSENDER, PREVEVENTS, CONT)) => .List ... </mcd-call-stack>
-         <tx-log> Transaction(... events: L => L EVENTS) </tx-log>
-         <frame-events> EVENTS => PREVEVENTS </frame-events>
+         <mcd-call-stack> ListItem(frame(PREVSENDER, PREVEVENTS:List, CONT:K)) => .List ... </mcd-call-stack>
+         <tx-log> Transaction(... events: L:List => L EVENTS) </tx-log>
+         <frame-events> EVENTS:List => PREVEVENTS </frame-events>
 
     rule <k> exception _MCDSTEP ~> dropState => popState ... </k>
          <mcd-call-stack> .List </mcd-call-stack>

--- a/kmcd-prelude.md
+++ b/kmcd-prelude.md
@@ -248,11 +248,11 @@ module KMCD-GEN
          </generator>
 
     rule <k> GenStepReplace => . ... </k>
-         <generator-remainder> GSS => .GenStep </generator-remainder>
+         <generator-remainder> GSS:GenStep => .GenStep </generator-remainder>
          <generator-current> I </generator-current>
          <generator>
            <generator-id> I </generator-id>
-           <generator-steps> _ => GSS </generator-steps>
+           <generator-steps> _:GenStep => GSS </generator-steps>
          </generator>
 
     syntax MCDSteps ::= "GenSteps"
@@ -280,10 +280,10 @@ module KMCD-GEN
  // ----------------------------------------------
     rule <k> .GenStep => . ... </k>
 
-    rule <k> .GenStep ; GSS => GSS ... </k> [priority(49)]
-    rule <k> GSS ; .GenStep => GSS ... </k> [priority(49)]
-    rule <k> .GenStep | GSS => GSS ... </k> [priority(49)]
-    rule <k> GSS | .GenStep => GSS ... </k> [priority(49)]
+    rule <k> .GenStep ; GSS         => GSS ... </k> [priority(49)]
+    rule <k> GSS ; .GenStep         => GSS ... </k> [priority(49)]
+    rule <k> .GenStep | GSS:GenStep => GSS ... </k> [priority(49)]
+    rule <k> GSS | .GenStep         => GSS ... </k> [priority(49)]
 
     rule <k> .GenStep _:DepthBound => . ... </k> [priority(49)]
 
@@ -292,7 +292,7 @@ module KMCD-GEN
     rule <k> GSS ; GSS' => GSS ... </k>
          <generator-remainder> GSS'' => GSS' ; GSS'' </generator-remainder>
 
-    rule <k> GSS | GSS' => #if head(BS) modInt 2 ==K 0 #then GSS #else GSS' #fi ... </k>
+    rule <k> GSS:GenStep | GSS':GenStep => #if head(BS) modInt 2 ==K 0 #then GSS #else GSS' #fi ... </k>
          <random> BS => tail(BS) </random>
          <used-random> BS' => BS' +Bytes headAsBytes(BS) </used-random>
       requires lengthBytes(BS) >Int 0

--- a/kmcd-props.md
+++ b/kmcd-props.md
@@ -262,8 +262,8 @@ A default `owise` rule is added which leaves the FSM state unchanged.
          </k>
          <processed-events> L => L ListItem(E) </processed-events>
 
-    rule <k> deriveVFSM(.List                 , _) => .                   ... </k>
-    rule <k> deriveVFSM(ListItem(VFSMID) REST , E) => deriveVFSM(REST, E) ... </k>
+    rule <k> deriveVFSM(.List                        , _) => .                   ... </k>
+    rule <k> deriveVFSM(ListItem(VFSMID:String) REST , E) => deriveVFSM(REST, E) ... </k>
          <properties> ... VFSMID |-> (VFSM => derive(VFSM, E)) ... </properties>
 ```
 
@@ -298,12 +298,12 @@ The Debt growth should be bounded in principle by the interest rates available i
  // --------------------------------------------------------------------
     rule derive(totalDebtBounded(... dsr: DSR), Measure(... debt: DEBT)) => totalDebtBoundedRun(... debt: DEBT, dsr: DSR)
 
-    rule derive( totalDebtBoundedRun(... debt: DEBT          ) #as PREV , Measure(... debt: DEBT')            ) => Violated(PREV) requires DEBT' >Rad DEBT
-    rule derive( totalDebtBoundedRun(... debt: DEBT, dsr: DSR)          , TimeStep(TIME, _)                   ) => totalDebtBoundedRun(... debt: DEBT +Rad rmul(vatDaiForUser(Pot), (DSR ^Ray TIME) -Ray ray(1)), dsr: DSR)
-    rule derive( totalDebtBoundedRun(...             dsr: DSR)          , LogNote(_ , Vat . frob _ _ _ _ _ _) ) => totalDebtBounded(... dsr: DSR)
-    rule derive( totalDebtBoundedRun(... debt: DEBT, dsr: DSR)          , LogNote(_ , Vat . suck _ _ AMOUNT)  ) => totalDebtBoundedRun(... debt: DEBT +Rad AMOUNT, dsr: DSR)
-    rule derive( totalDebtBoundedRun(... debt: DEBT          )          , LogNote(_ , Pot . file dsr DSR')    ) => totalDebtBoundedRun(... debt: DEBT, dsr: DSR')
-    rule derive( totalDebtBoundedRun(... debt: DEBT          )          , LogNote(_ , End . cage         )    ) => totalDebtBoundedEnd(... debt: DEBT)
+    rule derive( totalDebtBoundedRun(... debt: DEBT          ) #as PREV , Measure(... debt: DEBT')                    ) => Violated(PREV) requires DEBT' >Rad DEBT
+    rule derive( totalDebtBoundedRun(... debt: DEBT, dsr: DSR)          , TimeStep(TIME, _)                           ) => totalDebtBoundedRun(... debt: DEBT +Rad rmul(vatDaiForUser(Pot), (DSR ^Ray TIME) -Ray ray(1)), dsr: DSR)
+    rule derive( totalDebtBoundedRun(...             dsr: DSR:Ray)      , LogNote(_:Address , Vat . frob _ _ _ _ _ _) ) => totalDebtBounded(... dsr: DSR)
+    rule derive( totalDebtBoundedRun(... debt: DEBT, dsr: DSR)          , LogNote(_ , Vat . suck _ _ AMOUNT)          ) => totalDebtBoundedRun(... debt: DEBT +Rad AMOUNT, dsr: DSR)
+    rule derive( totalDebtBoundedRun(... debt: DEBT          )          , LogNote(_ , Pot . file dsr DSR')            ) => totalDebtBoundedRun(... debt: DEBT, dsr: DSR')
+    rule derive( totalDebtBoundedRun(... debt: DEBT          )          , LogNote(_ , End . cage         )            ) => totalDebtBoundedEnd(... debt: DEBT)
 
     rule derive(totalDebtBoundedEnd(... debt: DEBT) #as PREV, Measure(... debt: DEBT')) => Violated(PREV) requires DEBT' =/=Rad DEBT
 ```
@@ -327,7 +327,7 @@ The property checks if `flip . kick` is ever called by an unauthorized user (alt
 ```k
     syntax ViolationFSM ::= "unAuthFlipKick"
  // ----------------------------------------
-    rule derive(unAuthFlipKick, FlipKick(ADDR, ILK, _, _, _, _, _, _)) => Violated(unAuthFlipKick) requires notBool isAuthorized(ADDR, Flip ILK)
+    rule derive(unAuthFlipKick, FlipKick(ADDR:Address, ILK:String, _, _, _, _, _, _)) => Violated(unAuthFlipKick) requires notBool isAuthorized(ADDR, Flip ILK)
 ```
 
 ### Kicking off a fake `flap` auction (inspired by lucash-flap)


### PR DESCRIPTION
The current definition has many rules which take longer than 1s to parse. This adds sort annotations in key places to speed up sort inference, and speed up parsing.